### PR TITLE
improve raster mosaic

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - black
   - bottleneck
   - cartopy # to run examples
-  - dask=2021.4  # pin version because of AttributeError in 2021.5
+  - dask
   - descartes # to run examples
   - entrypoints
   - flit>=3.2

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,11 +12,13 @@ Added
 ^^^^^
 
 - Small patch for geoms/bbox regions when upscaling flow dir.
+- Mask option in merge.merge method for improved open_raster_from_tindex.
 
 Changed
 ^^^^^^^
 
 - New import of model plugins. Before plugins were only loaded when import MODELS or xxxModel from hydromt.models and not when importing hydromt as before.
+- Dropped dask version pins
 
 Deprecated
 ^^^^^^^^^^

--- a/envs/hydromt-dev.yml
+++ b/envs/hydromt-dev.yml
@@ -12,7 +12,7 @@ dependencies:
   - black
   - bottleneck
   - cartopy # to run examples
-  - dask=2021.4  # pin version because of AttributeError in 2021.5
+  - dask
   - descartes # to run examples
   - entrypoints
   - flit>=3.2

--- a/envs/hydromt-min.yml
+++ b/envs/hydromt-min.yml
@@ -10,7 +10,7 @@ dependencies:
   - affine
   - bottleneck
   - click
-  - dask=2021.4  # pin version because of AttributeError in 2021.5
+  - dask
   - entrypoints
   - flit>=3.2
   - gdal>=3.1

--- a/envs/hydromt-test.yml
+++ b/envs/hydromt-test.yml
@@ -11,7 +11,7 @@ dependencies:
   - click
   - black
   - bottleneck
-  - dask=2021.4  # pin version because of AttributeError in 2021.5
+  - dask
   - entrypoints
   - gdal>=3.1
   - geopandas

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -410,8 +410,6 @@ class Model(object, metaclass=ABCMeta):
         >> set_config('b', 'c', 'd', 99) # identical to set_config('b.d.e', 99)
         >> {'a': 1, 'b': {'c': {'d': 99}}}
         """
-        if not self._write:
-            raise IOError("Model opened in read-only mode")
         if len(args) < 2:
             raise TypeError("set_config() requires a least one key and one value.")
         args = list(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "affine",
     "bottleneck",
     "click",
-    "dask>=2021.1,<2021.5",
+    "dask",
     "geopandas>=0.8",
     "entrypoints",
     "gdal>=3.1",

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -291,8 +291,8 @@ def test_zonal_stats():
     geoms = [
         box(w, s, w + abs(e - w) / 2.0, n),
         box(w - 2, s, w - 0.2, n),  # outside
-        Point((w, n)),
-        LineString([(w, n), (e, s)]),
+        Point((w + 0.1, n - 0.1)),
+        LineString([(w, (n + s) / 2 - 0.1), (e, (n + s) / 2 - 0.1)]),  # vert line
     ]
     gdf = gpd.GeoDataFrame(geometry=geoms, crs=da.raster.crs)
 
@@ -301,8 +301,9 @@ def test_zonal_stats():
     assert np.all(ds0["index"] == np.array([0, 2, 3]))
     assert np.all(ds0["test_count"] == np.array([40, 1, 10]))
 
-    ds0 = ds.raster.zonal_stats(gdf.to_crs(3857), [np.nanmean, "mean"]).fillna(0)
-    ds1 = ds.raster.zonal_stats(gdf, [np.nanmean, "mean"]).fillna(0)
+    ds0 = ds.raster.zonal_stats(gdf.to_crs(3857), [np.nanmean, "mean"])
+    ds1 = ds.raster.zonal_stats(gdf, [np.nanmean, "mean"])
+
     assert np.all(ds0["test_nanmean"] == ds0["test_mean"])
     assert np.all(ds1["test_mean"] == ds0["test_mean"])
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -301,10 +301,10 @@ def test_zonal_stats():
     assert np.all(ds0["index"] == np.array([0, 2, 3]))
     assert np.all(ds0["test_count"] == np.array([40, 1, 10]))
 
-    ds0 = ds.raster.zonal_stats(gdf.to_crs(3857), [np.nanmean, "mean"])
-    ds1 = ds.raster.zonal_stats(gdf, [np.nanmean, "mean"])
-    assert np.all(ds0["test_nanmean"].values == ds0["test_mean"].values)
-    assert np.all(ds1["test_mean"].values == ds0["test_mean"].values)
+    ds0 = ds.raster.zonal_stats(gdf.to_crs(3857), [np.nanmean, "mean"]).fillna(0)
+    ds1 = ds.raster.zonal_stats(gdf, [np.nanmean, "mean"]).fillna(0)
+    assert np.all(ds0["test_nanmean"] == ds0["test_mean"])
+    assert np.all(ds1["test_mean"] == ds0["test_mean"])
 
     with pytest.raises(ValueError, match="Stat asdf not valid"):
         da.raster.zonal_stats(gdf, "asdf")

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -138,7 +138,7 @@ def test_rasterize(rioda):
     assert np.all(rioda.raster.rasterize(gdf, col_name="id") == 3)
     assert np.all(rioda.raster.rasterize(gdf, col_name="id", sindex=True) == 3)
     mask = rioda.raster.geometry_mask(gdf)
-    assert mask.dtype == np.bool
+    assert mask.dtype == bool
     assert np.all(mask)
     with pytest.raises(ValueError, match="No shapes found"):
         rioda.raster.rasterize(gpd.GeoDataFrame())
@@ -303,8 +303,8 @@ def test_zonal_stats():
 
     ds0 = ds.raster.zonal_stats(gdf.to_crs(3857), [np.nanmean, "mean"])
     ds1 = ds.raster.zonal_stats(gdf, [np.nanmean, "mean"])
-    assert np.all(ds0["test_nanmean"] == ds0["test_mean"])
-    assert np.all(ds1["test_mean"] == ds0["test_mean"])
+    assert np.all(ds0["test_nanmean"].values == ds0["test_mean"].values)
+    assert np.all(ds1["test_mean"].values == ds0["test_mean"].values)
 
     with pytest.raises(ValueError, match="Stat asdf not valid"):
         da.raster.zonal_stats(gdf, "asdf")


### PR DESCRIPTION
- mask option in merge.merge method for improved open_raster_from_tindex. The method reads and merges data from tiles with different projections summarized in a gdal tindex geometry within a bounding box. The destination crs and resolution are now determined based on the tile with the largest overlap with the destination bounding box, which basically keeps most of the data as is. 
- dropped dask version pins
- remove IOError in set_config (IOErrors should not be in set_ methods, only write_ methods) 