### PR TITLE
ENH: support relative paths for Model.read_config

### DIFF
--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -672,6 +672,12 @@ class Model(object, metaclass=ABCMeta):
             if isfile(config_fn):
                 cfdict = self._configread(config_fn)
                 self.logger.debug(f"{prefix} config read from {config_fn}")
+            elif isfile(abspath(config_fn)):
+                cfdict = self._configread(abspath(config_fn))
+                self.logger.debug(f"{prefix} config read from {abspath(config_fn)}")
+            elif self.root is not None and isfile(join(self.root,config_fn)):
+                cfdict = self._configread(join(self.root,config_fn))
+                self.logger.debug(f"{prefix} config read from {join(self.root,config_fn)}")
             elif not self._read and prefix != "Default":  # skip for missing default
                 self.logger.error(f"{prefix} config file not found at {config_fn}")
         self._config = cfdict


### PR DESCRIPTION
resolves #316 
Preference order is: 
1. check if file exists at exact path
2. try to convert `config_fn` to an absolute path and check if file exits there
3. check if model root is set and if so if the file is there

I was wondering if we should silent fail if no config can be read as mentioned in the issue, but that should probably be discussed since I'm not sure if that can have other consequences. 