### PR TITLE
Datacatalog fixes and strict read/write mode in Model class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changed
 
 Fixed
 -----
+- fix `DataCatalog.to_yml` and `DataCatalog.export()` with relative path and add meta section `PR #238 <https://github.com/Deltares/hydromt/pull/238>`_
 
 Deprecated
 ----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ Added
 
 Changed
 -------
+- strict and consistent read/write mode policy `PR #238 <https://github.com/Deltares/hydromt/pull/238>`_
+- do not automatically read hydromt_data.yml file in model root `PR #238 <https://github.com/Deltares/hydromt/pull/238>`_
 
 Fixed
 -----

--- a/examples/export_data.ipynb
+++ b/examples/export_data.ipynb
@@ -131,7 +131,7 @@
    "id": "02bc2086",
    "metadata": {},
    "source": [
-    "Now we will export a subset of the data in our `artifact_data` catalog using the `DataCatalog.export_data` method. Let's check the method's docstring:"
+    "Now we will export a subset of the data in our `artifact_data` catalog using the [DataCatalog.export_data](https://deltares.github.io/hydromt/latest/_generated/hydromt.data_catalog.DataCatalog.export_data.html) method. Let's check the method's docstring:"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "outputs": [],
    "source": [
     "# List of data sources to export\n",
-    "source_list = [\"merit_hydro_1k\", \"soilgrids\", \"vito\", \"era5\"]\n",
+    "source_list = [\"merit_hydro\", \"era5\"]\n",
     "# Geographic extent\n",
     "bbox = [12.0, 46.0, 13.0, 46.5]\n",
     "# Time extent\n",
@@ -172,7 +172,7 @@
    "id": "31bacffa",
    "metadata": {},
    "source": [
-    "And let's export the data in a *data_extract* folder:"
+    "And let's export the *tmp_data_export* folder:"
    ]
   },
   {
@@ -184,10 +184,11 @@
    "source": [
     "folder_name = \"tmp_data_export\"\n",
     "data_catalog.export_data(\n",
-    "    data_root=os.path.join(os.getcwd(), folder_name),\n",
+    "    data_root=folder_name,\n",
     "    bbox=bbox,\n",
     "    time_tuple=time_tuple,\n",
     "    source_names=source_list,\n",
+    "    meta={\"version\": \"1\"},\n",
     ")"
    ]
   },
@@ -215,9 +216,18 @@
     "for path, _, files in os.walk(folder_name):\n",
     "    print(path)\n",
     "    for name in files:\n",
-    "        if name.endswith(\".xml\"):\n",
-    "            continue\n",
     "        print(f\" - {name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93c006c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(os.path.join(folder_name, \"data_catalog.yml\"), \"r\") as f:\n",
+    "    print(f.read())"
    ]
   },
   {
@@ -258,10 +268,10 @@
    "source": [
     "# Get both the extracted and original merit_hydro_1k DEM\n",
     "dem = data_catalog.get_rasterdataset(\n",
-    "    \"merit_hydro_1k\", variables=[\"elevtn\"], bbox=[11.6, 45.2, 13.0, 46.8]\n",
+    "    \"merit_hydro\", variables=[\"elevtn\"], bbox=[11.6, 45.2, 13.0, 46.8]\n",
     ")\n",
     "dem_extract = data_catalog_extract.get_rasterdataset(\n",
-    "    \"merit_hydro_1k\", variables=[\"elevtn\"]\n",
+    "    \"merit_hydro\", variables=[\"elevtn\"]\n",
     ")"
    ]
   },
@@ -285,8 +295,7 @@
     "bbox_extract = gpd.GeoDataFrame(geometry=[box(*dem_extract.raster.bounds)], crs=4326)\n",
     "\n",
     "# Initialise plot\n",
-    "figsize = (10, 8)\n",
-    "fig = plt.figure(figsize=figsize)\n",
+    "fig = plt.figure(figsize=(7, 5))\n",
     "ax = fig.add_subplot(projection=proj)\n",
     "\n",
     "# Plot the bounding box\n",
@@ -295,7 +304,8 @@
     "\n",
     "# Plot elevation\n",
     "dem.raster.mask_nodata().plot(ax=ax, cmap=\"gray\")\n",
-    "dem_extract.raster.mask_nodata().plot(ax=ax, cmap=\"terrain\")"
+    "dem_extract.raster.mask_nodata().plot(ax=ax, cmap=\"terrain\")\n",
+    "ax.set_title(\"exported and original DEMs\")"
    ]
   }
  ],

--- a/hydromt/models/model_grid.py
+++ b/hydromt/models/model_grid.py
@@ -30,9 +30,8 @@ class GridMixin(object):
     def grid(self):
         """Model static gridded data. Returns xarray.Dataset.
         Previously called staticmaps."""
