### PR TITLE
Update css style

### DIFF
--- a/docs/_static/theme-deltares.css
+++ b/docs/_static/theme-deltares.css
@@ -1,23 +1,30 @@
 /* Override the default color set in the original theme */
 
-.navbar-light {
-    background: #080c80 !important;
+html[data-theme="light"] {
+    --pst-color-background: #fff !important;
+    --pst-color-on-background: #080c80 !important;
+    --pst-color-primary: #080c80 !important;
+}
+html[data-theme="dark"] {
+    --pst-color-border: #080c80 !important;
+    --pst-color-background: #080c80 !important;
+    --pst-color-on-background: #080c80 !important;
 }
 
-.bg-light {
-    background-color: #080c80 !important;
+div.admonition {
+    background-color:  #fff;
 }
 
-.navbar-brand p {
+.nav-link {
+    color: #8486c0 !important;
+}
+
+.navbar-nav>:hover>.nav-link {
     color: #fff !important;
 }
 
 img.icon-link-image {
     height: 2.5em !important;
-}
-
-.navbar-toggler-icon {
-    filter: invert(100%) ;
 }
 
 :root {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,6 +226,7 @@ html_context = {
     "github_repo": "hydromt",
     "github_version": "docs",  # FIXME
     "doc_path": "docs",
+    "default_mode": "light",
 }
 
 remove_from_toctrees = ["_generated/*"]


### PR DESCRIPTION
pydata-sphinx-theme recently updated and added functionality for dark theming, which currently is turned on by default by the package. 
https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.9.0
The current css deltares theme does not work with this.

This pull request:
- Sets the default theme to light theme
- Sets the light theme with the same colors as previously
- Provides some provisional dark theme version, this probably still requires some work. 