### PR TITLE
Fix haning test

### DIFF
--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -120,6 +120,11 @@ def test_rasterdataset_zoomlevels(rioda_large, tmpdir):
 
 
 def test_geodataset(geoda, geodf, ts, tmpdir):
+    # this test can sometimes hang because of threading issues therefore
+    # the synchronous scheduler here is necessary
+    from dask import config as dask_config
+
+    dask_config.set(scheduler="synchronous")
     fn_nc = str(tmpdir.join("test.nc"))
     fn_gdf = str(tmpdir.join("test.geojson"))
     fn_csv = str(tmpdir.join("test.csv"))


### PR DESCRIPTION
## Issue addressed
Fixes #408 

## Explanation
The problem seemed to be that Dask by default uses a light weight thread scheduler for it's workloads. This is lightweight but threads are flaky in python at best, and to the best of my understanding this caused the test to occasionally hang because at least two Dask threads were getting into a deadlock (each thread waiting on the other to complete something so they can continue their own work). Because this is quite a hard to reproduce issue and is arguably an upstream issue, I decided to go for the easy fix and just use the synchronous scheduler in Dask which should not run into this problem. If we run into the issue in more places we can start thinking of a more fundamental solution. 

Because the issue is quite hard to reproduce I can't be 100% certain that this solves the issue, but I ran the solution in a loop on my laptop in a while and the hang didn't occur once where without the fix, so I assume this is an adequate solution for this. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
async code is hard, especially in python :(
