### PR TITLE
only add coord mask if mask is set in raster

### DIFF
--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -1155,7 +1155,7 @@ class XRasterBase(XGeoBase):
             bbox = rasterio.warp.transform_bounds(geom.crs, self.crs, *bbox)
         obj_clip = self.clip_bbox(bbox, align=align, buffer=buffer)
         if mask:
-            obj_clip.coords["mask"] = obj_clip.raster.geometry_mask(geom) 
+            obj_clip.coords["mask"] = obj_clip.raster.geometry_mask(geom)
             obj_clip = obj_clip.raster.mask(obj_clip.coords["mask"])
         return obj_clip
 

--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -1154,8 +1154,8 @@ class XRasterBase(XGeoBase):
         if geom.crs is not None and self.crs is not None and geom.crs != self.crs:
             bbox = rasterio.warp.transform_bounds(geom.crs, self.crs, *bbox)
         obj_clip = self.clip_bbox(bbox, align=align, buffer=buffer)
-        obj_clip.coords["mask"] = obj_clip.raster.geometry_mask(geom)  # TODO remove!
         if mask:
+            obj_clip.coords["mask"] = obj_clip.raster.geometry_mask(geom) 
             obj_clip = obj_clip.raster.mask(obj_clip.coords["mask"])
         return obj_clip
 


### PR DESCRIPTION
## Issue addressed
Fixes #350 

## Explanation
When trying to clip a rasterized dataset to a geometry, the `clip_geom` had to allocate an entire numpy array at the highest resolution everywhere leading to memory issues when using high res datasets. To solve this problem, we moved the called to `geometry_mask ` inside the `clip_geom` to only happen if a mask is actually set. This solves the problem, but might have consequences for hydromt_wflow, I will open an issue there for them to investigate if this has impact for them. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
