### PR TITLE
DataCatalog.to_yml Path objects written as normal strings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this page.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+
+Unreleased
+----------
+
+Fixed
+^^^^^
+- DataCatalog.to_yml Path objects written as normal strings 
+
+
 v0.4.3 (3 October 2021)
 -----------------------
 

--- a/hydromt/data_adapter.py
+++ b/hydromt/data_adapter.py
@@ -301,6 +301,9 @@ class DataCatalog(object):
                     source_dict["path"] = os.path.relpath(
                         source_dict["path"], root
                     ).replace("\\", "/")
+            else:
+                # convert windows path to str
+                source_dict["path"] = str(source_dict["path"])
             sources_out.update({name: source_dict})
         return sources_out
 


### PR DESCRIPTION
- fixes #71 