### PR TITLE
Fix deprecated numpy function

### DIFF
--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -586,7 +586,7 @@ def write_map(
             # NOTE this should not be necessary
             pcrmap = pcr.lddrepair(ldd)
         elif pcr_vs == "bool":
-            pcrmap = pcr.numpy2pcr(pcr.Boolean, data.astype(np.bool), np.bool(nodata))
+            pcrmap = pcr.numpy2pcr(pcr.Boolean, data.astype(bool), np.bool_(nodata))
         elif pcr_vs == "scalar":
             pcrmap = pcr.numpy2pcr(pcr.Scalar, data.astype(float), float(nodata))
         elif pcr_vs == "ordinal":


### PR DESCRIPTION
Since numpy 1.20.0, aliases of builtin types is deprecated. In most cases, this was not a problem, but one line in `write_map` used np.bool. This functionality is now removed from numpy, and is failing the hydromt_wflow tests. This PR fixes this issue, by changing `np.bool` with `bool` and `np.bool_`. See https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations