### PR TITLE
Add version switch to docs

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,0 +1,45 @@
+[
+
+  {
+    "name":"v0.5.0",
+    "version":"0.5.0",
+    "url":"https://deltares.github.io/hydromt/v0.5.0/"
+
+  },
+  {
+    "name":"v0.6.0",
+    "version":"0.6.0",
+    "url":"https://deltares.github.io/hydromt/v0.6.0/"
+
+  },
+  {
+    "name":"v0.7.0",
+    "version":"0.7.0",
+    "url":"https://deltares.github.io/hydromt/v0.7.0/"
+
+  },
+  {
+    "name":"v0.7.1",
+    "version":"0.7.1",
+    "url":"https://deltares.github.io/hydromt/v0.7.1/"
+
+  },
+  {
+    "name":"latest",
+    "version":"latest",
+    "url":"https://deltares.github.io/hydromt/latest/"
+
+  },
+  {
+    "name":"dev",
+    "version":"dev",
+    "url":"https://deltares.github.io/hydromt/dev/"
+
+  },
+  {
+    "name":"v0.8.0",
+    "version":"0.8.0",
+    "url":"https://deltares.github.io/hydromt/v0.8.0/"
+
+  }
+]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -25,21 +25,15 @@
 
   },
   {
-    "name":"latest",
-    "version":"latest",
-    "url":"https://deltares.github.io/hydromt/latest/"
-
-  },
-  {
-    "name":"dev",
-    "version":"dev",
-    "url":"https://deltares.github.io/hydromt/dev/"
-
-  },
-  {
     "name":"v0.8.0",
     "version":"0.8.0",
     "url":"https://deltares.github.io/hydromt/v0.8.0/"
+
+  },
+  {
+    "name":"latest",
+    "version":"latest",
+    "url":"https://deltares.github.io/hydromt/latest/"
 
   }
 ]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ Unreleased
 
 Added
 -----
--
+- docs now include a dropdown for selecting older versions of the docs. (#457)
 
 Changed
 -------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,6 +234,8 @@ autoclass_content = "both"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
+bare_version = hydromt.__version__
+doc_version = bare_version[: bare_version.find("dev") - 1]
 html_static_path = ["_static"]
 html_css_files = ["theme-deltares.css"]
 html_theme_options = {
@@ -257,14 +259,18 @@ html_theme_options = {
     "logo": {
         "text": "HydroMT Core",
     },
-    "navbar_end": ["navbar-icon-links"],  # remove dark mode switch
+    "navbar_end": ["navbar-icon-links", "version-switcher"],  # remove dark mode switch
+    "switcher": {
+        "json_url": "https://deltares.github.io/hydromt/latest/switcher.json",
+        "version_match": doc_version,
+    },
 }
 
 html_context = {
     "github_url": "https://github.com",  # or your GitHub Enterprise interprise
     "github_user": "Deltares",
     "github_repo": "hydromt",
-    "github_version": "main",  # FIXME
+    "github_version": "main",
     "doc_path": "docs",
     "default_mode": "light",
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,7 +261,7 @@ html_theme_options = {
     },
     "navbar_end": ["navbar-icon-links", "version-switcher"],  # remove dark mode switch
     "switcher": {
-        "json_url": "https://deltares.github.io/hydromt/latest/switcher.json",
+        "json_url": "https://github.com/Deltares/hydromt/blob/doc-version-switcher/docs/_static/switcher.json",
         "version_match": doc_version,
     },
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,7 +261,7 @@ html_theme_options = {
     },
     "navbar_end": ["navbar-icon-links", "version-switcher"],  # remove dark mode switch
     "switcher": {
-        "json_url": "https://raw.githubusercontent.com/Deltares/hydromt/doc-version-switcher/docs/_static/switcher.json",
+        "json_url": "https://raw.githubusercontent.com/Deltares/hydromt/gh-pages/switcher.json",
         "version_match": doc_version,
     },
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,7 +261,7 @@ html_theme_options = {
     },
     "navbar_end": ["navbar-icon-links", "version-switcher"],  # remove dark mode switch
     "switcher": {
-        "json_url": "https://github.com/Deltares/hydromt/blob/doc-version-switcher/docs/_static/switcher.json",
+        "json_url": "https://raw.githubusercontent.com/Deltares/hydromt/doc-version-switcher/docs/_static/switcher.json",
         "version_match": doc_version,
     },
 }

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -425,14 +425,14 @@ Creating a release
 1. Create a new branch with the name "release/<version>" where <version> is the version number, e.g. v0.7.0
 2. Bump the version number (without "v"!) in the __init__.py, check and update the docs/changelog.rst file and add a short summary to the changelog for this version.
    Check if all dependencies in the toml are up to date. Commit all changes
-3. Create a tag using `git tag <version>`, e.g. git tag v0.7.0
-4. Push your changes to github. To include the tag do `git push origin <version>`. This should trigger a test release to test.pypi.org
-5. If all tests and the test release have succeeded, merge de branch to main.
-6. Create a new release on github under https://github.com/Deltares/hydromt/releases.
+3. Create a new documentation version in the `docs/switcher.json` that has the same structure as the other version entries. Please make sure the list stays sorted as this represents the ordering of the menu.
+4. Create a tag using `git tag <version>`, e.g. git tag v0.7.0
+5. Push your changes to github. To include the tag do `git push origin <version>`. This should trigger a test release to test.pypi.org
+6. If all tests and the test release have succeeded, merge de branch to main.
+7. Create a new release on github under https://github.com/Deltares/hydromt/releases.
    Use the "generate release notes" button and copy the content of the changelog for this version on top of the release notes. This should trigger the release to PyPi.
-7. The new PyPi package will trigger a new PR to the `HydroMT feedstock repos of conda-forge <https://github.com/conda-forge/hydromt-feedstock>`_.
+8. The new PyPi package will trigger a new PR to the `HydroMT feedstock repos of conda-forge <https://github.com/conda-forge/hydromt-feedstock>`_.
    Check if all dependencies are up to date and modify the PR if necessary. Merge the PR to release the new version on conda-forge.
-
 
 .. NOTE::
 


### PR DESCRIPTION
## Issue addressed
Fixes #188

## Explanation
simplay followed the link and followed the docs. Works just fine. The only downside is that the older versions of the docs don't have this added so once you switch, the menu for it disapears. Can go back and retroactively add this back to the older versions if necessary, but this could give issues with reproducability (e.g. not sure if this plugin is compatable with older doc versions.) 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Currently the url of the version switcher points to a file that will be deleted when the branch is deleted. Once this is approved, I'll switch it over to where the file will live after merging. This will temporary break the docs between update and merging as the file needs to be found for the docs to be generated, but should this should be fixed as soon as the merge is complete, so it should be fine. 
