### PR TITLE
Model API compliance test

### DIFF
--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -695,10 +695,6 @@ class Model(object, metaclass=ABCMeta):
         # Config
         if not isinstance(self.config, dict):
             non_compliant.append("config")
-        elif self.config:  # non-empty dict
-            for name, value in self.config.items():
-                if not isinstance(value, dict):
-                    non_compliant.append(f"config.{name}")
         # States
         if not isinstance(self.states, dict):
             non_compliant.append("states")

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -665,3 +665,53 @@ class Model(object, metaclass=ABCMeta):
             crs = None if self.crs is None else self.crs.to_epsg()
             region = gpd.GeoDataFrame(geometry=[box(*self.bounds)], crs=crs)
         return region
+
+    def test_model_api(self):
+        """Test compliance to model API instances.
+
+        Returns
+        -------
+        non_compliant: list
+            List of objects that are non-compliant with the model API structure.
+        """
+        non_compliant = []
+        # Staticmaps
+        if not isinstance(self.staticmaps, xr.Dataset):
+            non_compliant.append("staticmaps")
+        # Staticgeoms
+        if not isinstance(self.staticgeoms, dict):
+            non_compliant.append("staticgeoms")
+        elif self.staticgeoms:  # non-empty dict
+            for name, geom in self.staticgeoms.items():
+                if not isinstance(geom, gpd.GeoDataFrame):
+                    non_compliant.append(f"staticgeoms.{name}")
+        # Forcing
+        if not isinstance(self.forcing, dict):
+            non_compliant.append("forcing")
+        elif self.forcing:  # non-empty dict
+            for name, data in self.forcing.items():
+                if not isinstance(data, xr.DataArray):
+                    non_compliant.append(f"forcing.{name}")
+        # Config
+        if not isinstance(self.config, dict):
+            non_compliant.append("config")
+        elif self.config:  # non-empty dict
+            for name, value in self.config.items():
+                if not isinstance(value, dict):
+                    non_compliant.append(f"config.{name}")
+        # States
+        if not isinstance(self.states, dict):
+            non_compliant.append("states")
+        elif self.states:  # non-empty dict
+            for name, data in self.states.items():
+                if not isinstance(data, xr.DataArray):
+                    non_compliant.append(f"states.{name}")
+        # Results
+        if not isinstance(self.results, dict):
+            non_compliant.append("results")
+        elif self.results:  # non-empty dict
+            for name, data in self.results.items():
+                if not isinstance(data, xr.DataArray):
+                    non_compliant.append(f"results.{name}")
+
+        return non_compliant

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -211,7 +211,7 @@ def test_model(model, tmpdir):
 
     mod._staticgeoms["nc_test"] = dict()
     mod._forcing["nc_test"] = xr.Dataset()
-    mod._config["nc_test"] = "test"
+    mod._config = "test"
     mod._states["nc_test"] = dict()
     mod._results["nc_test"] = dict()
     non_compliant_list = mod.test_model_api()

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -9,6 +9,7 @@ import glob
 import numpy as np
 import xarray as xr
 import pandas as pd
+import geopandas as gpd
 from affine import Affine
 
 from pyflwdir import core_d8
@@ -203,6 +204,30 @@ def test_model(model, tmpdir):
     mod.shape
     mod.bounds
     mod.region
+
+    # test api compliance
+    non_compliant_list = mod.test_model_api()
+    assert len(non_compliant_list) == 0
+
+    mod._staticgeoms["nc_test"] = dict()
+    mod._forcing["nc_test"] = xr.Dataset()
+    mod._config["nc_test"] = "test"
+    mod._states["nc_test"] = dict()
+    mod._results["nc_test"] = dict()
+    non_compliant_list = mod.test_model_api()
+    assert len(non_compliant_list) == 5
+    assert "staticgeoms.nc_test" in non_compliant_list
+    assert "forcing.nc_test" in non_compliant_list
+
+    mod._staticmaps = dict()
+    mod._staticgeoms = ["test"]
+    mod._forcing = ["test"]
+    mod._config = ["test"]
+    mod._results = ["test"]
+    mod._states = ["test"]
+    non_compliant_list = mod.test_model_api()
+    assert len(non_compliant_list) == 6
+    assert "staticmaps" in non_compliant_list
 
 
 @pytest.mark.parametrize("model", list(_models.keys()))


### PR DESCRIPTION
I added a test_model_api method in model_api.py.

It should be able to do most of the checks. The limit I see now is that for config nested dictionnaries, I only test on two levels if the elements in config are dictionnaries. I guess this is enough.

I also added unittests of the function in test_model_api.py
@DirkEilander hope this is what you had in mind?