### PR TITLE
Test for pet forcing

### DIFF
--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -2,31 +2,41 @@
 
 import pytest
 from hydromt.data_catalog import DataCatalog
-from hydromt.raster import full_from_transform
 from hydromt.workflows.forcing import pet
+from hydromt.workflows.forcing import pet_debruin
 from hydromt_wflow import WflowModel
-
+import pandas
 
 def test_pet():
 
     # get data
     cat = DataCatalog()
-    dat = cat.get_rasterdataset("era5", variables=["temp", "press_msl", "kin", "kout"]) #era5 hourly
-#    dem = cat.get_rasterdataset("era5_orography", variables="elevtn") #era5 orography
-
-    # we create a more refined grid - make a fixture? --> put in conftest
-#    dem_transform = dem.raster.transform
-#    dat_transform = dat.raster.transform
-#    dem_shape = (21,18)
-#    dat_shape = (21,18)
-#    grid_dem = full_from_transform(transform=dem_transform, shape=dem_shape, crs = 4326)
-#    grid_dat = full_from_transform(transform=dat_transform, shape=dat_shape, crs = 4326)
+    ds = cat.get_rasterdataset("era5", variables=["temp", "press_msl", "kin", "kout"]) #era5 daily
+#    da_dem = cat.get_rasterdataset("era5_orography", variables="elevtn") #era5 orography
 
     # resample input to model grid
-    mod = WflowModel(root=r"wflow_piave_forcing", mode="r")
+    mod = WflowModel(root=r"c:\Users\marth\Projects\HydroMT\Software\wflow\hydromt_wflow\examples\wflow_piave_subbasin", mode="r") # wflow_piave_forcing
     da_wflow_dem = mod.staticmaps["wflow_dem"]
-    dat_out = dat.raster.reproject_like(da_wflow_dem, method="nearest_index")
+    ds_out = ds.raster.reproject_like(da_wflow_dem, method="nearest_index")
 
-    assert mod.shape == dat_out.shape  # shape
+    ## check the shape
+    assert [da_wflow_dem.shape[0], da_wflow_dem.shape[1]] == [ds_out["temp"].shape[1], ds_out["temp"].shape[2]]
+    assert [da_wflow_dem.shape[0], da_wflow_dem.shape[1]] == [ds_out["press_msl"].shape[1], ds_out["press_msl"].shape[2]]
+    assert [da_wflow_dem.shape[0], da_wflow_dem.shape[1]] == [ds_out["kin"].shape[1], ds_out["kin"].shape[2]]
+    assert [da_wflow_dem.shape[0], da_wflow_dem.shape[1]] == [ds_out["kout"].shape[1], ds_out["kout"].shape[2]]
 
