### PR TITLE
interpolate_na enhancement

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Added
 
 Changed
 ^^^^^^^
+- Interpolate missing values based on D4 neighbors of missing value cells only. This largely improves the performance without loosing accuracy.
 
 Fixed
 ^^^^^


### PR DESCRIPTION
Interpolate missing values based on D4 neighbors of missing value cells only. This largely improves the performance without loosing accuracy.

relates to #37 