### PR TITLE
from_gdf: gdf vs data index

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ Changed
 - Added extrapolate option to `raster.interpolate_na` method. PR #348
 - Name of methods ``setup_maps_from_raster`` and ``setup_mesh_from_raster`` to ``setup_maps_from_rasterdataset`` and ``setup_mesh_from_rasterdataset``. PR #333
 - Add rename argument to ``setup_*_from_rasterdataset``, ``setup_*_from_raster_reclass`` to maps and mesh for consistency with grid. PR #333
+- GeoDataFrame and accompanying array-like data can have different indices `RasterDataArray.from_gdf` (restored functionality). PR #441
 
 Fixed
 -----

--- a/hydromt/vector.py
+++ b/hydromt/vector.py
@@ -740,6 +740,10 @@ class GeoDataArray(GeoBase):
         if index_dim is None:
             index_dim = gdf.index.name if gdf.index.name is not None else "index"
         geom_name = gdf.geometry.name
+        # Some index dimension checking
+        # TODO Check this!!! Might be unwanted
+        if index_dim in gdf.columns:
+            gdf.set_index(index_dim, inplace=True)
         # create DataArray from array_like data
         da = xr.DataArray(data=data, coords=coords, dims=dims, name=name)
         # check dims -> assume index dim is first dim if not provided
@@ -760,6 +764,7 @@ class GeoDataArray(GeoBase):
             hdrs = gdf.columns
         else:
             hdrs = [geom_name]
+        da = da.reindex({index_dim: gdf.index})
         da = da.assign_coords({hdr: (index_dim, gdf[hdr]) for hdr in hdrs})
         da = da.transpose(index_dim, ...).reindex({index_dim: gdf.index})
         # set geospatial attributes

--- a/hydromt/vector.py
+++ b/hydromt/vector.py
@@ -713,8 +713,6 @@ class GeoDataArray(GeoBase):
         gdf: geopandas GeoDataFrame
             Spatial coordinates. The index should match the array_like index_dim and the
             geometry column may only contain Point geometries.
-        name:
-            The name of the data set for metadata purposes.
         data: array_like
             Values for this array. Must be an ``numpy.ndarray``, ndarray like,
             or castable to an ``ndarray``. If a self-described xarray or pandas
@@ -728,33 +726,38 @@ class GeoDataArray(GeoBase):
             for 1D data) or a sequence of hashables with length equal to the
             number of dimensions. If this argument is omitted, dimension names
             default to ``['dim_0', ... 'dim_n']``.
+        name: str, optional
+            The name of the data set for metadata purposes.
         index_dim: str, optional
             Name of index dimension of data
         keep_cols: bool, optional
             If True, keep gdf columns as extra coordinates in dataset