+    ## check method nearest_index
+
+
+    # check if press corerction is true the correction is calculated
+    da_temp = ds_out["temp"]
+    pet_out_press = pet(ds_out, da_temp, da_wflow_dem, press_correction=True)
+    pet_out = pet(ds_out, da_temp, da_wflow_dem)
+
+    assert pet_out_press[1, 1, 1].values != pet_out[1, 1, 1].values
+
+    # check debruin
+    pet_out_debruin = pet_debruin(da_temp[1, 1, 1], ds_out["press_msl"][1, 1, 1], ds_out["kin"][1, 1, 1], ds_out["kout"][1, 1, 1])
+
+    assert pet_out_debruin.round(6) == 0.766257
 

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Tests for the hydromt.workflows.forcing"""
+
+import pytest
+import logging
+
+from hydromt.data_catalog import DataCatalog
+from hydromt.raster import full_from_transform
+
+from hydromt.workflows.forcing import pet
+
+logger = logging.getLogger("test_forcing")
+
+
+def test_pet():
+
+    # get data
+    cat = DataCatalog()
+    dat = cat.get_rasterdataset("era5", variables=["temp", "press_msl", "kin", "kout"]) #era5 hourly
+    dem = cat.get_rasterdataset("era5_orography", variables="elevtn") #era5 orography
+
+    # resample to the ds_like -  don't have it but don't have one here so we will make a fixture --> put in conftest
+    dem_transform = dem.raster.transform
+    dat_transform = dat.raster.transform
+    #dat_shape = dat.raster.shape
+    #dem_shape = dem.raster.shape
+    dem_shape = (21,18)
+    dat_shape = (21,18)
+    grid_dat = full_from_transform(transform = dat_transform, shape = dat_shape, crs = 4326)
+    gri
+
+    pet_out = pet(dat, dat["temp"], )
+
+    assert pet_out.raster.shape == grid.raster.shape #shape
+    assert pout.x == grid.x #test coordinates
+
+    #test other arguments     clim=None,
+    freq=None,
+    reproj_method="nearest_index",
+    resample_kwargs={},
+    logger=logger,
+
+    p_clim = cat.get_rasterdataset("worldclim")
+    p_clim.raster.set_nodata(-999.0) #give it a nodata value in the datacatalog >> issue to create for the data artifacts
+
+    pout_clim = precip(p_precip, grid, clim=p_clim)
+
+    assert pout_clim.values != grid.raster.shape #shape
+
+
+    #test if transform and shape stayed the same
+
+    #test downscaling with correction (check values) or without correction (check values)
+    #Test whether resampling temporally working and check on one cell for example

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -1,15 +1,10 @@
-# -*- coding: utf-8 -*-
-"""Tests for the hydromt.workflows.forcing"""
+"""Test hydromt.forcing submodule"""
 
 import pytest
-import logging
-
 from hydromt.data_catalog import DataCatalog
 from hydromt.raster import full_from_transform
-
 from hydromt.workflows.forcing import pet
-
-logger = logging.getLogger("test_forcing")
+from hydromt_wflow import WflowModel
 
 
 def test_pet():
@@ -17,38 +12,21 @@ def test_pet():
     # get data
     cat = DataCatalog()
     dat = cat.get_rasterdataset("era5", variables=["temp", "press_msl", "kin", "kout"]) #era5 hourly
-    dem = cat.get_rasterdataset("era5_orography", variables="elevtn") #era5 orography
+#    dem = cat.get_rasterdataset("era5_orography", variables="elevtn") #era5 orography
 
-    # resample to the ds_like -  don't have it but don't have one here so we will make a fixture --> put in conftest
-    dem_transform = dem.raster.transform
-    dat_transform = dat.raster.transform
-    #dat_shape = dat.raster.shape
-    #dem_shape = dem.raster.shape
-    dem_shape = (21,18)
-    dat_shape = (21,18)
-    grid_dat = full_from_transform(transform = dat_transform, shape = dat_shape, crs = 4326)
-    gri
+    # we create a more refined grid - make a fixture? --> put in conftest
+#    dem_transform = dem.raster.transform
+#    dat_transform = dat.raster.transform
+#    dem_shape = (21,18)
+#    dat_shape = (21,18)
+#    grid_dem = full_from_transform(transform=dem_transform, shape=dem_shape, crs = 4326)
+#    grid_dat = full_from_transform(transform=dat_transform, shape=dat_shape, crs = 4326)
 
-    pet_out = pet(dat, dat["temp"], )
+    # resample input to model grid
+    mod = WflowModel(root=r"wflow_piave_forcing", mode="r")
+    da_wflow_dem = mod.staticmaps["wflow_dem"]
+    dat_out = dat.raster.reproject_like(da_wflow_dem, method="nearest_index")
 
-    assert pet_out.raster.shape == grid.raster.shape #shape
-    assert pout.x == grid.x #test coordinates
-
-    #test other arguments     clim=None,
-    freq=None,
-    reproj_method="nearest_index",
-    resample_kwargs={},
-    logger=logger,
-
-    p_clim = cat.get_rasterdataset("worldclim")
-    p_clim.raster.set_nodata(-999.0) #give it a nodata value in the datacatalog >> issue to create for the data artifacts
-
-    pout_clim = precip(p_precip, grid, clim=p_clim)
-
-    assert pout_clim.values != grid.raster.shape #shape
+    assert mod.shape == dat_out.shape  # shape
 
 
-    #test if transform and shape stayed the same
-
-    #test downscaling with correction (check values) or without correction (check values)
-    #Test whether resampling temporally working and check on one cell for example


### PR DESCRIPTION
Setting up a test for the pet forcing

- [x] load era5 
- [ ] calculate pet with the data for Makkink and debruin
- [x] check that shape is correctly resampled
- [ ] check after resampling that the data is indeed nearest index
- [ ] check that the pet in one cell is different between Makkink and Debruin
- [x] Check that pressure correction is applied as stated so

Open questions: 
- At the moment the lapse rate of the pressure equals the lapse rate of the temperature, is that correct? 
- Don't we need a lapse correction of the temperature?

