### PR TITLE
_uri_validator accepts Path objects

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Fixed
 -----
 - Order of renaming variables in get_rasterdataset for x,y dimensions. PR #324
 - fix bug in ``get_basin_geometry`` for region kind 'subbasin' if no stream or outlet option is specified.
+- fix use of Path objects in parsing data catalog files. PR #429
 
 Deprecated
 ----------

--- a/hydromt/data_adapter/caching.py
+++ b/hydromt/data_adapter/caching.py
@@ -5,6 +5,7 @@ import shutil
 from ast import literal_eval
 from os.path import basename, dirname, isdir, isfile, join
 from pathlib import Path
+from typing import Union
 from urllib.parse import urlparse
 
 import geopandas as gpd
@@ -19,10 +20,10 @@ logger = logging.getLogger(__name__)
 HYDROMT_DATADIR = join(Path.home(), ".hydromt_data")
 
 
-def _uri_validator(uri: str) -> bool:
+def _uri_validator(uri: Union[str, Path]) -> bool:
     """Check if uri is valid."""
     try:
-        result = urlparse(uri)
+        result = urlparse(str(uri))
         return all([result.scheme, result.netloc])
     except ValueError | AttributeError:
         return False

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -967,7 +967,7 @@ def _parse_data_dict(
         # Only for local files
         path = source.pop("path")
         # if remote path, keep as is else call abs_path method to solve local files
-        if not _uri_validator(path):
+        if not _uri_validator(str(path)):
             path = abs_path(root, path)
         meta = source.pop("meta", {})
         if "category" not in meta and category is not None:
@@ -1004,7 +1004,7 @@ def _parse_data_dict(
 
 
 def _yml_from_uri_or_path(uri_or_path: Union[Path, str]) -> Dict:
-    if _uri_validator(uri_or_path):
+    if _uri_validator(str(uri_or_path)):
         with requests.get(uri_or_path, stream=True) as r:
             if r.status_code != 200:
                 raise IOError(f"URL {r.content}: {uri_or_path}")

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -2,6 +2,7 @@
 
 import os
 from os.path import abspath, dirname, join
+from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
@@ -26,6 +27,10 @@ def test_parser():
     }
     dd_out = _parse_data_dict(dd, root=root)
     assert isinstance(dd_out["test"], RasterDatasetAdapter)
+    assert dd_out["test"].path == abspath(dd["test"]["path"])
+    # test with Path object
+    dd["test"].update(path=Path(dd["test"]["path"]))
+    dd_out = _parse_data_dict(dd, root=root)
     assert dd_out["test"].path == abspath(dd["test"]["path"])
     # rel path
     dd = {
@@ -62,6 +67,7 @@ def test_parser():
     assert len(dd_out) == 6
     assert dd_out["test_a_1"].path == abspath(join(root, "data_1.tif"))
     assert "placeholders" not in dd_out["test_a_1"].to_dict()
+
     # errors
     with pytest.raises(ValueError, match="Missing required path argument"):
         _parse_data_dict({"test": {}})


### PR DESCRIPTION
## Issue addressed
Fixes #413

## Explanation
Make sure _uri_validator accepts Path ojbects and is called with str.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
