### PR TITLE
Fix yamlfmt

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
@@ -9,8 +9,7 @@ body:
       label: HydroMT version checks
       options:
         - label: >
-            I have checked that the issue still exists on the latest versions of the docs
-            on `main` [here](https://github.com/Deltares/hydromt)
+            I have checked that the issue still exists on the latest versions of the docs on `main` [here](https://github.com/Deltares/hydromt)
           required: true
   - type: dropdown
     id: kind

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Explain how you addressed the bug/feature request, what choices you made and why
 - [ ] Branch is up to date with `main`
 - [ ] Tests & pre-commit hooks pass
 - [ ] Updated documentation if needed
+- [ ] Updated changelog.rst if needed
 
 ## Additional Notes (optional)
 Add any additional notes or information that may be helpful.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,19 +11,15 @@ repos:
       - id: check-json
       - id: debug-statements
       - id: mixed-line-ending
-
-  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-    rev: 0.2.1
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.8.0
     hooks:
       - id: yamlfmt
-        args: [--mapping, '2', --sequence, '4', --offset, '2']
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.270
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,4 +1,5 @@
 formatter:
   type: basic
   include_document_start: true
-  retain_line_breaks: false
+  retain_line_breaks: true
+  max_line_length: 150

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,4 @@
+formatter:
+  type: basic
+  include_document_start: true
+  retain_line_breaks: false

--- a/data/catalogs/deltares_data.yml
+++ b/data/catalogs/deltares_data.yml
@@ -140,7 +140,7 @@ copdem30_v2021.1:
     source_license: https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex+%281%29.pdf/83b44c0a-244a-7ba3-b00c-b578a34e88a7?t=1604070311399
     source_url: https://spacedata.copernicus.eu/web/cscda/dataset-details?articleId=394198#D4
     source_version: '2021_1'
-  nodata: -9999  # copdem has no actual nodata, this is to suppress a missing nodata warning
+  nodata: -9999 # copdem has no actual nodata, this is to suppress a missing nodata warning
   path: topography/copdem/copdem.vrt
   rename:
     copdem: elevtn
@@ -159,7 +159,7 @@ copdem30_mask_v2021.1:
     source_license: https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex+%281%29.pdf/83b44c0a-244a-7ba3-b00c-b578a34e88a7?t=1604070311399
     source_url: https://spacedata.copernicus.eu/web/cscda/dataset-details?articleId=394198#D4
     source_version: '2021_1'
-  nodata: -1  # copdem has no actual nodata, this is to suppress a missing nodata warning
+  nodata: -1 # copdem has no actual nodata, this is to suppress a missing nodata warning
   path: topography/copdem/copdem_mask.vrt
   rename:
     copdem_mask: mask

--- a/data/catalogs/gcs_cmip6_data.yml
+++ b/data/catalogs/gcs_cmip6_data.yml
@@ -22,12 +22,12 @@ cmip6_{model}_historical_{member}_{timestep}:
     model: [IPSL/IPSL-CM6A-LR, SNU/SAM0-UNICON, NCAR/CESM2, NCAR/CESM2-WACCM, INM/INM-CM4-8, INM/INM-CM5-0, NOAA-GFDL/GFDL-ESM4, NCC/NorESM2-LM, NIMS-KMA/KACE-1-0-G,
       CAS/FGOALS-f3-L, CSIRO-ARCCSS/ACCESS-CM2, NCC/NorESM2-MM, CSIRO/ACCESS-ESM1-5, NCAR/CESM2-WACCM-FV2, NCAR/CESM2-FV2, CMCC/CMCC-CM2-SR5, AS-RCEC/TaiESM1,
       NCC/NorCPM1, IPSL/IPSL-CM5A2-INCA, CMCC/CMCC-CM2-HR4, CMCC/CMCC-ESM2, IPSL/IPSL-CM6A-LR-INCA, E3SM-Project/E3SM-1-0]
-#    model: ['NOAA-GFDL/GFDL-CM4','BCC/BCC-CSM2-MR', 'BCC/BCC-ESM1', 'CCCma/CanESM5', 'MRI/MRI-ESM2-0',
-#    'HAMMOZ-Consortium/MPI-ESM-1-2-HAM', 'MPI-M/MPI-ESM1-2-LR', 'MPI-M/MPI-ESM1-2-HR', 'NUIST/NESM3',
-#    'CAS/FGOALS-g3', 'MIROC/MIROC6', 'KIOST/KIOST-ESM', 'CCCR-IITM/IITM-ESM', 'AWI/AWI-ESM-1-1-LR',
-#    'EC-Earth-Consortium/EC-Earth3-Veg-LR', 'EC-Earth-Consortium/EC-Earth3-Veg',
-#    'EC-Earth-Consortium/EC-Earth3', 'EC-Earth-Consortium/EC-Earth3-AerChem',
-#    'EC-Earth-Consortium/EC-Earth3-CC', 'MPI-M/ICON-ESM-LR'] # other models but were regridded to irregular grid for lat
+    #    model: ['NOAA-GFDL/GFDL-CM4','BCC/BCC-CSM2-MR', 'BCC/BCC-ESM1', 'CCCma/CanESM5', 'MRI/MRI-ESM2-0',
+    #    'HAMMOZ-Consortium/MPI-ESM-1-2-HAM', 'MPI-M/MPI-ESM1-2-LR', 'MPI-M/MPI-ESM1-2-HR', 'NUIST/NESM3',
+    #    'CAS/FGOALS-g3', 'MIROC/MIROC6', 'KIOST/KIOST-ESM', 'CCCR-IITM/IITM-ESM', 'AWI/AWI-ESM-1-1-LR',
+    #    'EC-Earth-Consortium/EC-Earth3-Veg-LR', 'EC-Earth-Consortium/EC-Earth3-Veg',
+    #    'EC-Earth-Consortium/EC-Earth3', 'EC-Earth-Consortium/EC-Earth3-AerChem',
+    #    'EC-Earth-Consortium/EC-Earth3-CC', 'MPI-M/ICON-ESM-LR'] # other models but were regridded to irregular grid for lat
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/CMIP/{model}/historical/{member}/{timestep}/{variable}/*/*
@@ -61,8 +61,8 @@ cmip6_{model}_ssp119_{member}_{timestep}:
     source_version: 1.3.1
   placeholders:
     model: [NOAA-GFDL/GFDL-ESM4, IPSL/IPSL-CM6A-LR]
-#    model: ['CCCma/CanESM5', 'MRI/MRI-ESM2-0','EC-Earth-Consortium/EC-Earth3-Veg',
-#    'EC-Earth-Consortium/EC-Earth3-Veg-LR'] # other models but were regridded to irregular grid for lat
+    #    model: ['CCCma/CanESM5', 'MRI/MRI-ESM2-0','EC-Earth-Consortium/EC-Earth3-Veg',
+    #    'EC-Earth-Consortium/EC-Earth3-Veg-LR'] # other models but were regridded to irregular grid for lat
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/ScenarioMIP/{model}/ssp119/{member}/{timestep}/{variable}/*/*
@@ -97,10 +97,10 @@ cmip6_{model}_ssp126_{member}_{timestep}:
   placeholders:
     model: [NOAA-GFDL/GFDL-ESM4, INM/INM-CM4-8, INM/INM-CM5-0, IPSL/IPSL-CM6A-LR, NIMS-KMA/KACE-1-0-G, NCC/NorESM2-MM, CMCC/CMCC-CM2-SR5, IPSL/IPSL-CM5A2-INCA,
       CMCC/CMCC-ESM2]
-#    model: ['BCC/BCC-CSM2-MR','CCCma/CanESM5','AWI/AWI-CM-1-1-MR','DKRZ/MPI-ESM1-2-HR','MPI-M/MPI-ESM1-2-LR',
-#    'NUIST/NESM3', 'MIROC/MIROC6','MRI/MRI-ESM2-0','KIOST/KIOST-ESM','EC-Earth-Consortium/EC-Earth3-Veg',
-#    'EC-Earth-Consortium/EC-Earth3','CCCR-IITM/IITM-ESM','EC-Earth-Consortium/EC-Earth3-Veg-LR',
-#    'NCAR/CESM2-WACCM','CSIRO-ARCCSS/ACCESS-CM2'] # other models but were regridded to irregular grid for lat or time outofbounds
+    #    model: ['BCC/BCC-CSM2-MR','CCCma/CanESM5','AWI/AWI-CM-1-1-MR','DKRZ/MPI-ESM1-2-HR','MPI-M/MPI-ESM1-2-LR',
+    #    'NUIST/NESM3', 'MIROC/MIROC6','MRI/MRI-ESM2-0','KIOST/KIOST-ESM','EC-Earth-Consortium/EC-Earth3-Veg',
+    #    'EC-Earth-Consortium/EC-Earth3','CCCR-IITM/IITM-ESM','EC-Earth-Consortium/EC-Earth3-Veg-LR',
+    #    'NCAR/CESM2-WACCM','CSIRO-ARCCSS/ACCESS-CM2'] # other models but were regridded to irregular grid for lat or time outofbounds
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/ScenarioMIP/{model}/ssp126/{member}/{timestep}/{variable}/*/*
@@ -135,10 +135,10 @@ cmip6_{model}_ssp245_{member}_{timestep}:
   placeholders:
     model: [NOAA-GFDL/GFDL-ESM4, IPSL/IPSL-CM6A-LR, INM/INM-CM4-8, INM/INM-CM5-0, NCAR/CESM2-WACCM, NCC/NorESM2-LM, CSIRO-ARCCSS/ACCESS-CM2, NCC/NorESM2-MM,
       NIMS-KMA/KACE-1-0-G, CMCC/CMCC-CM2-SR5, CMCC/CMCC-ESM2, AS-RCEC/TaiESM1]
-#    model: ['NOAA-GFDL/GFDL-CM4','BCC/BCC-CSM2-MR','CCCma/CanESM5','EC-Earth-Consortium/EC-Earth3-Veg',
-#    'EC-Earth-Consortium/EC-Earth3','EC-Earth-Consortium/EC-Earth3-Veg-LR','EC-Earth-Consortium/EC-Earth3-CC',
-#    'AWI/AWI-CM-1-1-MR','MRI/MRI-ESM2-0','MPI-M/MPI-ESM1-2-LR','DKRZ/MPI-ESM1-2-HR','NUIST/NESM3',
-#    'CAS/FGOALS-g3','MIROC/MIROC6','KIOST/KIOST-ESM','CCCR-IITM/IITM-ESM'] # other models but were regridded to irregular grid for lat
+    #    model: ['NOAA-GFDL/GFDL-CM4','BCC/BCC-CSM2-MR','CCCma/CanESM5','EC-Earth-Consortium/EC-Earth3-Veg',
+    #    'EC-Earth-Consortium/EC-Earth3','EC-Earth-Consortium/EC-Earth3-Veg-LR','EC-Earth-Consortium/EC-Earth3-CC',
+    #    'AWI/AWI-CM-1-1-MR','MRI/MRI-ESM2-0','MPI-M/MPI-ESM1-2-LR','DKRZ/MPI-ESM1-2-HR','NUIST/NESM3',
+    #    'CAS/FGOALS-g3','MIROC/MIROC6','KIOST/KIOST-ESM','CCCR-IITM/IITM-ESM'] # other models but were regridded to irregular grid for lat
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/ScenarioMIP/{model}/ssp245/{member}/{timestep}/{variable}/*/*
@@ -173,10 +173,10 @@ cmip6_{model}_ssp370_{member}_{timestep}:
   placeholders:
     model: [NOAA-GFDL/GFDL-ESM4, IPSL/IPSL-CM6A-LR, INM/INM-CM4-8, INM/INM-CM5-0, NCAR/CESM2-WACCM, CSIRO-ARCCSS/ACCESS-CM2, NCC/NorESM2-MM, NCC/NorESM2-LM,
       NIMS-KMA/KACE-1-0-G, CMCC/CMCC-CM2-SR5, IPSL/IPSL-CM5A2-INCA, CMCC/CMCC-ESM2]
-#    model: ['BCC/BCC-CSM2-MR','CCCma/CanESM5','AWI/AWI-CM-1-1-MR','BCC/BCC-ESM1','DKRZ/MPI-ESM1-2-HR',
-#    EC-Earth-Consortium/EC-Earth3-Veg','EC-Earth-Consortium/EC-Earth3','EC-Earth-Consortium/EC-Earth3-AerChem',
-#    'EC-Earth-Consortium/EC-Earth3-Veg-LR','MRI/MRI-ESM2-0','MPI-M/MPI-ESM1-2-LR','HAMMOZ-Consortium/MPI-ESM-1-2-HAM',
-#    'CAS/FGOALS-g3','MIROC/MIROC6','CCCR-IITM/IITM-ESM'] # other models but were regridded to irregular grid for lat
+    #    model: ['BCC/BCC-CSM2-MR','CCCma/CanESM5','AWI/AWI-CM-1-1-MR','BCC/BCC-ESM1','DKRZ/MPI-ESM1-2-HR',
+    #    EC-Earth-Consortium/EC-Earth3-Veg','EC-Earth-Consortium/EC-Earth3','EC-Earth-Consortium/EC-Earth3-AerChem',
+    #    'EC-Earth-Consortium/EC-Earth3-Veg-LR','MRI/MRI-ESM2-0','MPI-M/MPI-ESM1-2-LR','HAMMOZ-Consortium/MPI-ESM-1-2-HAM',
+    #    'CAS/FGOALS-g3','MIROC/MIROC6','CCCR-IITM/IITM-ESM'] # other models but were regridded to irregular grid for lat
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/ScenarioMIP/{model}/ssp370/{member}/{timestep}/{variable}/*/*
@@ -210,7 +210,7 @@ cmip6_{model}_ssp434_{member}_{timestep}:
     source_version: 1.3.1
   placeholders:
     model: [IPSL/IPSL-CM6A-LR]
-#    model: ['CCCma/CanESM5'] # other models but were regridded to irregular grid for lat
+    #    model: ['CCCma/CanESM5'] # other models but were regridded to irregular grid for lat
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/ScenarioMIP/{model}/ssp434/{member}/{timestep}/{variable}/*/*
@@ -244,7 +244,7 @@ cmip6_{model}_ssp460_{member}_{timestep}:
     source_version: 1.3.1
   placeholders:
     model: [IPSL/IPSL-CM6A-LR]
-#    model: ['CCCma/CanESM5'] # other models but were regridded to irregular grid for lat
+    #    model: ['CCCma/CanESM5'] # other models but were regridded to irregular grid for lat
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/ScenarioMIP/{model}/ssp460/{member}/{timestep}/{variable}/*/*
@@ -279,11 +279,11 @@ cmip6_{model}_ssp585_{member}_{timestep}:
   placeholders:
     model: [NOAA-GFDL/GFDL-ESM4, INM/INM-CM4-8, INM/INM-CM5-0, NIMS-KMA/KACE-1-0-G, NCC/NorESM2-MM, NCC/NorESM2-LM, CMCC/CMCC-CM2-SR5, AS-RCEC/TaiESM1,
       CMCC/CMCC-ESM2]
-#    model: ['NOAA-GFDL/GFDL-CM4','BCC/BCC-CSM2-MR','CCCma/CanESM5','AWI/AWI-CM-1-1-MR','MPI-M/MPI-ESM1-2-LR',
-#    'DKRZ/MPI-ESM1-2-HR','MIROC/MIROC6','MRI/MRI-ESM2-0','EC-Earth-Consortium/EC-Earth3-Veg',
-#    'EC-Earth-Consortium/EC-Earth3','EC-Earth-Consortium/EC-Earth3-Veg-LR','EC-Earth-Consortium/EC-Earth3-CC',
-#    'NUIST/NESM3','CAS/FGOALS-g3','IPSL/IPSL-CM6A-LR','KIOST/KIOST-ESM', 'NCAR/CESM2-WACCM','CCCR-IITM/IITM-ESM',
-#    'CSIRO-ARCCSS/ACCESS-CM2','CSIRO/ACCESS-ESM1-5'] # other models but were regridded to irregular grid for lat or time outofbounds
+    #    model: ['NOAA-GFDL/GFDL-CM4','BCC/BCC-CSM2-MR','CCCma/CanESM5','AWI/AWI-CM-1-1-MR','MPI-M/MPI-ESM1-2-LR',
+    #    'DKRZ/MPI-ESM1-2-HR','MIROC/MIROC6','MRI/MRI-ESM2-0','EC-Earth-Consortium/EC-Earth3-Veg',
+    #    'EC-Earth-Consortium/EC-Earth3','EC-Earth-Consortium/EC-Earth3-Veg-LR','EC-Earth-Consortium/EC-Earth3-CC',
+    #    'NUIST/NESM3','CAS/FGOALS-g3','IPSL/IPSL-CM6A-LR','KIOST/KIOST-ESM', 'NCAR/CESM2-WACCM','CCCR-IITM/IITM-ESM',
+    #    'CSIRO-ARCCSS/ACCESS-CM2','CSIRO/ACCESS-ESM1-5'] # other models but were regridded to irregular grid for lat or time outofbounds
     member: [r1i1p1f1]
     timestep: [day, Amon]
   path: gs://cmip6/CMIP6/ScenarioMIP/{model}/ssp585/{member}/{timestep}/{variable}/*/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,6 +222,7 @@ napoleon_preprocess_types = True
 #
 html_theme = "pydata_sphinx_theme"
 html_logo = "_static/hydromt-icon.svg"
+html_favicon = "_static/hydromt-icon.svg"
 autodoc_member_order = "bysource"  # overwrite default alphabetical sort
 autoclass_content = "both"
 

--- a/tests/data/test_sources.yml
+++ b/tests/data/test_sources.yml
@@ -21,14 +21,14 @@ era5:
     tisr: kout
   unit_mult:
     precip: 1000 # mm/day
-    press_msl: 0.01  # hPa
-    kin: 0.000277778  # J hr-1
-    kout: 0.000277778  # J hr-1
+    press_msl: 0.01 # hPa
+    kin: 0.000277778 # J hr-1
+    kout: 0.000277778 # J hr-1
   unit_add:
     time: 86400 # [sec] 1D shift to set 'right' labels
-    temp: -273.15  # deg. C.
-    temp_min: -273.15  # deg. C.
-    temp_max: -273.15  # deg. C.
+    temp: -273.15 # deg. C.
+    temp_min: -273.15 # deg. C.
+    temp_max: -273.15 # deg. C.
   meta:
     category: meteo
     history: Extracted from Copernicus Climate Data Store; resampled by Deltares to daily frequency


### PR DESCRIPTION
## Issue addressed
Fixes #426 

## Explanation
The previous pre-commit hook for yaml formatting did not work on windows for whatever reason. So in order to remedy this I moved us over to the google pre-commit hook, which should be better maintained. If I recall correctly the google formatter has a bit fewer options for customization, but I tuned it to be as close to the format rules we already have. It made a few small changes, but overall should be fine, and now it works on windows as well, so all in all, I think this is fine. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
