### PR TITLE
data adapter improvements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ Added
 ^^^^^
 - New skill scores: KGE 2012, KGE non-parametric (2018), KGE non-parametric flood (2018).
 - new rasterio inverse distance weighting method ("rio_idw") in raster.interpolate_na
-- Add option to add placeholders in yml file to explode a single yml entry to multiple yml entries (useful for climate datasets).
+- Add option to add placeholders in yml file to explode a single yml entry to multiple yml entries (useful for e.g. climate datasets).
 - general Model.setup_region method
 
 Changed
@@ -22,7 +22,10 @@ Changed
 - file handlers of loggers are replaced in Model.set_root
 - log.setuplog replaces old handlers if these exist to avoid duplicates.
 - setup_basemaps method no longer required for build method
-- improver interbasin regions in workflows.get_basin_geometry
+- improved interbasin regions in workflows.get_basin_geometry
+- drop non-serializable entries from yml file when writing data catalog to avoid it getting corrupt
+- data catalog yml entries get priority over local files or folders with the same name in the data_adapter.get_* methods
+  multi-file rasterdatasets are only supported through the data catalog yml file 
 
 Fixed
 ^^^^^

--- a/hydromt/data_adapter.py
+++ b/hydromt/data_adapter.py
@@ -494,7 +494,7 @@ class DataCatalog(object):
         align : float, optional
             Resolution to align the bounding box, by default None
         variables : list of str, optional.
-            Names of GeoDataFrame columns to return. By default all colums are returned.
+            Names of GeoDataFrame columns to return. By default all columns are returned.
 
         Returns
         -------
@@ -565,7 +565,7 @@ class DataCatalog(object):
             Start and end date of period of interest. By default the entire time period
             of the dataset is returned.
         single_var_as_array: bool, optional
-            If True, return a DataArray if the dataset consits of a single variable.
+            If True, return a DataArray if the dataset consists of a single variable.
             If False, always return a Dataset. By default True.
 
         Returns
@@ -717,7 +717,7 @@ class DataAdapter(object, metaclass=ABCMeta):
         **kwargs,
     ):
         # general arguments
-        self.path = str(path)  # string path to make it serializable to yml
+        self.path = path
         # driver and driver keyword-arguments
         # check for non default driver based on extension
         if driver is None:
@@ -1123,7 +1123,7 @@ class GeoDatasetAdapter(DataAdapter):
         driver: {'vector', 'netcdf', 'zarr'}, optional
             Driver to read files with, for 'vector' :py:func:`~hydromt.io.open_geodataset`,
             for 'netcdf' :py:func:`xarray.open_mfdataset`.
-            By default the driver is infered from the file extension and falls back to
+            By default the driver is inferred from the file extension and falls back to
             'vector' if unknown.
         crs: int, dict, or str, optional
             Coordinate Reference System. Accepts EPSG codes (int or str); proj (str or dict)
@@ -1409,7 +1409,7 @@ class GeoDataFrameAdapter(DataAdapter):
         driver: {'vector', 'vector_table'}, optional
             Driver to read files with, for 'vector' :py:func:`~geopandas.read_file`,
             for {'vector_table'} :py:func:`hydromt.io.open_vector_from_table`
-            By default the driver is infered from the file extension and falls back to
+            By default the driver is inferred from the file extension and falls back to
             'vector' if unknown.
         crs: int, dict, or str, optional
             Coordinate Reference System. Accepts EPSG codes (int or str); proj (str or dict)

--- a/hydromt/data_adapter.py
+++ b/hydromt/data_adapter.py
@@ -5,7 +5,7 @@
 
 from abc import ABCMeta, abstractmethod
 import os
-from os.path import join, isdir, dirname, basename, isfile, abspath
+from os.path import join, isdir, dirname, basename, isfile, abspath, exists
 from itertools import product
 import copy
 from pathlib import Path
@@ -439,8 +439,8 @@ class DataCatalog(object):
         obj: xarray.Dataset or xarray.DataArray
             RasterDataset
         """
-        if path_or_key not in self.sources and len(glob.glob(str(path_or_key))) > 0:
-            path = path_or_key
+        if path_or_key not in self.sources and exists(abspath(path_or_key)):
+            path = str(abspath(path_or_key))
             name = basename(path_or_key).split(".")[0]
             self.update(**{name: RasterDatasetAdapter(path=path, **kwargs)})
         elif path_or_key in self.sources:
@@ -501,8 +501,8 @@ class DataCatalog(object):
         gdf: geopandas.GeoDataFrame
             GeoDataFrame
         """
-        if path_or_key not in self.sources and len(glob.glob(str(path_or_key))) > 0:
-            path = path_or_key
+        if path_or_key not in self.sources and exists(abspath(path_or_key)):
+            path = str(abspath(path_or_key))
             name = basename(path_or_key).split(".")[0]
             self.update(**{name: GeoDataFrameAdapter(path=path, **kwargs)})
         elif path_or_key in self.sources:
@@ -573,8 +573,8 @@ class DataCatalog(object):
         obj: xarray.Dataset or xarray.DataArray
             GeoDataset
         """
-        if path_or_key not in self.sources and len(glob.glob(str(path_or_key))) > 0:
-            path = path_or_key
+        if path_or_key not in self.sources and exists(abspath(path_or_key)):
+            path = str(abspath(path_or_key))
             name = basename(path_or_key).split(".")[0]
             self.update(**{name: GeoDatasetAdapter(path=path, **kwargs)})
         elif path_or_key in self.sources:
@@ -672,7 +672,7 @@ def _process_dict(d, logger=logger):
         elif _check_key and isinstance(v, Path):
             d[k] = str(v)  # path to string
         elif not _check_key or not isinstance(v, (list, str, int, float, bool)):
-            d.pop(k)
+            d.pop(k)  # remove this entry
             logger.debug(f'Removing non-serializable entry "{k}"')
     return d
 
@@ -733,7 +733,7 @@ class DataAdapter(object, metaclass=ABCMeta):
         self.unit_mult = unit_mult
         self.unit_add = unit_add
         # meta data
-        self.meta = {k: str(v) for k, v in meta.items() if v is not None}
+        self.meta = {k: v for k, v in meta.items() if v is not None}
 
     @property
     def data_type(self):


### PR DESCRIPTION
- drop non-serializable entries from yml file when writing data catalog to avoid it getting corrupt
- data catalog yml entries get priority over local files or folders with the same name in the data_adapter.get_* methods
  and multi-file rasterdatasets are only supported through the data catalog yml file 