-        if len(self._grid) == 0:
-            if self._read:
-                self.read_grid()
+        if len(self._grid) == 0 and self._read:
+            self.read_grid()
         return self._grid
 
     def set_grid(
@@ -84,6 +83,7 @@ class GridMixin(object):
         fn : str, optional
             filename relative to model root, by default 'grid/grid.nc'
         """
+        self._assert_read_mode
         for ds in self._read_nc(fn, **kwargs).values():
             self.set_grid(ds)
 
@@ -97,11 +97,12 @@ class GridMixin(object):
         fn : str, optional
             filename relative to model root, by default 'grid/grid.nc'
         """
-        nc_dict = dict()
-        if len(self._grid) > 0:
-            # _write_nc requires dict - use dummy key
-            nc_dict.update({"grid": self._grid})
-        self._write_nc(nc_dict, fn, **kwargs)
+        if len(self._grid) == 0:
+            self.logger.debug("No grid data found, skip writing.")
+        else:
+            self._assert_write_mode
+            # _write_nc requires dict - use dummy 'grid' key
+            self._write_nc({"grid": self._grid}, fn, **kwargs)
 
 
 class GridModel(GridMixin, Model):

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -147,10 +147,10 @@ def test_export_global_datasets(tmpdir):
         "GeoDatasetAdapter": (xr.DataArray, xr.Dataset),
         "GeoDataFrameAdapter": gpd.GeoDataFrame,
     }
-    bbox = [11.70, 45.35, 12.95, 46.70]  # Piava river
-    time_tuple = ("2010-02-01", "2010-02-14")
+    bbox = [12.0, 46.0, 13.0, 46.5]  # Piava river
+    time_tuple = ("2010-02-10", "2010-02-15")
     data_catalog = DataCatalog()  # read artifacts by default
-    sns = [
+    source_names = [
         "era5",
         "grwl_mask",
         "modis_lai",
@@ -158,14 +158,23 @@ def test_export_global_datasets(tmpdir):
         "grdc",
         "corine",
         "gtsmv3_eu_era5",
-        "hydro_lakes",
-        "eobs",
     ]
     data_catalog.export_data(
-        str(tmpdir), bbox=bbox, time_tuple=time_tuple, source_names=sns
+        tmpdir,
+        bbox=bbox,
+        time_tuple=time_tuple,
+        source_names=source_names,
+        meta={"version": 1},
     )
-
-    data_catalog1 = DataCatalog(str(tmpdir.join("data_catalog.yml")))
+    data_lib_fn = join(tmpdir, "data_catalog.yml")
+    # check if meta is written
+    with open(data_lib_fn, "r") as f:
+        yml_list = f.readlines()
+    assert yml_list[0].strip() == "meta:"
+    assert yml_list[1].strip() == "version: 1"
+    assert yml_list[2].strip().startswith("root:")
+    # check if data is parsed correctly
+    data_catalog1 = DataCatalog(data_lib_fn)
     for key, source in data_catalog1.sources.items():
         source_type = type(source).__name__
         dtypes = DTYPES[source_type]

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -72,10 +72,13 @@ def test_parser():
 def test_data_catalog_io(tmpdir):
     data_catalog = DataCatalog()
     # read / write
-    fn_yml = str(tmpdir.join("test.yml"))
+    fn_yml = join(tmpdir, "test.yml")
     data_catalog.to_yml(fn_yml)
     data_catalog1 = DataCatalog(data_libs=fn_yml)
     assert data_catalog.to_dict() == data_catalog1.to_dict()
+    # test that no file is written for empty DataCatalog
+    fn_yml = join(tmpdir, "test1.yml")
+    DataCatalog(fallback_lib=None).to_yml(fn_yml)
     # test print
     print(data_catalog["merit_hydro"])
 
@@ -100,6 +103,8 @@ def test_data_catalog(tmpdir):
     assert isinstance(data_catalog.to_dataframe(), pd.DataFrame)
     with pytest.raises(ValueError, match="Value must be DataAdapter"):
         data_catalog["test"] = "string"
+    # check that no sources are loaded if fallback_lib is None
+    assert not DataCatalog(fallback_lib=None).sources
     # test artifact keys (NOTE: legacy code!)
     data_catalog = DataCatalog(deltares_data=False)
     assert len(data_catalog._sources) == 0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -106,9 +106,13 @@ def test_model(model, tmpdir):
     # write model
     model.set_root(str(tmpdir), mode="w")
     model.write()
+    with pytest.raises(IOError, match="Model opened in write-only mode"):
+        model.read()
     # read model
     model1 = Model(str(tmpdir), mode="r")
     model1.read()
+    with pytest.raises(IOError, match="Model opened in read-only mode"):
+        model1.write()
     # check if equal
     model._results = {}  # reset results for comparison
     equal, errors = model._test_equal(model1)


### PR DESCRIPTION
- strict and consistent read/write mode policy
- do not automatically read hydromt_data.yml file in model root #237
- fix `DataCatalog.to_yml` and `DataCatalog.export()` with relative path and add meta section #230 