### PR TITLE
fix subbasin xy without snapping options

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ Changed
 Fixed
 -----
 - Order of renaming variables in get_rasterdataset for x,y dimensions. PR #324
+- fix bug in ``get_basin_geometry`` for region kind 'subbasin' if no stream or outlet option is specified.
 
 Deprecated
 ----------

--- a/docs/user_guide/model_region.rst
+++ b/docs/user_guide/model_region.rst
@@ -78,7 +78,7 @@ Users can supply the following:
 
     - ``{'subbasin': [x, y], 'bounds': [xmin, ymin, xmax, ymax]}``
 
-    The subbasins can further be refined based one (or more) variable-threshold pair(s)
+    The subbasins can further be refined based on one (or more) variable-threshold pair(s)
     to define streams, as described above for basins. If used in combination with point outlet locations,
     these are snapped to the nearest stream which meets the threshold criteria.
 

--- a/hydromt/workflows/basin_mask.py
+++ b/hydromt/workflows/basin_mask.py
@@ -429,6 +429,9 @@ def get_basin_geometry(
                 dims=ds.raster.dims,
                 data=np.full(ds.raster.shape, True, dtype=bool),
             )  # all True
+        # Convert xy to tuple
+        if xy is not None:
+            xy = (np.atleast_1d(xy[0]), np.atleast_1d(xy[1]))
         # get stream mask. Always over entire domain
         # to include cells downstream of aoi!
         kwargs = dict()


### PR DESCRIPTION
## Issue addressed
Fixes #297 

## Explanation
Turns out it was a bug. the list [xy] from region was parsed into tuples in a lot of different if else conditions in get_basin_geometry or basin_map. Fixed by converting to tuples more upstream in the code.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
