### PR TITLE
Fix api inherritence of models using __mro__

### DIFF
--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -41,7 +41,6 @@ class Model(object, metaclass=ABCMeta):
 
     """General and basic API for models in HydroMT."""
 
-    # FIXME
     _DATADIR = ""  # path to the model data folder
     _NAME = "modelname"
     _CONF = "model.ini"

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -25,6 +25,7 @@ from shapely.geometry import box
 from .. import config, log, workflows
 from ..data_catalog import DataCatalog
 from ..raster import GEO_MAP_COORD
+from ..utils import _classproperty
 
 __all__ = ["Model"]
 
@@ -130,13 +131,17 @@ class Model(object, metaclass=ABCMeta):
         self.set_root(root, mode)  # also creates hydromt.log file
         self.logger.info(f"Initializing {self._NAME} model from {dist} (v{version}).")
 
-    @property
-    def api(self) -> Dict:
+    @_classproperty
+    def api(cls) -> Dict:
         """Return all model components and their data types."""
-        _api = self._API.copy()
-        # loop over parent and mixin classes and update API
-        for base_cls in self.__class__.__bases__:
-            _api.update(getattr(base_cls, "_API", {}))
+        _api = cls._API.copy()
+
+        # reversed is so that child attributes take priority
+        # this does mean that it becomes imporant in which order you
+        # inherit from your base classes.
+        for base_cls in reversed(cls.__mro__):
+            if hasattr(base_cls, "_API"):
+                _api.update(getattr(base_cls, "_API", {}))
         return _api
 
     def _check_get_opt(self, opt):

--- a/hydromt/utils.py
+++ b/hydromt/utils.py
@@ -1,6 +1,11 @@
 """Utility functions for hydromt that have no other home."""
 
 
+class _classproperty(property):
+    def __get__(self, owner_self, owner_cls):
+        return self.fget(owner_cls)
+
+
 def partition_dictionaries(left, right):
     """Calculate a partitioning of the two dictionaries.
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,8 +15,25 @@ import hydromt.models.model_plugins
 from hydromt.data_catalog import DataCatalog
 from hydromt.models import MODELS, GridModel, LumpedModel, Model, model_plugins
 from hydromt.models.model_api import _check_data
+from hydromt.models.model_grid import GridMixin
 
 DATADIR = join(dirname(abspath(__file__)), "data")
+
+
+class _DummyModel(GridModel, GridMixin):
+    _API = {"asdf": "yeah"}
+
+
+def test_api_attrs():
+    dm = _DummyModel()
+    assert hasattr(dm, "_NAME")
+    assert hasattr(dm, "_API")
+    assert "asdf" in dm.api
+    assert dm.api["asdf"] == "yeah"
+    assert "region" in dm.api
+    assert dm.api["region"] == gpd.GeoDataFrame
+    assert "grid" in dm.api
+    assert dm.api["grid"] == xr.Dataset
 
 
 def test_plugins(mocker):


### PR DESCRIPTION
## Issue addressed
Fixes #253 

## Explanation
I'll be honest, this is not the most elegant solution I've ever found but it does do the job. I'm not a fan of this design (the dictionary) but this solution does work, and refactoring the dictionary away could have unintended consequences that I don't have insight into so for now this is okay. However, if this continues to have problems, then we should seriously consider a redesign of this part of the system. 

The problem was that the dictionary was only being updated using the direct parent class and not any of the ancestors. This was fixed by using the `__mro__` (Method Resolution Order) attribute, which gives access to basically all ancestor classes as opposed to only the direct parent. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

