### PR TITLE
add user warning when data crs conflicts with provided crs

### DIFF
--- a/hydromt/data_adapter/geodataset.py
+++ b/hydromt/data_adapter/geodataset.py
@@ -323,8 +323,20 @@ class GeoDatasetAdapter(DataAdapter):
             ds_out = ds_out[variables]
 
         # set crs
-        if ds_out.vector.crs is None and self.crs is not None:
-            ds_out.vector.set_crs(self.crs)
+        if self.crs is not None:
+            if ds_out.vector.crs is None:
+                ds_out.vector.set_crs(self.crs)
+            elif ds_out.vector.crs != self.crs:
+                raise UserWarning(
+                    f"DataCatalog entry and data attributes specify"
+                    f"inconsistent CRS. Data CRS: {ds_out.vector.crs},"
+                    f" user specified CRS: {self.crs}. The data specified CRS will "
+                    "be used."
+                )
+            else:
+                # specified and data CRS are equal, we don't have to do anything
+                pass
+
         if ds_out.vector.crs is None:
             raise ValueError(
                 "GeoDataset: The data has no CRS, set in GeoDatasetAdapter."

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -379,12 +379,19 @@ class RasterDatasetAdapter(DataAdapter):
                 raise IndexError("RasterDataset: Time slice out of range.")
 
         # set crs
-        if ds_out.raster.crs is None and self.crs is not None:
-            ds_out.raster.set_crs(self.crs)
-        elif ds_out.raster.crs is None:
-            raise ValueError(
-                "RasterDataset: The data has no CRS, set in RasterDatasetAdapter."
-            )
+        if self.crs is not None:
+            if ds_out.raster.crs is None:
+                ds_out.raster.set_crs(self.crs)
+            elif ds_out.raster.crs != self.crs:
+                raise UserWarning(
+                    f"DataCatalog entry and data attributes specify"
+                    f"inconsistent CRS. Data CRS: {ds_out.raster.crs},"
+                    f" user specified CRS: {self.crs}. The data specified CRS will "
+                    "be used."
+                )
+            else:
+                # specified and data CRS are equal, we don't have to do anything
+                pass
 
         # clip
         # make sure bbox is in data crs

--- a/hydromt/io.py
+++ b/hydromt/io.py
@@ -586,10 +586,22 @@ def open_vector(
             raise ValueError(f"{fn} contains other geometries than {assert_gtype}")
 
     # check if crs and filter
-    if gdf.crs is None and crs is not None:
-        gdf = gdf.set_crs(pyproj.CRS.from_user_input(crs))
-    elif gdf.crs is None:
-        raise ValueError("The GeoDataFrame has no CRS. Set one using the crs option.")
+    if gdf.crs is None:
+        if crs is not None:
+            gdf = gdf.set_crs(pyproj.CRS.from_user_input(crs))
+        else:
+            raise ValueError(
+                "The GeoDataFrame has no CRS. Set one using the crs option."
+            )
+    else:
+        if gdf.crs != dst_crs:
+            logger.warning(
+                f"DataCatalog entry and data attributes specify"
+                f"inconsistent CRS. Data CRS: {gdf.crs},"
+                f" user specified CRS: {dst_crs}. The user specified CRS will "
+                "be used."
+            )
+
     if dst_crs is not None:
         gdf = gdf.to_crs(dst_crs)
     # filter points

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -215,6 +215,10 @@ def test_geodataset(geoda, geodf, ts, tmpdir):
     da3 = data_catalog.get_geodataset(
         fn_csv_locs, driver_kwargs=dict(fn_data=fn_csv), crs=geodf.crs
     ).sortby("index")
+    with pytest.warns(UserWarning):
+        _ = data_catalog.get_geodataset(
+            fn_csv_locs, driver_kwargs=dict(fn_data=fn_csv), crs=2380
+        )
     assert np.allclose(da3, geoda)
     assert da3.vector.crs.to_epsg() == 4326
     with pytest.raises(FileNotFoundError, match="No such file or catalog source"):


### PR DESCRIPTION
## Issue addressed
Fixes #462 

## Explanation
Does what it says on the tin. Wasn't able to add a test for the rasterdataset adapter that the warning is actually emitted because the kwargs don't get passed to the underlying funtions always, but I figured it was good to keep the warning there anyway just to be sure. The logic is the same as with the other adapters so it should be fine. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
