### PR TITLE
Support for checking if DataCatalog "contains" a source 

### DIFF
--- a/hydromt/data_adapter/data_adapter.py
+++ b/hydromt/data_adapter/data_adapter.py
@@ -201,11 +201,17 @@ class DataAdapter(object, metaclass=ABCMeta):
         self.meta = {k: v for k, v in meta.items() if v is not None}
         # variable attributes
         self.attrs = {k: v for k, v in attrs.items() if v is not None}
+        # keep track of wether the data is used
+        self._used = False
 
     @property
     def data_type(self):
         """Return the datatype of the addapter."""
         return type(self).__name__.replace("Adapter", "")
+
+    def mark_as_used(self):
+        """Mark the data adapter as used."""
+        self._used = True
 
     def summary(self):
         """Return a dictionary summary of the data adapter."""
@@ -223,7 +229,7 @@ class DataAdapter(object, metaclass=ABCMeta):
         """
         source = dict(data_type=self.data_type)
         for k, v in vars(self).items():
-            if k in ["name", "catalog_name"]:
+            if k in ["name", "catalog_name"] or k.startswith("_"):
                 continue  # do not add these identifiers
             if v is not None and (not isinstance(v, dict) or len(v) > 0):
                 source.update({k: v})

--- a/hydromt/data_adapter/dataframe.py
+++ b/hydromt/data_adapter/dataframe.py
@@ -192,6 +192,7 @@ class DataFrameAdapter(DataAdapter):
         # load data
         fns = self._resolve_paths(variables)
         df = self._read_data(fns, logger=logger)
+        self.mark_as_used()  # mark used
         # rename variables and parse nodata
         df = self._rename_vars(df)
         df = self._set_nodata(df)

--- a/hydromt/data_adapter/geodataframe.py
+++ b/hydromt/data_adapter/geodataframe.py
@@ -234,6 +234,7 @@ class GeoDataFrameAdapter(DataAdapter):
         # load
         fns = self._resolve_paths(variables)
         gdf = self._read_data(fns, bbox, geom, buffer, predicate, logger=logger)
+        self.mark_as_used()  # mark used
         # rename variables and parse crs & nodata
         gdf = self._rename_vars(gdf)
         gdf = self._set_crs(gdf, logger=logger)

--- a/hydromt/data_adapter/geodataset.py
+++ b/hydromt/data_adapter/geodataset.py
@@ -255,6 +255,7 @@ class GeoDatasetAdapter(DataAdapter):
         # load data
         fns = self._resolve_paths(variables, time_tuple)
         ds = self._read_data(fns, logger=logger)
+        self.mark_as_used()  # mark used
         # rename variables and parse data and attrs
         ds = self._rename_vars(ds)
         ds = self._validate_spatial_coords(ds)

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -271,6 +271,7 @@ class RasterDatasetAdapter(DataAdapter):
         # load data
         fns = self._resolve_paths(time_tuple, variables, zoom_level, geom, bbox, logger)
         ds = self._read_data(fns, geom, bbox, cache_root, logger)
+        self.mark_as_used()  # mark used
         # rename variables and parse data and attrs
         ds = self._rename_vars(ds)
         ds = self._validate_spatial_dims(ds)

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -417,9 +417,39 @@ class DataCatalog(object):
         """Iterate over sources."""
         return iter(self.iter_sources())
 
-    def __contains__(self, key: str) -> bool:
-        """Check if source is in catalog."""
-        return key in self._sources
+    def contains_source(
+        self,
+        source: str,
+        provider: Optional[str] = None,
+        version: Optional[str] = None,
+        permissive: bool = True,
+    ) -> bool:
+        """
+        Check if source is in catalog.
+
+        Paramters
+        ---------
+        source: str
+        provider
+        version
+        permissive
+
+        Returns
+        -------
+        bool
+        """
+        if permissive or (version is None and provider is None):
+            return source in self._sources
+        else:
+            if version:
+                if version not in self._sources[source]:
+                    return False
+                else:
+                    selected_version = version
+            else:
+                selected_version = next(iter(self._sources[source].keys()))
+
+            return provider not in self._sources[source][selected_version].keys()
 
     def __len__(self):
         """Return number of sources."""

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -427,16 +427,27 @@ class DataCatalog(object):
         """
         Check if source is in catalog.
 
-        Paramters
-        ---------
-        source: str
-        provider
-        version
-        permissive
+        Parameters
+        ----------
+        source : str
+            Name of the data source.
+        provider : str, optional
+            Name of the data provider, by default None.
+            By default the last added provider is returned.
+        version : str, optional
+            Version of the data source, by default None.
+            By default the newest version of the requested provider is returned.
+        permissive : bool, optional
+            Whether variant checking is necessary. If true, the name of the source
+            only is checked, if false, and at least one of version or provider is
+            not None, this will only return True if that variant specifically is
+            available.
+
 
         Returns
         -------
         bool
+            whether the source (with specified variants if necessary) is available
         """
         if permissive or (version is None and provider is None):
             return source in self._sources

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -1178,7 +1178,6 @@ class DataCatalog(object):
         else:
             raise ValueError(f'Unknown raster data type "{type(data_like).__name__}"')
 
-        source.mark_as_used()
         obj = source.get_data(
             bbox=bbox,
             geom=geom,
@@ -1273,7 +1272,6 @@ class DataCatalog(object):
         else:
             raise ValueError(f'Unknown vector data type "{type(data_like).__name__}"')
 
-        source.mark_as_used()
         gdf = source.get_data(
             bbox=bbox,
             geom=geom,
@@ -1380,7 +1378,6 @@ class DataCatalog(object):
         else:
             raise ValueError(f'Unknown geo data type "{type(data_like).__name__}"')
 
-        source.mark_as_used()
         obj = source.get_data(
             bbox=bbox,
             geom=geom,
@@ -1450,7 +1447,6 @@ class DataCatalog(object):
         else:
             raise ValueError(f'Unknown tabular data type "{type(data_like).__name__}"')
 
-        source.mark_as_used()
         obj = source.get_data(
             variables=variables,
             time_tuple=time_tuple,

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -588,17 +588,13 @@ class Model(object, metaclass=ABCMeta):
         """
         path = data_lib_fn if isabs(data_lib_fn) else join(self.root, data_lib_fn)
         cat = DataCatalog(logger=self.logger, fallback_lib=None)