-        how: str, optional
-            Which indices to use for the new DataArray
-            E.g. how = 'gdf' will result in the usage of the GeoDataFrame indices
-            The options are: 'gdf', 'inner'
+        how: {'gdf', 'inner'}, default 'gdf'
+            Type of merge to be performed between gdf and data.
+
+            * gdf: use only keys from gdf index. Missing values will be filled with NaNs
+            * inner: use intersection of gdf and data index.
 
         Returns
         -------
         da: xarray.DataArray
             DataArray with geospatial coordinates
         """
-        if how not in ["gdf", "inner", "data"]:
-            raise ValueError(f"{how} is not a valid value for 'how'")
+        # parse gdf to dataset
+        if isinstance(gdf, GeoSeries):
+            if gdf.name is None:
+                gdf.name = "geometry"
+            gdf = gdf.to_frame()
+        if not isinstance(gdf, GeoDataFrame):
+            raise ValueError(f"gdf data type not understood {type(gdf)}")
+        # check index_dim
         if index_dim is None:
             index_dim = gdf.index.name if gdf.index.name is not None else "index"
         geom_name = gdf.geometry.name
-        # Some index dimension checking
-        # TODO Check this!!! Might be unwanted
-        if index_dim in gdf.columns:
-            gdf = gdf.set_index(index_dim)
         # create DataArray from array_like data
         da = xr.DataArray(data=data, coords=coords, dims=dims, name=name)
         # check dims -> assume index dim is first dim if not provided
-        if dims is None and index_dim not in da.dims:
+        if dims is None and index_dim not in da.dims and len(da.dims) > 0:
             da = da.rename({list(da.dims)[0]: index_dim})
         # check if all data array contain index_dim
         if index_dim not in da.dims:
@@ -766,27 +769,17 @@ class GeoDataArray(GeoBase):
                 raise TypeError(
                     "DataArray and GeoDataFrame index datatypes do not match."
                 )
-        # set gdf geometry and optional other columns
-        if keep_cols:
-            hdrs = gdf.columns
-        else:
-            hdrs = [geom_name]
         # Which indices to use
         if how == "gdf":
-            _index = gdf.index
-            da = da.reindex({index_dim: gdf.index})
-            da = da.assign_coords({hdr: (index_dim, gdf[hdr]) for hdr in hdrs})
+            _index = gdf.index.values
         elif how == "inner":
-            _comb = [*data.index, *gdf.index]
-            _index = [n for n in set(_comb) if _comb.count(n) > 1]
-            da = da.reindex({index_dim: _index})
-            da = da.assign_coords(
-                {hdr: (index_dim, gdf.loc[_index][hdr]) for hdr in hdrs}
-            )
-        elif how == "data":
-            raise NotImplementedError("")
-
-        da = da.transpose(index_dim, ...).reindex({index_dim: _index})
+            _index = gdf.index.intersection(da[index_dim]).values
+        else:
+            raise ValueError(f"{how} is not a valid value for 'how'")
+        da = da.reindex({index_dim: _index}).transpose(index_dim, ...)
+        # set gdf geometry and optional other columns
+        hdrs = gdf.columns if keep_cols else [geom_name]
+        da = da.assign_coords({hdr: (index_dim, gdf.loc[_index, hdr]) for hdr in hdrs})
         # set geospatial attributes
         da.vector.set_spatial_dims(geom_name=geom_name, geom_format="geom")
         da.vector.set_crs(gdf.crs)
@@ -856,14 +849,13 @@ class GeoDataset(GeoBase):
     @staticmethod
     def from_gdf(
         gdf: gpd.GeoDataFrame,
-        data_vars: dict = {},
+        data_vars: dict = None,
         coords: dict = None,
         index_dim: str = None,
         keep_cols: bool = True,
+        how: str = "gdf",
     ) -> xr.Dataset:
         """Create Dataset with geospatial coordinates.
-
-        The Dataset values are reindexed to the gdf index.
 
         Arguments
         ---------
@@ -882,6 +874,11 @@ class GeoDataset(GeoBase):
             Name of index dimension in data_vars
         keep_cols: bool, optional
             If True, keep gdf columns as extra coordinates in dataset
+        how: {'gdf', 'inner'}, default 'gdf'
+            Type of merge to be performed between gdf and data.
+
+            * gdf: use only keys from gdf index. Missing values will be filled with NaNs
+            * inner: use intersection of gdf and data index.
 
         Returns
         -------
@@ -895,35 +892,47 @@ class GeoDataset(GeoBase):
             gdf = gdf.to_frame()
         if not isinstance(gdf, GeoDataFrame):
             raise ValueError(f"gdf data type not understood {type(gdf)}")
+        # check index_dim
         if index_dim is None:
             index_dim = gdf.index.name if gdf.index.name is not None else "index"
         geom_name = gdf.geometry.name
-        if not keep_cols:
-            gdf = gdf[[geom_name]]
-        ds = gdf.to_xarray().set_coords(gdf.columns)
         # parse data_vars to dataset
-        if data_vars is not None and len(data_vars) > 0:
+        if data_vars is not None:
             if isinstance(data_vars, xr.DataArray):
-                data_vars = data_vars.to_dataset()
+                ds = data_vars.to_dataset()
             elif isinstance(data_vars, xr.Dataset):
