### PR TITLE
remove defaults channel from conda

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
       - data/*
       - docs/*
       - examples/*
+      - pyproject.toml
   pull_request:
     branches: [main]
     paths:
@@ -19,6 +20,7 @@ on:
       - data/*
       - docs/*
       - examples/*
+      - pyproject.toml
 
 jobs:
   # Build docs on Linux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,14 @@ on:
       - tests/*
       - hydromt/*
       - data/*
+      - pyproject.toml
   pull_request:
     branches: [main]
     paths:
       - tests/*
       - hydromt/*
       - data/*
+      - pyproject.toml
 
 jobs:
   Test-matrix:

--- a/make_env.py
+++ b/make_env.py
@@ -56,10 +56,10 @@ with open("pyproject.toml", "rb") as f:
 deps = toml["project"]["dependencies"]
 opt_deps = toml["project"]["optional-dependencies"]
 project_name = toml["project"]["name"]
-# specific pyproject2conda settings
-kwargs = toml["tool"].get("pyproject2conda", {})
-deps_not_in_conda = kwargs.get("deps_not_in_conda", [])
-channels = kwargs.get("channels", ["defaults"])
+# specific conda_install settings
+install_config = toml["tool"].get("conda_install", {})
+deps_not_in_conda = install_config.get("deps_not_in_conda", [])
+channels = install_config.get("channels", ["conda-forge"])
 if args.channels is not None:
     channels.extend(args.channels.split(","))
 

--- a/make_env.py
+++ b/make_env.py
@@ -57,7 +57,7 @@ deps = toml["project"]["dependencies"]
 opt_deps = toml["project"]["optional-dependencies"]
 project_name = toml["project"]["name"]
 # specific conda_install settings
-install_config = toml["tool"].get("conda_install", {})
+install_config = toml["tool"].get("make_env", {})
 deps_not_in_conda = install_config.get("deps_not_in_conda", [])
 channels = install_config.get("channels", ["conda-forge"])
 if args.channels is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ Source = "https://github.com/Deltares/hydromt"
 hydromt = "hydromt.cli.main:main"
 
 [tool.pyproject2conda]
-channels = ["conda-forge", "defaults"]
+channels = ["conda-forge"]
 deps_not_in_conda  = [
     "sphinx_autosummary_accessors",
     "sphinx_design",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ Source = "https://github.com/Deltares/hydromt"
 [project.scripts]
 hydromt = "hydromt.cli.main:main"
 
-[tool.conda_install]
+[tool.make_env]
 channels = ["conda-forge"]
 deps_not_in_conda  = [
     "sphinx_autosummary_accessors",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ Source = "https://github.com/Deltares/hydromt"
 [project.scripts]
 hydromt = "hydromt.cli.main:main"
 
-[tool.pyproject2conda]
+[tool.conda_install]
 channels = ["conda-forge"]
 deps_not_in_conda  = [
     "sphinx_autosummary_accessors",


### PR DESCRIPTION
## Issue addressed
Fixes #447 

## Explanation
Not sure why but the inclusion of the "defaults" channel seems to make everything go haywire, so this is removed. Should fix all the CIs. It doesn't seem necessary so I can't remember why it got included, but it should all be okay after this PR is merged again. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
