### PR TITLE
Fix `make dev` for mamba 

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - .binder/*
       - Dockerfile
+      - pyproject.toml
   pull_request:
     branches: [main]
     paths:
       - .binder/*
       - Dockerfile
+      - pyproject.toml
 
 jobs:
   test-docker-image:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -32,7 +32,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: generate envs
-        run: make full-environment.yml
+        run: |
+          pip install tomli
+          make full-environment.yml
 
       - name: Build and test
         uses: docker/build-push-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PY_ENV_MANAGER		?= micromamba
+PY_ENV_MANAGER		?= mamba
 DOCKER_USER_NAME 	?= deltares
 OPT_DEPS			?= ""
 SPHINXBUILD   	 	 = sphinx-build
@@ -9,16 +9,9 @@ BUILDDIR      	 	 = docs/_build
 .PHONY: clean html
 
 dev: full-environment.yml
-	$(PY_ENV_MANAGER) create -f full-environment.yml -y
-	$(PY_ENV_MANAGER) -n hydromt run pip install .
-	$(PY_ENV_MANAGER) -n hydromt run pre-commit install
-
-env:
-	@# the subst is to make sure the is always exactly one "" around OPT_DEPS so people can
-	@# specify it both as OPT_DEPS=extra,io and OPT_DEPS="extra,io"
-	python3 make_env.py "$(subst ",,$(OPT_DEPS))"
-	$(PY_ENV_MANAGER) create -f environment.yml -y
-	$(PY_ENV_MANAGER) -n hydromt run pip install .
+	$(PY_ENV_MANAGER) env create -f full-environment.yml
+	$(PY_ENV_MANAGER) run -n hydromt-full pip install -e .
+	$(PY_ENV_MANAGER) run -n hydromt-full pre-commit install
 
 min-environment.yml:
 	pip install tomli

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PY_ENV_MANAGER		?= mamba
 DOCKER_USER_NAME 	?= deltares
 OPT_DEPS			?= ""
+ENV_NAME			?= hydromt
 SPHINXBUILD   	 	 = sphinx-build
 SPHINXPROJ    	 	 = hydromt
 SOURCEDIR     	 	 = docs
@@ -8,17 +9,20 @@ BUILDDIR      	 	 = docs/_build
 
 .PHONY: clean html
 
-dev: full-environment.yml
-	$(PY_ENV_MANAGER) env create -f full-environment.yml
-	$(PY_ENV_MANAGER) run -n hydromt-full pip install -e .
-	$(PY_ENV_MANAGER) run -n hydromt-full pre-commit install
+dev:
+	pip install tomli
+	python make_env.py full -n hydromt-dev
+	$(PY_ENV_MANAGER) env create -f environment.yml
+	$(PY_ENV_MANAGER) run -n hydromt-dev pip install -e .
+	$(PY_ENV_MANAGER) run -n hydromt-dev pre-commit install
 
 env:
 	@# the subst is to make sure the is always exactly one "" around OPT_DEPS so people can
 	@# specify it both as OPT_DEPS=extra,io and OPT_DEPS="extra,io"
-	python make_env.py "$(subst ",,$(OPT_DEPS))"
-	$(PY_ENV_MANAGER) create -f environment.yml -y
-	$(PY_ENV_MANAGER) -n hydromt run pip install .
+	pip install tomli
+	python make_env.py "$(subst ",,$(OPT_DEPS))" -n $(ENV_NAME)
+	$(PY_ENV_MANAGER) env create -f environment.yml
+	$(PY_ENV_MANAGER) run -n $(ENV_NAME) pip install .
 
 min-environment.yml:
 	pip install tomli
@@ -52,8 +56,10 @@ pypi:
 
 clean:
 	rm -f *environment.yml
-	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)
 	rm -rf dist
+	rm -rf docs/_generated
+	rm -rf docs/_examples
 
 docker-clean:
 	docker images =reference="*hydromt*" -q | xargs --no-run-if-empty docker rmi -f

--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,24 @@ dev: full-environment.yml
 	$(PY_ENV_MANAGER) run -n hydromt-full pip install -e .
 	$(PY_ENV_MANAGER) run -n hydromt-full pre-commit install
 
+env:
+	@# the subst is to make sure the is always exactly one "" around OPT_DEPS so people can
+	@# specify it both as OPT_DEPS=extra,io and OPT_DEPS="extra,io"
+	python make_env.py "$(subst ",,$(OPT_DEPS))"
+	$(PY_ENV_MANAGER) create -f environment.yml -y
+	$(PY_ENV_MANAGER) -n hydromt run pip install .
+
 min-environment.yml:
 	pip install tomli
-	python3 make_env.py -o min-environment.yml
+	python make_env.py -o min-environment.yml
 
 slim-environment.yml:
 	pip install tomli
-	python3 make_env.py "slim" -o slim-environment.yml
+	python make_env.py "slim" -o slim-environment.yml
 
 full-environment.yml:
 	pip install tomli
-	python3 make_env.py "full" -o full-environment.yml
+	python make_env.py "full" -o full-environment.yml
 
 docker-min: min-environment.yml
 	docker build -t $(DOCKER_USER_NAME)/hydromt:min --target=min .

--- a/Makefile
+++ b/Makefile
@@ -9,31 +9,27 @@ BUILDDIR      	 	 = docs/_build
 
 .PHONY: clean html
 
-dev:
-	pip install tomli
+dev: pyproject.toml
 	python make_env.py full -n hydromt-dev
 	$(PY_ENV_MANAGER) env create -f environment.yml
 	$(PY_ENV_MANAGER) run -n hydromt-dev pip install -e .
 	$(PY_ENV_MANAGER) run -n hydromt-dev pre-commit install
 
-env:
+env: pyproject.toml
 	@# the subst is to make sure the is always exactly one "" around OPT_DEPS so people can
 	@# specify it both as OPT_DEPS=extra,io and OPT_DEPS="extra,io"
-	pip install tomli
+	@# Note that if you use this receipt you will not get in editable install
 	python make_env.py "$(subst ",,$(OPT_DEPS))" -n $(ENV_NAME)
 	$(PY_ENV_MANAGER) env create -f environment.yml
 	$(PY_ENV_MANAGER) run -n $(ENV_NAME) pip install .
 
 min-environment.yml:
-	pip install tomli
 	python make_env.py -o min-environment.yml
 
 slim-environment.yml:
-	pip install tomli
 	python make_env.py "slim" -o slim-environment.yml
 
 full-environment.yml:
-	pip install tomli
 	python make_env.py "full" -o full-environment.yml
 
 docker-min: min-environment.yml

--- a/docs/dev/dev_install.rst
+++ b/docs/dev/dev_install.rst
@@ -98,7 +98,7 @@ After the environment file has been created you can create an environment out of
 .. code-block:: console
 
     $ mamba env create -f environment.yml
-    $ mamba activate hydromt
+    $ mamba activate hydromt-full
 
 Finally, create a developer installation of HydroMT:
 

--- a/docs/dev/dev_install.rst
+++ b/docs/dev/dev_install.rst
@@ -13,27 +13,27 @@ However, there is a script that can generate the conda enviroment specification 
 Developer installation guide
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-First, clone the HydroMT ``git`` repo using `ssh <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`_ from
-`github <https://github.com/Deltares/hydromt.git>`_.
+Here we describe two ways to install HydroMT for development.
+The first is using the `makefile` which boils down to running a single command.
+The second is a step-by-step guide that shows you exactly what the makefile does
+and how to do it manually.
+
+But first, you need to clone the HydroMT ``git`` repo using
+`ssh <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`_
+from `github <https://github.com/Deltares/hydromt.git>`_.
+Then, navigate into the the code folder (where the pyproject.toml is located)
 
 .. code-block:: console
 
     $ git clone git@github.com:Deltares/hydromt.git
     $ cd hydromt
 
-.. Note::
 
-    In the commands below you can exchange `conda` for `mamba`, see :ref:`installation guide <installation_guide>` for the difference between both.
+Makefile based installation
+---------------------------
 
-Then, navigate into the the code folder (where the envs folder and pyproject.toml are located):
-To generate a usable mamba/conda environment you'll need to have `tomli` installed. You can simply install this with pip:
-
-.. code-block:: console
-
-    $ pip install tomli
-
-You wil also need a suable instalation of `make`. If you're using linux this should already be installed by defautl. If you are using windows we
-recommend you install it using `chocolatey <https://chocolatey.org/install>`_ like so:
+You wil need a usable instalation of `make`. If you're using linux this should already be installed by default.
+If you are using windows we recommend you install it using `chocolatey <https://chocolatey.org/install>`_ like so:
 
 .. code-block:: console
 
@@ -45,43 +45,82 @@ Afterwards to create an environment you can simply call:
 
     $ make dev
 
-This will create an enviromnment file, create an environment using a packagemangager and install hydromt into it. By default
-the makefile will attempt to use `mamba`. If you want it to use a diferent one like, conda, you only have to set the
-environment variable like this if you're on linux:
+This will create an enviromnment file, create an environment called `hydromt-dev` using a packagemangager
+and install hydromt into it. By default the makefile will attempt to use `mamba`. If you want it to use a
+diferent one like, conda, you only have to set the environment variable like this:
 
 .. code-block:: console
 
-    $ export PY_ENV_MANAGER=conda
+    $ make dev PY_ENV_MANAGER=conda
 
-or like this if you're on windows:
+Step-by-step installation
+--------------------------
 
-.. code-block::console
+If you want you can also do the steps of `make dev` manually.
 
-    $ $Env:PY_ENV_MANAGER = 'conda'
-
-If you want you can also do these steps manually. The first step is to create the `environment.yml`:
-
-.. code-block:: console
-
-    $ python make_env.py "full"
-
-When the script is finished, a file called `environment.yml` will be created which you can pass to conda
-as demonstrated in the sections below. This will include all optional dependencies of HydroMT. If you want a more
-finetined instalation you can also specify exactly which dependency grousp you'd like like this:
+To generate a usable mamba/conda environment you'll need to have `tomli` installed.
+You can simply install this with pip (only required for python < 3.11):
 
 .. code-block:: console
 
-    $ make env OPT_DEPS="extra,io,doc"
+    $ pip install tomli
+
+The first step is to create the `environment.yml`:
+
+.. code-block:: console
+
+    $ python make_env.py full -n hydromt-dev
+
+When the script is finished, a file called `environment.yml` will be created which you can pass to mamba
+as demonstrated in the sections below. This will include all optional dependencies of HydroMT.
+
+After the environment file has been created you can create an environment out of it by running:
+
+.. code-block:: console
+
+    $ mamba env create -f environment.yml
+    $ mamba activate hydromt-dev
+
+Finally, create a developer installation of HydroMT:
+
+.. code-block:: console
+
+    $ pip install -e .
+
+.. Note::
+
+    In the commands above you can exchange `mamba` for `conda`,
+    see :ref:`installation guide <installation_guide>` for the difference between both.
+
+Finetined installation
+----------------------
+
+If you want a more finetined installation you can also specify exactly
+which dependency groups you'd. For instance, this will create an environment
+with the extra, io and doc dependencies.
+
+.. code-block:: console
+
+    $ make env OPT_DEPS="extra,io,doc" ENV_NAME="hydromt-extra-io-doc"
 
 
-We have 7 optional dependency groups you can specify:
+Or manually:
+
+.. code-block:: console
+
+    $ pip install tomli # only required for python < 3.11
+    $ python make_env.py "extra,io,doc" -n hydromt-extra-io-doc
+    $ mamba env create -f environment.yml
+
+
+We have 7 optional dependency groups you can specify (see `pyproject.toml` for list of dependencies in each group):
 
 1. `io`: Reading and writing various formats like excel but also cloud file systems
 2. `extra`: Couldn't think of a better name for this one, but it has some extra for ET and mesh calculations
 3. `dev`: everything you need to develop and publish HydroMT
 4. `test` What you need to run the test suite. Test suite should be setup that only tests that use the dependencies that are installed are run, so this should always pass no matter what other dependencies you may or may not have installed.
 5. `doc` generate the docs
-6. `jupyter` Run Jupyter notebooks and run the examples. Going to use this for binder support mostly.
+6. `examples` Run Jupyter notebook examples. Used this for binder support mostly.
 7. `deprecated` dependencies that we hope to remove soon, but aren't quite ready to yet.
 
 
@@ -91,17 +130,3 @@ We also have 3 "flavors". These are more or less just collections of one or more
 3. `full` absolutely everything, useful for developing.
 
 We also have docker images for each of the flavours that should be published soon (but are not yet as the writing of this section)
-
-
-After the environment file has been created you can create an environment out of it by running:
-
-.. code-block:: console
-
-    $ mamba env create -f environment.yml
-    $ mamba activate hydromt-full
-
-Finally, create a developer installation of HydroMT:
-
-.. code-block:: console
-
-    $ pip install -e .

--- a/docs/dev/dev_install.rst
+++ b/docs/dev/dev_install.rst
@@ -46,7 +46,7 @@ Afterwards to create an environment you can simply call:
     $ make dev
 
 This will create an enviromnment file, create an environment using a packagemangager and install hydromt into it. By default
-the makefile will attempt to use `micromamba`. If you want it to use a diferent one like, conda, you only have to set the
+the makefile will attempt to use `mamba`. If you want it to use a diferent one like, conda, you only have to set the
 environment variable like this if you're on linux:
 
 .. code-block:: console
@@ -97,8 +97,8 @@ After the environment file has been created you can create an environment out of
 
 .. code-block:: console
 
-    $ micromamba env create -f environment.yml
-    $ micromamba activate hydromt
+    $ mamba env create -f environment.yml
+    $ mamba activate hydromt
 
 Finally, create a developer installation of HydroMT:
 

--- a/docs/dev/dev_install.rst
+++ b/docs/dev/dev_install.rst
@@ -45,13 +45,19 @@ Afterwards to create an environment you can simply call:
 
     $ make dev
 
-This will create an enviromnment file, create an environment called `hydromt-dev` using a packagemangager
+This will create an enviromnment file, create an environment called `hydromt-dev` using a package mangager
 and install hydromt into it. By default the makefile will attempt to use `mamba`. If you want it to use a
 diferent one like, conda, you only have to set the environment variable like this:
 
 .. code-block:: console
 
     $ make dev PY_ENV_MANAGER=conda
+
+If you would like this to be the case you can also add make this the default behaviour with the following command:
+
+.. code-block:: console
+
+    $ echo 'export PY_ENV_MANAGER=conda' >> ~/.$(basename $0)rc
 
 Step-by-step installation
 --------------------------
@@ -92,11 +98,11 @@ Finally, create a developer installation of HydroMT:
     In the commands above you can exchange `mamba` for `conda`,
     see :ref:`installation guide <installation_guide>` for the difference between both.
 
-Finetined installation
+Fine tuned installation
 ----------------------
 
-If you want a more finetined installation you can also specify exactly
-which dependency groups you'd. For instance, this will create an environment
+If you want a more fine tuned installation you can also specify exactly
+which dependency groups you'd like. For instance, this will create an environment
 with the extra, io and doc dependencies.
 
 .. code-block:: console

--- a/make_env.py
+++ b/make_env.py
@@ -47,7 +47,7 @@ parser.add_argument("profile", default="dev,test", nargs="?")
 parser.add_argument("--output", "-o", default="environment.yml")
 parser.add_argument("--channels", "-c", default=None)
 parser.add_argument("--name", "-n", default=None)
-parser.add_argument("--py", "-p", default=None)
+parser.add_argument("--py-version", "-p", default=None)
 args = parser.parse_args()
 
 #
@@ -83,8 +83,8 @@ for dep in deps_to_install:
         pip_deps.append(dep)
     else:
         conda_deps.append(dep)
-if args.py is not None:
-    conda_deps.append(f"python=={args.py}")
+if args.py_version is not None:
+    conda_deps.append(f"python=={args.py_version}")
 
 # add pip as a conda dependency if we have pip deps
 if len(pip_deps) > 0:

--- a/make_env.py
+++ b/make_env.py
@@ -43,7 +43,7 @@ def _parse_profile(profile_str: str, opt_deps) -> List[str]:
 pat = re.compile(r"\s*hydromt\[(.*)\]\s*")
 parser = argparse.ArgumentParser()
 
-parser.add_argument("profile", default="", nargs="?")
+parser.add_argument("flavour", default="", nargs="?")
 parser.add_argument("--output", "-o", default="environment.yml")
 parser.add_argument("--channel", "-c", default="conda-forge")
 
@@ -58,7 +58,7 @@ with open("pyproject.toml", "rb") as f:
 deps = toml["project"]["dependencies"]
 opt_deps = toml["project"]["optional-dependencies"]
 
-extra_deps = _parse_profile(args.profile, opt_deps)
+extra_deps = _parse_profile(args.flavour, opt_deps)
 
 deps_to_install = deps.copy()
 deps_to_install.extend(extra_deps)
@@ -73,7 +73,7 @@ for dep in deps_to_install:
 # the list(set()) is to remove duplicates
 conda_deps_to_install_string = "\n- ".join(sorted(list(set(conda_deps))))
 env_spec = f"""
-name: hydromt
+name: hydromt-{args.flavour}
 
 channels:
     - {args.channel}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,9 @@ doc = [
     "sphinx",                       # build docks
     "sphinx_design",                # doc layout
     "sphinx_autosummary_accessors", # doc layout
-    "hydromt[jupyter,extra]",       # examples are included in the docs
+    "hydromt[examples,extra]",      # examples are included in the docs
 ]
-jupyter = [
+examples = [
     "jupyterlab",      # run examples in jupyter notebook
     "cartopy",         # plotting examples
     "matplotlib-base", # plotting
@@ -90,8 +90,8 @@ deprecated = [
     "pygeos",   # Supersceded by shapely 2
 ]
 
-full = ["hydromt[io,extra,dev,test,doc, jupyter]"]
-slim = ["hydromt[io,extra,jupyter]"]
+full = ["hydromt[io,extra,dev,test,doc,examples]"]
+slim = ["hydromt[io,extra,examples]"]
 
 [project.urls]
 Documentation = "https://deltares.github.io/hydromt"
@@ -99,6 +99,14 @@ Source = "https://github.com/Deltares/hydromt"
 
 [project.scripts]
 hydromt = "hydromt.cli.main:main"
+
+[tool.pyproject2conda]
+channels = ["conda-forge", "defaults"]
+deps_not_in_conda  = [
+    "sphinx_autosummary_accessors",
+    "sphinx_design",
+    "pyet",
+]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Issue addressed
Fixes #436 

## Explanation
Simply adjusted the make commands to use the `mamba` api instead of `micromamba` as that should be the default. Tested the install on windows, and that seems to go fine as well, so should all be good 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
