### PR TITLE
load plugins lazy to avoid circular dependencies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,16 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 [Unreleased]
 ------------
 
+Changed
+^^^^^^^
+
+- New import of model plugins. Before plugins were only loaded when import MODELS or xxxModel from hydromt.models and not when importing hydromt as before.
+
+Deprecated
+^^^^^^^^^^
+
+- Importing model plugins via "hydromt import xxxModel" or "import hydromt.xxxModel" will be deprecated. Instead use "from hydromt.models import xxxModel" 
+  or "from hydromt_xxx import xxxModel"
 
 v0.4.1 (18 May 2021)
 --------------------

--- a/hydromt/__init__.py
+++ b/hydromt/__init__.py
@@ -3,6 +3,7 @@
 __version__ = "0.4.1"
 
 import geopandas as gpd
+import warnings
 
 # required for accessor style documentation
 from xarray import DataArray, Dataset
@@ -29,3 +30,15 @@ from . import cli, workflows, stats, flw, raster, vector
 from .models import *
 from .io import *
 from .data_adapter import *
+
+# TODO remove after fixed in all plugins
+def __getattr__(name):
+    if name in PLUGINS:
+        ep = ENTRYPOINTS[PLUGINS[name]]
+        plugin_name = ep.module_name.split(".")[0]
+        warnings.warn(
+            f'"hydromt.{name}" will be deprecated, use "{plugin_name}.{name}" instead.',
+            DeprecationWarning,
+        )
+        return model_plugins.load(ep)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/hydromt/models/__init__.py
+++ b/hydromt/models/__init__.py
@@ -4,11 +4,26 @@ import sys
 from .model_api import Model
 from . import model_plugins
 
-# model dictionary to be used in command line interface
-MODELS, ENTRYPOINTS = model_plugins.discover()
 
-# make models available for import
-# from hydromt.models import xxxxModel
-thismodule = sys.modules[__name__]
-for model_class in MODELS.values():
-    setattr(thismodule, model_class.__name__, model_class)
+# dictionary with entry points (not yet loaded!)
+ENTRYPOINTS = model_plugins.discover()
+
+# only load when requested
+def __getattr__(name):
+    name2class = {ep.object_name: name for name, ep in ENTRYPOINTS.items()}
+    thismodule = sys.modules[__name__]
+
+    # load a register all models
+    if name == "MODELS":
+        MODELS = {
+            ep.name: model_plugins.load(ep, thismodule) for ep in ENTRYPOINTS.values()
+        }
+        setattr(thismodule, name, MODELS)
+        return MODELS
+
+    # trick to allow import of plugin model class from hydromt core
+    # from hydromt.models import xxxxModel
+    elif name in name2class:
+        model_class = model_plugins.load(ENTRYPOINTS[name2class[name]])
+        return model_class
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/hydromt/models/__init__.py
+++ b/hydromt/models/__init__.py
@@ -7,10 +7,10 @@ from . import model_plugins
 
 # dictionary with entry points (not yet loaded!)
 ENTRYPOINTS = model_plugins.discover()
+PLUGINS = {ep.object_name: name for name, ep in ENTRYPOINTS.items()}
 
 # only load when requested
 def __getattr__(name):
-    name2class = {ep.object_name: name for name, ep in ENTRYPOINTS.items()}
     thismodule = sys.modules[__name__]
 
     # load a register all models
@@ -23,7 +23,7 @@ def __getattr__(name):
 
     # trick to allow import of plugin model class from hydromt core
     # from hydromt.models import xxxxModel
-    elif name in name2class:
-        model_class = model_plugins.load(ENTRYPOINTS[name2class[name]])
+    elif name in PLUGINS:
+        model_class = model_plugins.load(ENTRYPOINTS[PLUGINS[name]])
         return model_class
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")


### PR DESCRIPTION
Plugins are only loaded when import MODELS or xxxModel from hydromt.models and not when importing hydromt as before. This avoids potential circular dependencies and makes partial imports of plugins possible (e.g. import hydromt_wflow.worksflows).