### PR TITLE
Small bugfix for {month} in DataAdapter

### DIFF
--- a/docs/user_guide/data_prepare_cat.rst
+++ b/docs/user_guide/data_prepare_cat.rst
@@ -60,7 +60,8 @@ A full list of **data source options** is given below
   Relative paths are combined with the global ``root`` option of the yaml file (if available) or the directory of the yaml file itself. 
   To read multiple files in a single dataset (if supported by the driver) a string glob in the form of ``"path/to/my/files/*.nc"`` can be used.
   The filenames can be further specified with ``{variable}``, ``{year}`` and ``{month}`` keys to limit which files are being read 
-  based on the get_data request in the form of ``"path/to/my/files/{variable}_{year}_{month:02d}.nc"``
+  based on the get_data request in the form of ``"path/to/my/files/{variable}_{year}_{month}.nc"``. The keyword ``{month}`` can be stored as one or two digits 
+  (e.g. January 2012 could be stored as ``"path/to/my/files/{variable}_2012_01.nc"`` or ``"path/to/my/files/{variable}_2012_1.nc"``).
 - **data_type** (required): type of input data. Either *RasterDataset*, *GeoDataset* or *GeoDataFrame*.
 - **crs** (required if missing in the data): EPSG code or WKT string of the reference coordinate system of the data. 
 - **driver** (required): data_type specific driver to read a dataset, see overview below.


### PR DESCRIPTION
Reading GeoDataset with a time slice with month with one digits was failing depending on how the file was stored. (for eg. January 2012 could be stored as ("2012_01.nc" or "2012_1.nc").  data_adapter will now automatically check for both options to see which one exists. 

Documentation has been changed accordingly. 

Also modified another small bugfix based on an upgrade of xarray I think