-        # read hydromt_data configuration file and add to data catalog
+        # read hydromt_data yml file and add to data catalog
         if self._read and isfile(path) and append:
             cat.from_yml(path)
         # update data catalog with new used sources
-        source_names = (
-            self.data_catalog._used_data
-            if used_only
-            else list(self.data_catalog.sources.keys())
-        )
-        if len(source_names) > 0:
-            cat.from_dict(self.data_catalog.to_dict(source_names=source_names))
+        for name, source in self.data_catalog.iter_sources(used_only=used_only):
+            cat.add_source(name, source)
+        # write data catalog
         if cat.sources:
             self._assert_write_mode
             cat.to_yml(path, root=root)

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -296,11 +296,15 @@ def test_from_archive(tmpdir):
 
 
 def test_used_sources(tmpdir):
-    data_catalog = DataCatalog("artifact_data=v0.0.8")
-    data_catalog.get_source("koppen_geiger").mark_as_used()
+    merged_yml_fn = join(DATADIR, "merged_esa_worldcover.yml")
+    data_catalog = DataCatalog(merged_yml_fn)
+    source = data_catalog.get_source("esa_worldcover")
+    source.mark_as_used()
     sources = data_catalog.iter_sources(used_only=True)
     assert len(sources) == 1
-    assert sources[0][0] == "koppen_geiger"
+    assert sources[0][0] == "esa_worldcover"
+    assert sources[0][1].provider == source.provider
+    assert sources[0][1].version == source.version
 
 
 def test_from_predefined_catalogs():

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -244,6 +244,7 @@ def test_data_catalog(tmpdir):
     # test keys, getitem,
     keys = [key for key, _ in data_catalog.iter_sources()]
     source = data_catalog.get_source(keys[0])
+    assert keys[0] in data_catalog
     assert isinstance(source, DataAdapter)
     assert keys[0] in data_catalog.get_source_names()
     # add source from dict
@@ -292,6 +293,14 @@ def test_from_archive(tmpdir):
     # failed to download
     with pytest.raises(ConnectionError, match="Data download failed"):
         data_catalog.from_archive("https://asdf.com/asdf.zip")
+
+
+def test_used_sources(tmpdir):
+    data_catalog = DataCatalog("artifact_data=v0.0.8")
+    data_catalog.get_source("koppen_geiger").mark_as_used()
+    sources = data_catalog.iter_sources(used_only=True)
+    assert len(sources) == 1
+    assert sources[0][0] == "koppen_geiger"
 
 
 def test_from_predefined_catalogs():

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -244,7 +244,13 @@ def test_data_catalog(tmpdir):
     # test keys, getitem,
     keys = [key for key, _ in data_catalog.iter_sources()]
     source = data_catalog.get_source(keys[0])
-    assert keys[0] in data_catalog
+    assert data_catalog.contains_source(keys[0])
+    assert data_catalog.contains_source(
+        keys[0], version="asdfasdfasdf", permissive=True
+    )
+    assert not data_catalog.contains_source(
+        keys[0], version="asdfasdf", permissive=False
+    )
     assert isinstance(source, DataAdapter)
     assert keys[0] in data_catalog.get_source_names()
     # add source from dict

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -301,6 +301,7 @@ def test_used_sources(tmpdir):
     source = data_catalog.get_source("esa_worldcover")
     source.mark_as_used()
     sources = data_catalog.iter_sources(used_only=True)
+    assert len(data_catalog) > 1
     assert len(sources) == 1
     assert sources[0][0] == "esa_worldcover"
     assert sources[0][1].provider == source.provider

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -127,7 +127,7 @@ def test_write_data_catalog(tmpdir):
     model.write_data_catalog()
     assert not isfile(data_lib_fn)
     # write with single source
-    model.data_catalog._used_data.append(sources[0])
+    model.data_catalog.get_source(sources[0]).mark_as_used()
     model.write_data_catalog()
     assert list(DataCatalog(data_lib_fn).sources.keys()) == sources[:1]
     # write to different file
@@ -136,10 +136,10 @@ def test_write_data_catalog(tmpdir):
     assert isfile(data_lib_fn1)
     # append source
     model1 = Model(root=model.root, data_libs=["artifact_data"], mode="r+")
-    model1.data_catalog._used_data.append(sources[1])
+    model1.data_catalog.get_source(sources[1]).mark_as_used()
     model1.write_data_catalog(append=False)
     assert list(DataCatalog(data_lib_fn).sources.keys()) == [sources[1]]
-    model1.data_catalog._used_data.append(sources[0])
+    model1.data_catalog.get_source(sources[0]).mark_as_used()
     model1.write_data_catalog(append=True)
     assert list(DataCatalog(data_lib_fn).sources.keys()) == sources[:2]
 


### PR DESCRIPTION
## Issue addressed
Fixes #501 

## Explanation
Implementing a `__contains__` method allows for checking if data catalog contains a source with `name in catalog`

Also fixed the used_only argument of the to_yml method. This did no work properly as it only saved the source name and not the catalog or version.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
