### PR TITLE
Test basin mask

### DIFF
--- a/hydromt/workflows/basin_mask.py
+++ b/hydromt/workflows/basin_mask.py
@@ -11,6 +11,7 @@ from shapely.geometry import box
 from sklearn.neighbors import VALID_METRICS
 import xarray as xr
 import logging
+import warnings
 
 # local
 from ..io import open_raster
@@ -256,16 +257,16 @@ def get_basin_geometry(
     if kind == "outlet":
         outlets = True
         kind = "basin"
-        logger.warning(
+        warnings.warn(
             'kind="outlets" has been deprecated, use outlets=True in combination with '
-            ' kind="basin" or kind="interbasin" instead.',
+            'kind="basin" or kind="interbasin" instead.',
             DeprecationWarning,
         )
     elif kind not in kind_lst:
         msg = f"Unknown kind: {kind}, select from {kind_lst}."
         raise ValueError(msg)
     if bool(stream_kwargs.pop("within", False)):
-        logger.warning(
+        warnings.warn(
             '"within" stream argument has been deprecated.', DeprecationWarning
         )
 

--- a/tests/test_basin_mask.py
+++ b/tests/test_basin_mask.py
@@ -8,6 +8,7 @@ import geopandas as gpd
 import xarray as xr
 import hydromt
 import logging
+import warnings
 
 from hydromt.workflows.basin_mask import get_basin_geometry, parse_region, _parse_region_value, _check_size
 from hydromt import raster
@@ -113,7 +114,7 @@ def test_check_size(caplog):
     
 
 
-def test_basin():
+def test_basin(caplog):
     data_catalog = hydromt.DataCatalog(logger=logger)
     ds = data_catalog.get_rasterdataset("merit_hydro")
     gdf_bas_index = data_catalog.get_geodataframe("merit_hydro_index")
@@ -228,3 +229,35 @@ def test_basin():
         outlets=True,
     )
     assert gdf_bas.index.size == 180
+
+    with pytest.warns(DeprecationWarning) as record:        
+        gdf_bas, gdf_out = get_basin_geometry(
+        ds,
+        kind="outlet"
+    )
+    assert len(record) == 1
+    assert record[0].message.args[0] == 'kind="outlets" has been deprecated, use outlets=True in combination with kind="basin" or kind="interbasin" instead.'
+
+    with pytest.raises(ValueError):
+        gdf_bas, gdf_out = get_basin_geometry(
+        ds,
+        kind="watershed"
+    )
+    
+    with pytest.raises(ValueError):        
+        gdf_bas, gdf_out = get_basin_geometry(
+        ds,
+        kind="basin",
+        stream_kwargs={"within": True}
+    )
+    with pytest.raises(ValueError):        
+        gdf_bas, gdf_out = get_basin_geometry(
+        ds,
+        kind="interbasin",        
+    )
+
+
+
+
+        
+        


### PR DESCRIPTION
- Added unit tests for basin_mask.py
- Changed logging.warning(..) to warning.warn(..)  in basin_mask.py because logging.warning([str], DeprecationWarning) throws an error.