### PR TITLE
Remove shapely pin + update dependencies

### DIFF
--- a/envs/hydromt-dev.yml
+++ b/envs/hydromt-dev.yml
@@ -19,10 +19,9 @@ dependencies:
   - gdal>=3.1
   - geopandas>=0.10
   - jupyter # to run examples
-  - netcdf4
   - matplotlib # to run examples
   - nbsphinx # docs notebook examples
-  - numba
+  - netcdf4
   - numpy
   - openpyxl
   - pandas
@@ -32,6 +31,7 @@ dependencies:
   - pydata-sphinx-theme  # docs
   - pyflwdir>=0.5.4
   - pygeos>=0.8
+  - pyproj
   - pytest # tests
   - pytest-cov # tests
   - pytest-benchmark # tests
@@ -43,7 +43,7 @@ dependencies:
   - scipy
   - testpath  # tests
   - toml
-  - shapely=1.8.2  # temp version pin see geopandas#2531
+  - shapely
   - sphinx # docs
   - xarray
   - xugrid>=0.1.5 # optional for mesh

--- a/envs/hydromt-min.yml
+++ b/envs/hydromt-min.yml
@@ -14,18 +14,18 @@ dependencies:
   - gdal>=3.1
   - geopandas>=0.10
   - netcdf4
-  - numba
   - numpy
-  - openpyxl
   - pandas
   - packaging
   - pip  # install
   - pyflwdir>=0.5.4
   - pygeos>=0.8
+  - pyproj
   - python>=3.8
   - rasterio
   - requests
   - rioxarray
   - scipy
+  - shapely
   - xarray
   - zarr

--- a/envs/hydromt-test.yml
+++ b/envs/hydromt-test.yml
@@ -14,7 +14,6 @@ dependencies:
   - gdal>=3.1
   - geopandas>=0.10
   - netcdf4
-  - numba
   - numpy
   - openpyxl
   - pandas
@@ -22,6 +21,7 @@ dependencies:
   - pcraster # optional
   - pyflwdir>=0.5.4
   - pygeos>=0.8
+  - pyproj
   - pytest # tests
   - pytest-cov # tests
   - pytest-benchmark # tests
@@ -29,7 +29,7 @@ dependencies:
   - requests
   - rioxarray
   - scipy
-  - shapely=1.8.2  # temp version pin see geopandas#2531
+  - shapely
   - xarray
   - xugrid>=0.1.5 # optional for mesh
   - zarr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "rasterio",
     "requests",
     "rioxarray",
-    "shapely==1.8.2", # temp version pin see geopandas#2531
+    "shapely",
     "scipy",
     "xarray",
     "zarr",


### PR DESCRIPTION
Shapely pin 1.8.2 now conflicts with other library and giving errors when trying geopandas.read_file.

Also update dependencies related to #176 