### PR TITLE
ENH: cache predefined data catalogs file to be able to work offline

### DIFF
--- a/hydromt/data_adapter/caching.py
+++ b/hydromt/data_adapter/caching.py
@@ -26,7 +26,7 @@ def _uri_validator(uri: str) -> bool:
         return False
 
 
-def _copyfile(src, dst):
+def _copyfile(src, dst, chunk_size=1024):
     """Copy src file to dst. This method supports both online and local files."""
     if not isdir(dirname(dst)):
         os.makedirs(dirname(dst))
@@ -37,7 +37,9 @@ def _copyfile(src, dst):
                     f"Data download failed with status code {r.status_code}"
                 )
             with open(dst, "wb") as f:
-                shutil.copyfileobj(r.raw, f)
+                for chunk in r.iter_content(chunk_size=chunk_size):
+                    f.write(chunk)
+                # shutil.copyfileobj(r.raw, f)
     else:
         shutil.copyfile(src, dst)
 

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -158,7 +158,7 @@ class DataCatalog(object):
         try:
             # download file locally; overwrite existing file
             _copyfile(urlpath, cache_path)
-        except ConnectionError:  # if offline
+        except Exception:  # if offline
             self.logger.warning(
                 "Downloading the predefined catalogs failed; check your internet connection"
             )


### PR DESCRIPTION
This PR makes it possible to work with artifact data (required for many tests!) when offline. Currently it relies on the online predefined data catalog yaml file. With this change is caches that file to ~/.hydromt_data and uses the cached version if now internet connection is available.

A small modification to the _copyfile method was required to be able to download text data (this didn't work with shutil.copyfileobj in combination with the request.get().raw attribute). I've tested this still works with other data formats as well. 