### PR TITLE
Fix path in setting up examples

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -60,7 +60,7 @@ Alternatively, you can run the notebooks from `Visual Studio Code <https://code.
 .. code-block:: console
 
   $ conda activate hydromt
-  $ cd examples
+  $ cd hydromt/examples
   $ jupyter notebook
 
 


### PR DESCRIPTION
Updated the `cd` argument to open the examples directory inside the hydromt folder