### PR TITLE
Avoid RecursionError when using Model.set methods inside Model.read methods

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,8 @@ Added
 Changed
 -------
 - possibility to ``load`` the data in the model read_ functions for netcdf files (default for read_grid in r+ mode). (PR #460)
--
+- Internal model components (e.g. `Models._maps`, `GridModel._grid``) are now initialized with None and should not be accessed directly,
+  call the corresponding model property  (e.g. `Model.maps`, `GridModel.grid`) instead. (PR #473)
 
 Fixed
 -----

--- a/hydromt/models/model_grid.py
+++ b/hydromt/models/model_grid.py
@@ -28,7 +28,7 @@ class GridMixin(object):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._grid = xr.Dataset()
+        self._grid = None  # xr.Dataset()
 
     # generic grid methods
     def setup_grid_from_constant(
@@ -314,8 +314,10 @@ class GridMixin(object):
     @property
     def grid(self):
         """Model static gridded data as xarray.Dataset."""
-        if len(self._grid) == 0 and self._read:
-            self.read_grid()
+        if self._grid is None:
+            self._grid = xr.Dataset()
+            if self._read:
+                self.read_grid()
         return self._grid
 
     def set_grid(
@@ -353,11 +355,11 @@ class GridMixin(object):
         elif not isinstance(data, xr.Dataset):
             raise ValueError(f"cannot set data of type {type(data).__name__}")
         # force read in r+ mode
-        if len(self.grid) == 0:  # new data
+        if len(self.grid) == 0:  # trigger init / read
             self._grid = data
         else:
             for dvar in data.data_vars:
-                if dvar in self._grid:
+                if dvar in self.grid:
                     if self._read:
                         self.logger.warning(f"Replacing grid map: {dvar}")
                 self._grid[dvar] = data[dvar]
@@ -380,8 +382,7 @@ class GridMixin(object):
             kwargs["load"] = True
         loaded_nc_files = self.read_nc(fn, single_var_as_array=False, **kwargs)
         for ds in loaded_nc_files.values():
-            for dvar in ds.data_vars:
-                self._grid[dvar] = ds[dvar]
+            self.set_grid(ds)
 
     def write_grid(
         self,
@@ -411,13 +412,13 @@ class GridMixin(object):
             If True and gdal_compliant, forces the dataset to have
             South -> North orientation.
         """
-        if len(self._grid) == 0:
+        if len(self.grid) == 0:
             self.logger.debug("No grid data found, skip writing.")
         else:
             self._assert_write_mode
             # write_nc requires dict - use dummy 'grid' key
             self.write_nc(
-                {"grid": self._grid},
+                {"grid": self.grid},
                 fn,
                 gdal_compliant=gdal_compliant,
                 rename_dims=rename_dims,

--- a/hydromt/models/model_grid.py
+++ b/hydromt/models/model_grid.py
@@ -699,7 +699,7 @@ class GridModel(GridMixin, Model):
 
     def write(
         self,
-        components: List = ["config", "grid", "geoms", "forcing", "states"],
+        components: List = ["config", "maps", "grid", "geoms", "forcing", "states"],
     ) -> None:
         """Write the complete model schematization and configuration to model files.
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -85,8 +85,8 @@ def test_check_data(demda):
 def test_model_api(grid_model):
     assert np.all(np.isin(["grid", "geoms"], list(grid_model.api.keys())))
     # add some wrong data
-    grid_model._geoms.update({"wrong_geom": xr.Dataset()})
-    grid_model._forcing.update({"test": gpd.GeoDataFrame()})
+    grid_model.geoms.update({"wrong_geom": xr.Dataset()})
+    grid_model.forcing.update({"test": gpd.GeoDataFrame()})
     non_compliant = grid_model._test_model_api()
     assert non_compliant == ["geoms.wrong_geom", "forcing.test"]
 
@@ -152,6 +152,29 @@ def test_model(model, tmpdir):
     model._geoms.pop("region")
     with pytest.deprecated_call():
         assert np.all(model.region.total_bounds == model.staticmaps.raster.bounds)
+
+
+def test_model_set(demda):
+    # test set methods in an empty model in write mode
+    mod = GridModel(mode="w")
+    mod.set_config("test", "test")
+    assert "test" in mod.config
+    mod.set_grid(demda, name="dem")
+    assert "dem" in mod.grid
+    mod.set_maps(demda, name="dem")
+    assert "dem" in mod.maps
+    mod.set_forcing(demda, name="dem")
+    assert "dem" in mod.forcing
+    mod.set_states(demda, name="dem")
+    assert "dem" in mod.states
+    mod.set_results(demda, name="dem")
+    assert "dem" in mod.results
+    mod.set_geoms(demda.raster.box, name="dem")
+    assert "dem" in mod.geoms
+    # test set method error in read mode
+    mod = GridModel(mode="r+")
+    with pytest.raises(ValueError, match="Root unknown, use set_root method"):
+        mod.set_config("test", "test")
 
 
 @pytest.mark.filterwarnings("ignore:The setup_basemaps")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -154,27 +154,31 @@ def test_model(model, tmpdir):
         assert np.all(model.region.total_bounds == model.staticmaps.raster.bounds)
 
 
-def test_model_set(demda):
-    # test set methods in an empty model in write mode
-    mod = GridModel(mode="w")
-    mod.set_config("test", "test")
-    assert "test" in mod.config
+def test_model_append(demda, tmpdir):
+    # write a model
+    demda.name = "dem"
+    mod = GridModel(mode="w", root=str(tmpdir))
+    mod.set_config("test.data", "dem")
     mod.set_grid(demda, name="dem")
-    assert "dem" in mod.grid
     mod.set_maps(demda, name="dem")
-    assert "dem" in mod.maps
     mod.set_forcing(demda, name="dem")
-    assert "dem" in mod.forcing
     mod.set_states(demda, name="dem")
-    assert "dem" in mod.states
-    mod.set_results(demda, name="dem")
-    assert "dem" in mod.results
     mod.set_geoms(demda.raster.box, name="dem")
-    assert "dem" in mod.geoms
-    # test set method error in read mode
-    mod = GridModel(mode="r+")
-    with pytest.raises(ValueError, match="Root unknown, use set_root method"):
-        mod.set_config("test", "test")
+    mod.write()
+    # append to model and check if previous data is still there
+    mod1 = GridModel(mode="r+", root=str(tmpdir))
+    mod1.set_config("test1.data", "dem")
+    assert mod1.get_config("test.data") == "dem"
+    mod1.set_grid(demda, name="dem1")
+    assert "dem" in mod1.grid
+    mod1.set_maps(demda, name="dem1")
+    assert "dem" in mod1.maps
+    mod1.set_forcing(demda, name="dem1")
+    assert "dem" in mod1.forcing
+    mod1.set_states(demda, name="dem1")
+    assert "dem" in mod1.states
+    mod1.set_geoms(demda.raster.box, name="dem1")
+    assert "dem" in mod1.geoms
 
 
 @pytest.mark.filterwarnings("ignore:The setup_basemaps")


### PR DESCRIPTION
## Issue addressed
Fixes #472 

## Explanation
I moved the initialization of the model component to the property definition. 
When called the first time, we initialize the component and try to read it if in read-mode.
From the second time forward a call of the property returns the initialized component without trying to read.
Now we can use the `set_` methods again inside the `read_` methods like we used to do.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
This could also break code downstream, if the internal properties are called (e.g. `self._maps` instead of `self.maps`). In the new implementation calling the internal static properties should be restricted to the `set_` methods and the dynamic property methods only which happen in the core. Hence, an easy fix should be to replace all calls to the internal static property by the dynamic property.
