### PR TITLE
Remove unnecessary nodata value not found warnings

### DIFF
--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -994,9 +994,8 @@ class XRasterBase(XGeoBase):
             nodata=np.uint8(invert),
             **kwargs,
         )
-        da_out.attrs.pop(
-            "_FillValue", None
-        )  # remove nodata value before converting to boolean
+        # remove nodata value before converting to boolean
+        da_out.attrs.pop("_FillValue", None)
         return da_out.astype(bool)
 
     def vector_grid(self):


### PR DESCRIPTION
Too many unnecessary warnings message of type "No numerical nodata value found, skipping set_nodata" were issued by HydroMT.

This happened in two places:

- calls to raster.geometry_mask (example in get_rasterdataset if geom is not None)
- calls to raster.nodata (calling a set_nodata even if both rio.nodata and rio.encoded_nodata are None already)