### PR TITLE
Bugfix #210

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,7 @@ Fixed
 -----
 - Bug in backward compatibility of staticgeoms (not read automatically). `Issue #190 <https://github.com/Deltares/hydromt/issues/190>`_
 - Direct import of xarray.core.resample. `Issue #189 <https://github.com/Deltares/hydromt/issues/189>`_
+- Bug in dim0 attribute of raster, removed instead of set to None if no dim0 `Issue #210 <https://github.com/Deltares/hydromt/issues/210>`
 
 Deprecated
 ----------

--- a/hydromt/models/model_plugins.py
+++ b/hydromt/models/model_plugins.py
@@ -64,6 +64,7 @@ def load(ep, module=None, logger=logger):
         logger.debug(
             f"Loaded model plugin '{ep.name} = {ep.module_name}.{ep.object_name}' ({ep.distro.version})"
         )
+        return model_class
     except (ModuleNotFoundError, AttributeError) as err:
         logger.exception(f"Error while loading entrypoint {ep.name}: {str(err)}")
-    return model_class
+        return None

--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -397,8 +397,8 @@ class XRasterBase(XGeoBase):
         if len(extra_dims) == 1:
             dims = tuple(extra_dims) + dims
             self.set_attrs(dim0=extra_dims[0])
-        # elif len(extra_dims) == 0:
-        #    self.set_attrs(dim0=None)
+        elif len(extra_dims) == 0:
+            self._obj.coords[GEO_MAP_COORD].attrs.pop("dim0", None)
         elif len(extra_dims) > 1:
             raise ValueError("Only 2D and 3D data arrays supported.")
         if isinstance(self._obj, xr.Dataset):


### PR DESCRIPTION
Bugfix #210 dim0 removal in raster._check_dimensions

While testting I did not have xugrid and found a bug in ep.load in model_plugins.py if an exception is found while loading entrypoints.