-                pass
+                ds = data_vars
             else:
-                data_vars = xr.Dataset(data_vars, coords=coords)
-            # check if any data array contain index_dim
-            if index_dim not in data_vars.dims:
-                raise ValueError(f"Index dimension {index_dim} not found in dataset.")
-            if np.dtype(data_vars[index_dim]).type != np.dtype(gdf.index).type:
                 try:
-                    data_vars[index_dim] = data_vars[index_dim].astype(
-                        np.dtype(gdf.index).type
+                    ds = xr.Dataset(data_vars, coords=coords)
+                except TypeError:
+                    raise TypeError(
+                        "data_vars should be a dict-like, DataArray or Dataset"
                     )
+            # check if any data array contain index_dim
+            if index_dim not in ds.dims:
+                raise ValueError(f"Index dimension {index_dim} not found in data_vars.")
+            if np.dtype(ds[index_dim]).type != np.dtype(gdf.index).type:
+                try:
+                    ds[index_dim] = ds[index_dim].astype(np.dtype(gdf.index).type)
                 except TypeError:
                     raise TypeError(
                         "Dataset and GeoDataFrame index datatypes do not match."
                     )
-        # combine both, transpose and reindex
-        ds = ds.assign(data_vars)
-        ds = ds.transpose(index_dim, ...).reindex({index_dim: gdf.index})
+        else:  # create empty dataset
+            ds = xr.Dataset(coords={index_dim: gdf.index.values})
+        # Which indices to use
+        if how == "gdf":
+            _index = gdf.index.values
+        elif how == "inner":
+            _index = gdf.index.intersection(ds[index_dim]).values
+        else:
+            raise ValueError(f"{how} is not a valid value for 'how'")
+        ds = ds.reindex({index_dim: _index}).transpose(index_dim, ...)
+        # set gdf geometry and optional other columns
+        hdrs = gdf.columns if keep_cols else [geom_name]
+        ds = ds.assign_coords({hdr: (index_dim, gdf.loc[_index, hdr]) for hdr in hdrs})
+        # set geospatial attributes
         ds.vector.set_spatial_dims(geom_name=geom_name, geom_format="geom")
         ds.vector.set_crs(gdf.crs)
         return ds

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -3,11 +3,12 @@
 
 import numpy as np
 import pytest
+import xarray as xr
 from geopandas import GeoDataFrame
 from pyproj import CRS
 from shapely.geometry import MultiPolygon, Polygon
 
-from hydromt.vector import GeoDataset
+from hydromt.vector import GeoDataArray, GeoDataset
 
 
 @pytest.fixture()
@@ -57,14 +58,11 @@ def test_ogr(tmpdir, gdf):
     assert np.all(ds.vector.geometry == ds1.vector.geometry)
 
 
-def test_geo(geoda, geodf):
+def test_vector(geoda, geodf):
     # vector props
     assert geoda.vector.crs.to_epsg() == geodf.crs.to_epsg()
     assert np.dtype(geoda[geoda.vector.time_dim]).type == np.datetime64
     assert np.all(geoda.vector.geometry == geodf.geometry)
-    # build from array
-    da1 = GeoDataset.from_gdf(geodf, geoda)[geoda.name]
-    assert np.all(da1 == geoda)
     # to geopandas
     gdf1 = geoda.vector.to_gdf(reducer=np.mean)
     gdf2 = geoda.to_dataset().vector.to_gdf(reducer=np.mean)
@@ -76,9 +74,65 @@ def test_geo(geoda, geodf):
     da1 = geoda.vector.to_crs(3857)
     gdf1 = geodf.to_crs(3857)
     assert np.all(da1.vector.geometry == gdf1.geometry)
-    # errors
+
+
+def test_from_gdf(geoda, geodf):
+    geoda0 = geoda.reset_coords(drop=True)  # drop geometries
+    dims = list(geoda0.dims)
+    coords = geoda0.coords
+    # build from GeoDataFrame
+    da1 = GeoDataArray.from_gdf(geodf, geoda0)
+    assert np.all(geodf.geometry == da1.vector.geometry)
+    assert all([c in da1.coords for c in geodf.columns])
+    ds1 = GeoDataset.from_gdf(geodf, geoda0)  # idem for dataset
+    xr.testing.assert_equal(ds1[geoda.name], da1)
+    # build from GeoSeries
+    da1 = GeoDataArray.from_gdf(geodf["geometry"], geoda0)
+    assert np.all(geodf.geometry == da1.vector.geometry)
+    ds1 = GeoDataset.from_gdf(geodf["geometry"], geoda0)  # idem for dataset
+    xr.testing.assert_equal(ds1[geoda.name], da1)
+    # test with numpy array
+    ds1 = GeoDataset.from_gdf(geodf, {"test": (dims, geoda0.values)}, coords=coords)
+    assert isinstance(ds1, xr.Dataset)
+    assert np.all(geodf.geometry == ds1.vector.geometry)
+    da1 = GeoDataArray.from_gdf(geodf, geoda0.values, coords=coords)  # idem for array
+    xr.testing.assert_equal(ds1["test"], da1)
+    # test with different merging strategies
+    da1 = GeoDataArray.from_gdf(geodf, geoda0.sel(index=[0, 1, 2]))
+    assert np.all(np.isnan(da1.sel(index=[3, 4])))
+    assert np.all(geodf.geometry == da1.vector.geometry)
+    assert np.all(da1.index == geodf.index)
+    ds1 = GeoDataset.from_gdf(geodf, geoda0.sel(index=[0, 1, 2]))  # idem for dataset
+    xr.testing.assert_equal(ds1[geoda.name], da1)
+    # inner join
+    da1 = GeoDataArray.from_gdf(
+        geodf.loc[[2, 3, 4]], geoda0.sel(index=[0, 1, 2]), how="inner"
+    )
+    assert np.all(np.isin(da1.index, [2]))
+    ds1 = GeoDataset.from_gdf(
+        geodf.loc[[2, 3, 4]], geoda0.sel(index=[0, 1, 2]), how="inner"
+    )  # idem for dataset
+    xr.testing.assert_equal(ds1[geoda.name], da1)
+    # test without data
+    ds1 = GeoDataset.from_gdf(geodf)
+    assert isinstance(ds1, xr.Dataset)
+    assert np.all(geodf.geometry == ds1.vector.geometry)
+    # errors GeoDataset
     with pytest.raises(ValueError, match="gdf data type not understood"):
         GeoDataset.from_gdf(geoda)
+    with pytest.raises(TypeError, match="data_vars should be a dict-like"):
+        GeoDataset.from_gdf(geodf, data_vars=1)
+    with pytest.raises(ValueError, match="Index dimension city not found in data_vars"):
+        GeoDataset.from_gdf(geodf, geoda0, index_dim="city")
+    with pytest.raises(ValueError, match="wrong is not a valid value for 'how'"):
+        GeoDataset.from_gdf(geodf, geoda0, how="wrong")
+    # errors GeoDataArray
+    with pytest.raises(ValueError, match="gdf data type not understood"):
+        GeoDataArray.from_gdf(geoda, geoda)
+    with pytest.raises(ValueError, match="Index dimension city not found in data_vars"):
+        GeoDataset.from_gdf(geodf, geoda0, index_dim="city")
+    with pytest.raises(ValueError, match="wrong is not a valid value for 'how'"):
+        GeoDataArray.from_gdf(geodf, geoda0, how="wrong")
 
 
 def test_geo_clip(geoda, world):


### PR DESCRIPTION
## Issue addressed
Fixes #415 

## Explanation
Added a new `index_merge` argument in `GeoDataset.from_gdf` and `GeoDataArray.from_gdf` to decide whether to merge based on the gdf index (default) or the intersection of both the gdf and data indices. Other merge options do not make sense as a GeoDataset/Array should contain a coordinate with geometries which cannot/should not have missing values. An error is raised in both cases if there is no overlap in indices between both datasets.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
