### PR TITLE
Support for http and other filesystems in path of data source

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,7 @@ Changed
 - Internal model components (e.g. `Models._maps`, `GridModel._grid``) are now initialized with None and should not be accessed directly,
   call the corresponding model property  (e.g. `Model.maps`, `GridModel.grid`) instead. (PR #473)
 - Use the Model.data_catalog to read the model region if defined by a geom or grid. (PR #479)
+- Support for http and other *filesystems* in path of data source (PR #515).
 
 Fixed
 -----

--- a/docs/user_guide/data_prepare_cat.rst
+++ b/docs/user_guide/data_prepare_cat.rst
@@ -38,7 +38,7 @@ The ``rename``, ``nodata``, ``unit_add`` and ``unit_mult`` options are set per v
       driver: raster/raster_tindex/netcdf/zarr/vector/vector_table/csv/xlsx/xls
       driver_kwargs:
         key: value
-      filesystem: local/gcs/s3
+      filesystem: local/gcs/s3/http
       meta:
         source_url: zenodo.org/my_dataset
         source_license: CC-BY-3.0
@@ -92,9 +92,11 @@ A full list of **optional data source arguments** is given below
 - **driver_kwargs**: pairs of key value arguments to pass to the driver specific open data method
   (eg xr.open_mfdataset for netdcf raster, see the full list below).
   *NOTE*: New with HydroMT v0.7.2 (was called *kwargs* before)
-- **filesystem** (required if different than local): specify if the data is stored locally or remotely (e.g cloud). Supported filesystems are *local* for local data,
-  *gcs* for data stored on Google Cloud Storage, and *aws* for data stored on Amazon Web Services. Profile or authentication information can be passed to ``driver_kwargs`` via
-  *storage_options*.
+- **filesystem** (optional): specify at what filesystem the data is stored. This is used to select the correct protocol to
+  access different filesystems (e.g. local, gcs, s3, http). If not provided the filesystem is inferred from the path.
+  See `fsspec <https://filesystem-spec.readthedocs.io/en/latest/index.html>`_ for more available protocols.
+- **storage_options** (optional): Additional arguments to pass to the filesystem protocol, these are protocal specific.
+  *NOTE*: New in HydroMT v0.8.1
 - **version** (recommended): data source version
   *NOTE*: New in HydroMT v0.8.1
 - **provider** (recommended): data source provider

--- a/hydromt/data_adapter/data_adapter.py
+++ b/hydromt/data_adapter/data_adapter.py
@@ -332,11 +332,11 @@ class DataAdapter(object, metaclass=ABCMeta):
             # resolve dates: month & year keys
             if time_tuple is not None:
                 dt = pd.to_timedelta(self.unit_add.get("time", 0), unit="s")
-                trange = pd.to_datetime(list(time_tuple)) - dt
+                t_range = pd.to_datetime(list(time_tuple)) - dt
                 freq, strf = ("m", "%Y-%m") if "month" in keys else ("a", "%Y")
-                dates = pd.period_range(*trange, freq=freq)
-                trange_str = [t.strftime(strf) for t in trange]
-                postfix += "; date range: " + " - ".join(trange_str)
+                dates = pd.period_range(*t_range, freq=freq)
+                t_range_str = [t.strftime(strf) for t in t_range]
+                postfix += "; date range: " + " - ".join(t_range_str)
             # resolve variables
             if variables is not None:
                 variables = np.atleast_1d(variables).tolist()

--- a/hydromt/data_adapter/data_adapter.py
+++ b/hydromt/data_adapter/data_adapter.py
@@ -2,38 +2,26 @@
 from __future__ import annotations
 
 import logging
+import os
+import pathlib
+import warnings
 from abc import ABCMeta, abstractmethod
 from itertools import product
 from pathlib import Path
 from string import Formatter
 from typing import Optional, Union
 
+import fsspec
 import numpy as np
 import pandas as pd
 import xarray as xr
 import yaml
-from fsspec.implementations import local
 from upath import UPath
-
-from .. import _compat
 
 logger = logging.getLogger(__name__)
 
 
-__all__ = [
-    "DataAdapter",
-]
-
-FILESYSTEMS = ["local"]
-# Add filesystems from optional dependencies
-if _compat.HAS_GCSFS:
-    import gcsfs
-
-    FILESYSTEMS.append("gcs")
-if _compat.HAS_S3FS:
-    import s3fs
-
-    FILESYSTEMS.append("s3")
+__all__ = ["DataAdapter"]
 
 
 def round_latlon(ds, decimals=5):
@@ -115,7 +103,7 @@ class DataAdapter(object, metaclass=ABCMeta):
         self,
         path: str | Path,
         driver: Optional[str] = None,
-        filesystem="local",
+        filesystem: Optional[str] = None,
         nodata: Optional[Union[dict, float, int]] = None,
         rename: Optional[dict] = None,
         unit_mult: Optional[dict] = None,
@@ -123,6 +111,7 @@ class DataAdapter(object, metaclass=ABCMeta):
         meta: Optional[dict] = None,
         attrs: Optional[dict] = None,
         driver_kwargs: Optional[dict] = None,
+        storage_options: Optional[dict] = None,
         name: str = "",
         catalog_name: str = "",
         provider: Optional[str] = None,
@@ -142,9 +131,10 @@ class DataAdapter(object, metaclass=ABCMeta):
             for 'netcdf' :py:func:`xarray.open_mfdataset`.
             By default the driver is inferred from the file extension and falls back to
             'vector' if unknown.
-        filesystem: {'local', 'gcs', 's3'}, optional
+        filesystem: str, optional
             Filesystem where the data is stored (local, cloud, http etc.).
-            By default, local.
+            If None (default) the filesystem is inferred from the path.
+            See :py:func:`fsspec.registry.known_implementations` for all options.
         nodata: float, int, optional
             Missing value number. Only used if the data has no native missing value.
             Nodata values can be differentiated between variables using a dictionary.
@@ -166,6 +156,8 @@ class DataAdapter(object, metaclass=ABCMeta):
             or long name of the variable.
         driver_kwargs, dict, optional
             Additional key-word arguments passed to the driver.
+        storage_options: dict, optional
+            Additional key-word arguments passed to the fsspec FileSystem object.
         name, catalog_name: str, optional
             Name of the dataset and catalog, optional for now.
 
@@ -175,6 +167,7 @@ class DataAdapter(object, metaclass=ABCMeta):
         meta = meta or {}
         attrs = attrs or {}
         driver_kwargs = driver_kwargs or {}
+        storage_options = storage_options or {}
         rename = rename or {}
         self.name = name
         self.catalog_name = catalog_name
@@ -189,9 +182,18 @@ class DataAdapter(object, metaclass=ABCMeta):
                 str(path).split(".")[-1].lower(), self._DEFAULT_DRIVER
             )
         self.driver = driver
-        self.filesystem = filesystem
+        if "storage_options" in driver_kwargs:
+            warnings.warn(
+                "storage_options should be provided as a separate argument, "
+                "not as part of driver_kwargs",
+                DeprecationWarning,
+            )
+            storage_options.update(driver_kwargs.pop("storage_options"))
         self.driver_kwargs = driver_kwargs
-
+        self.storage_options = storage_options
+        # get filesystem
+        self.filesystem = filesystem
+        self._fs = None  # placeholder for fsspec filesystem object
         # data adapter arguments
         self.nodata = nodata
         self.rename = rename
@@ -223,7 +225,7 @@ class DataAdapter(object, metaclass=ABCMeta):
         """
         source = dict(data_type=self.data_type)
         for k, v in vars(self).items():
-            if k in ["name", "catalog_name"]:
+            if k in ["name", "catalog_name"] or k.startswith("_"):
                 continue  # do not add these identifiers
             if v is not None and (not isinstance(v, dict) or len(v) > 0):
                 source.update({k: v})
@@ -244,12 +246,37 @@ class DataAdapter(object, metaclass=ABCMeta):
         else:
             return False
 
+    @property
+    def fs(self):
+        """Return the filesystem object ."""
+        if self._fs is not None:
+            return self._fs
+        fs = None
+        if self.filesystem:  # use filesystem property
+            protocols = {"local": "file"}
+            protocol = protocols.get(self.filesystem, self.filesystem)
+        else:  # infer filesystem from path
+            upath = UPath(self.path)
+            if hasattr(upath, "fs"):
+                fs = upath.fs
+            else:
+                protocol = "file"
+                if hasattr(upath, "protocol"):
+                    protocol = upath.protocol
+                elif not isinstance(upath, (pathlib.PosixPath, pathlib.WindowsPath)):
+                    warnings.warn(
+                        "No filesystem found for path, using default local filesystem"
+                    )
+        if fs is None:
+            fs = fsspec.filesystem(protocol, **self.storage_options)
+        self._fs = fs
+        return fs
+
     def _resolve_paths(
         self,
         time_tuple: Optional[tuple] = None,
         variables: Optional[list] = None,
         zoom_level: Optional[int] = 0,
-        **kwargs,
     ):
         """Resolve {year}, {month} and {variable} keywords in self.path.
 
@@ -267,9 +294,6 @@ class DataAdapter(object, metaclass=ABCMeta):
             See :py:meth:`RasterDataAdapter._parse_zoom_level` for more info
         logger:
             The logger to use. If none is provided, the devault logger will be used.
-        **kwargs
-            key-word arguments are passed to fsspec FileSystem objects. Arguments
-            depend on protocal (local, gcs, s3...).
 
         Returns
         -------
@@ -280,94 +304,81 @@ class DataAdapter(object, metaclass=ABCMeta):
         fns = []
         keys = []
         # rebuild path based on arguments and escape unknown keys
-        path = ""
-        for literal_text, key, fmt, _ in Formatter().parse(self.path):
-            path += literal_text
-            if key is None:
-                continue
-            key_str = "{" + f"{key}:{fmt}" + "}" if fmt else "{" + key + "}"
-            # remove unused fields
-            if key in ["year", "month"] and time_tuple is None:
-                path += "*"
-            elif key == "variable" and variables is None:
-                path += "*"
-            # escape unknown fields
-            elif key is not None and key not in known_keys:
-                path = path + "{" + key_str + "}"
-            else:
-                path = path + key_str
-                keys.append(key)
+        if "{" in self.path:
+            path = ""
+            for literal_text, key, fmt, _ in Formatter().parse(self.path):
+                path += literal_text
+                if key is None:
+                    continue
+                key_str = "{" + f"{key}:{fmt}" + "}" if fmt else "{" + key + "}"
+                # remove unused fields
+                if key in ["year", "month"] and time_tuple is None:
+                    path += "*"
+                elif key == "variable" and variables is None:
+                    path += "*"
+                # escape unknown fields
+                elif key is not None and key not in known_keys:
+                    path = path + "{" + key_str + "}"
+                else:
+                    path = path + key_str
+                    keys.append(key)
+        else:
+            path = self.path
 
-        # resolve dates: month & year keys
+        # expand path based on keys for dates, variables and zoomlevel
         dates, vrs, postfix = [None], [None], ""
-        if time_tuple is not None:
-            dt = pd.to_timedelta(self.unit_add.get("time", 0), unit="s")
-            trange = pd.to_datetime(list(time_tuple)) - dt
-            freq, strf = ("m", "%Y-%m") if "month" in keys else ("a", "%Y")
-            dates = pd.period_range(*trange, freq=freq)
-            postfix += "; date range: " + " - ".join([t.strftime(strf) for t in trange])
-        # resolve variables
-        if variables is not None:
-            variables = np.atleast_1d(variables).tolist()
-            mv_inv = {v: k for k, v in self.rename.items()}
-            vrs = [mv_inv.get(var, var) for var in variables]  # type: ignore
-            postfix += f"; variables: {variables}"
-
-        # get filenames with glob for all date / variable combinations
-        fs = self.get_filesystem(**kwargs)
         fmt = {}
-        # update based on zoomlevel (size = 1)
-        if "zoom_level" in keys:
-            fmt.update(zoom_level=zoom_level)
-        # update based on dates and variables  (size >= 1)
-        for date, var in product(dates, vrs):
-            if date is not None:
-                fmt.update(year=date.year, month=date.month)
-            if var is not None:
-                fmt.update(variable=var)
-            fns.extend(fs.glob(path.format(**fmt)))
+        if len(keys) > 0:
+            # resolve dates: month & year keys
+            if time_tuple is not None:
+                dt = pd.to_timedelta(self.unit_add.get("time", 0), unit="s")
+                trange = pd.to_datetime(list(time_tuple)) - dt
+                freq, strf = ("m", "%Y-%m") if "month" in keys else ("a", "%Y")
+                dates = pd.period_range(*trange, freq=freq)
+                trange_str = [t.strftime(strf) for t in trange]
+                postfix += "; date range: " + " - ".join(trange_str)
+            # resolve variables
+            if variables is not None:
+                variables = np.atleast_1d(variables).tolist()
+                mv_inv = {v: k for k, v in self.rename.items()}
+                vrs = [mv_inv.get(var, var) for var in variables]  # type: ignore
+                postfix += f"; variables: {variables}"
+            # update based on zoomlevel (size = 1)
+            if "zoom_level" in keys:
+                fmt.update(zoom_level=zoom_level)
+            # update based on dates and variables  (size >= 1)
+            for date, var in product(dates, vrs):
+                if date is not None:
+                    fmt.update(year=date.year, month=date.month)
+                if var is not None:
+                    fmt.update(variable=var)
+                fns.append(path.format(**fmt))
+        else:
+            fns.append(path)
 
-        if len(fns) == 0:
+        # expand path with glob and check if files existW
+        fns_out = []
+        protocol = str(path).split("://")[0] if "://" in path else ""
+        # For s3, anonymous connection still requires --no-sign-request profile to
+        # read the data setting environment variable works
+        if self.storage_options and protocol in ["s3"]:
+            if "anon" in self.storage_options:
+                os.environ["AWS_NO_SIGN_REQUEST"] = "YES"
+            else:
+                os.environ["AWS_NO_SIGN_REQUEST"] = "NO"
+        for fn in list(set(fns)):
+            if "*" in str(fn):
+                for fn0 in self.fs.glob(fn):
+                    if protocol and not str(fn0).startswith(protocol):
+                        fn0 = f"{protocol}://{fn0}"
+                    fns_out.append(UPath(fn0, **self.storage_options))
+            elif self.fs.exists(fn):
+                fns_out.append(UPath(fn, **self.storage_options))
+
+        if len(fns_out) == 0:
             raise FileNotFoundError(f"No such file found: {path}{postfix}")
 
-        # With some fs like gcfs or s3fs, the first part of the path is not returned
-        # properly with glob
-        if not str(UPath(fns[0])).startswith(str(UPath(path))[0:2]):
-            # Assumes it's the first part of the path that is not
-            # correctly parsed with gcsfs, s3fs etc.
-            last_parent = UPath(path).parents[-1]
-            # add the rest of the path
-            fns = [last_parent.joinpath(*UPath(fn).parts[1:]) for fn in fns]
-        fns = list(set(fns))  # return unique paths
-        return fns
-
-    def get_filesystem(self, **kwargs):
-        """Return an initialised filesystem object."""
-        if self.filesystem == "local":
-            fs = local.LocalFileSystem(**kwargs)
-        elif self.filesystem == "gcs":
-            if _compat.HAS_GCSFS:
-                fs = gcsfs.GCSFileSystem(**kwargs)
-            else:
-                raise ModuleNotFoundError(
-                    "The gcsfs library is required to read data from gcs"
-                    + "(Google Cloud Storage). Please install."
-                )
-        elif self.filesystem == "s3":
-            if _compat.HAS_S3FS:
-                fs = s3fs.S3FileSystem(**kwargs)
-            else:
-                raise ModuleNotFoundError(
-                    "The s3fs library is required to read data from s3"
-                    + " (Amazon Web Storage). Please install."
-                )
-        else:
-            raise ValueError(
-                f"Unknown or unsupported filesystem {self.filesystem}."
-                + f" Use one of {FILESYSTEMS}"
-            )
-
-        return fs
+        return fns_out
 
     @abstractmethod
     def get_data(self, bbox, geom, buffer):

--- a/hydromt/data_adapter/dataframe.py
+++ b/hydromt/data_adapter/dataframe.py
@@ -1,6 +1,5 @@
 """Implementation for the Pandas Dataframe adapter."""
 import logging
-import os
 import warnings
 from os.path import join
 from typing import Optional, Union
@@ -28,7 +27,7 @@ class DataFrameAdapter(DataAdapter):
         self,
         path: str,
         driver: Optional[str] = None,
-        filesystem: str = "local",
+        filesystem: Optional[str] = None,
         nodata: Optional[Union[dict, float, int]] = None,
         rename: dict = {},
         unit_mult: dict = {},
@@ -36,6 +35,7 @@ class DataFrameAdapter(DataAdapter):
         meta: dict = {},
         attrs: dict = {},
         driver_kwargs: dict = {},
+        storage_options: dict = {},
         name: str = "",  # optional for now
         catalog_name: str = "",  # optional for now
         provider: Optional[str] = None,
@@ -60,9 +60,10 @@ class DataFrameAdapter(DataAdapter):
             :py:func:`~pandas.read_excel`, and for 'fwf' :py:func:`~pandas.read_fwf`.
             By default the driver is inferred from the file extension and falls back to
             'csv' if unknown.
-        filesystem: {'local', 'gcs', 's3'}, optional
+        filesystem: str, optional
             Filesystem where the data is stored (local, cloud, http etc.).
-            By default, local.
+            If None (default) the filesystem is inferred from the path.
+            See :py:func:`fsspec.registry.known_implementations` for all options.
         nodata: dict, float, int, optional
             Missing value number. Only used if the data has no native missing value.
             Nodata values can be differentiated between variables using a dictionary.
@@ -86,6 +87,8 @@ class DataFrameAdapter(DataAdapter):
             Not used in this adapter. Only here for compatability with other adapters.
         driver_kwargs, dict, optional
             Additional key-word arguments passed to the driver.
+        storage_options: dict, optional
+            Additional key-word arguments passed to the fsspec FileSystem object.
         name, catalog_name: str, optional
             Name of the dataset and catalog, optional for now.
         """
@@ -108,6 +111,7 @@ class DataFrameAdapter(DataAdapter):
             meta=meta,
             attrs=attrs,
             driver_kwargs=driver_kwargs,
+            storage_options=storage_options,
             name=name,
             catalog_name=catalog_name,
             provider=provider,
@@ -201,23 +205,6 @@ class DataFrameAdapter(DataAdapter):
         df = self._apply_unit_conversion(df, logger=logger)
         df = self._set_metadata(df)
         return df
-
-    def _resolve_paths(self, variables=None):
-        # Extract storage_options from kwargs to instantiate fsspec object correctly
-        so_kwargs = {}
-        if "storage_options" in self.driver_kwargs:
-            so_kwargs = self.driver_kwargs["storage_options"]
-            # For s3, anonymous connection still requires --no-sign-request profile
-            # to read the data setting environment variable works
-            if "anon" in so_kwargs:
-                os.environ["AWS_NO_SIGN_REQUEST"] = "YES"
-            else:
-                os.environ["AWS_NO_SIGN_REQUEST"] = "NO"
-
-        # throw nice error if data not found
-        fns = super()._resolve_paths(variables=variables, **so_kwargs)
-
-        return fns
 
     def _read_data(self, fns, logger=logger):
         if len(fns) > 1:

--- a/hydromt/data_adapter/geodataframe.py
+++ b/hydromt/data_adapter/geodataframe.py
@@ -35,7 +35,7 @@ class GeoDataFrameAdapter(DataAdapter):
         self,
         path: str,
         driver: Optional[str] = None,
-        filesystem: str = "local",
+        filesystem: Optional[str] = None,
         crs: Optional[Union[int, str, dict]] = None,
         nodata: Optional[Union[dict, float, int]] = None,
         rename: Optional[dict] = None,
@@ -45,6 +45,7 @@ class GeoDataFrameAdapter(DataAdapter):
         attrs: Optional[dict] = None,
         extent: Optional[dict] = None,
         driver_kwargs: Optional[dict] = None,
+        storage_options: Optional[dict] = None,
         name: str = "",  # optional for now
         catalog_name: str = "",  # optional for now
         provider=None,
@@ -68,9 +69,10 @@ class GeoDataFrameAdapter(DataAdapter):
             for {'vector_table'} :py:func:`hydromt.io.open_vector_from_table`
             By default the driver is inferred from the file extension and falls back to
             'vector' if unknown.
-        filesystem: {'local', 'gcs', 's3'}, optional
+        filesystem: str, optional
             Filesystem where the data is stored (local, cloud, http etc.).
-            By default, local.
+            If None (default) the filesystem is inferred from the path.
+            See :py:func:`fsspec.registry.known_implementations` for all options.
         crs: int, dict, or str, optional
             Coordinate Reference System. Accepts EPSG codes (int or str);
             proj (str or dict) or wkt (str). Only used if the data has no native CRS.
@@ -104,6 +106,8 @@ class GeoDataFrameAdapter(DataAdapter):
             time_range should be inclusive on both sides.
         driver_kwargs, dict, optional
             Additional key-word arguments passed to the driver.
+        storage_options: dict, optional
+            Additional key-word arguments passed to the fsspec FileSystem object.
         name, catalog_name: str, optional
             Name of the dataset and catalog, optional.
         provider: str, optional
@@ -134,6 +138,7 @@ class GeoDataFrameAdapter(DataAdapter):
             meta=meta,
             attrs=attrs,
             driver_kwargs=driver_kwargs,
+            storage_options=storage_options,
             name=name,
             catalog_name=catalog_name,
             provider=provider,
@@ -246,20 +251,6 @@ class GeoDataFrameAdapter(DataAdapter):
         gdf = self._apply_unit_conversions(gdf, logger=logger)
         gdf = self._set_metadata(gdf)
         return gdf
-
-    def _resolve_paths(self, variables):
-        # storage options for fsspec (TODO: not implemented yet)
-        if "storage_options" in self.driver_kwargs:
-            # not sure if storage options can be passed to fiona.open()
-            # for now throw NotImplemented Error
-            raise NotImplementedError(
-                "Remote file storage_options not implemented for GeoDataFrame"
-            )
-
-        # resolve paths
-        fns = super()._resolve_paths(variables=variables)
-
-        return fns
 
     def _read_data(self, fns, bbox, geom, buffer, predicate, logger=logger):
         if len(fns) > 1:

--- a/hydromt/stats/extremes.py
+++ b/hydromt/stats/extremes.py
@@ -689,7 +689,7 @@ def plot_return_values(
     ax.legend(loc="upper left")
 
     ymin = 0
-    ymax = np.max([np.max(rvs_obs), np.max(rvs_sim), 0])
+    ymax = np.nanmax([np.nanmax(rvs_obs), np.nanmax(rvs_sim), 0])
     ymax = ymax * 1.1
     ax.set_ylim(ymin, ymax)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "click",             # CLI configuration
     "dask",              # lazy computing
     "entrypoints",       # Provide access for Plugins
+    "fsspec",            # general file systems utilities
     "geopandas>=0.10",   # pandas but geo, wraps fiona and shapely
     "gdal>=3.1",         # enable geospacial data manipulation, both  raster and victor
     "numba",             # speed up computations (used in e.g. stats)
@@ -54,7 +55,6 @@ io = [
     "gcsfs",            # google cloud file system
     "openpyxl",         # excel IO
     "requests",         # donwload stuff
-    "fsspec==2023.5.0", # enable cloud file systems likg GCS and S3
 ]
 extra = [
     "xugrid", # xarray wrapper for mesh processing

--- a/tests/data/aws_esa_worldcover.yml
+++ b/tests/data/aws_esa_worldcover.yml
@@ -5,9 +5,8 @@ esa_worldcover:
   filesystem: s3
   version: 2021
   provider: aws
-  driver_kwargs:
-    storage_options:
-      anon: true
+  storage_options:
+    anon: true
   meta:
     category: landuse
     source_license: CC BY 4.0

--- a/tests/data/merged_esa_worldcover.yml
+++ b/tests/data/merged_esa_worldcover.yml
@@ -24,6 +24,5 @@ esa_worldcover:
       rename:
         ESA_WorldCover_10m_2020_v100_Map_AWS: landuse
       filesystem: s3
-      driver_kwargs:
-        storage_options:
-          anon: true
+      storage_options:
+        anon: true

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -82,7 +82,7 @@ def test_gcs_cmip6(tmpdir):
     ds = data_catalog.get_rasterdataset(
         "cmip6_NOAA-GFDL/GFDL-ESM4_historical_r1i1p1f1_Amon",
         variables=["precip", "temp"],
-        time_tuple=(("1990-01-01", "1990-06-01")),
+        time_tuple=(("1990-01-01", "1990-03-01")),
     )
     fn_nc = str(tmpdir.join("test.nc"))
     ds.to_netcdf(fn_nc)
@@ -95,8 +95,7 @@ def test_gcs_cmip6(tmpdir):
 
 
 @pytest.mark.skipif(not compat.HAS_S3FS, reason="S3FS not installed.")
-def test_aws_copdem(tmpdir):
-    # TODO switch to pre-defined catalogs when pushed to main
+def test_aws_worldcover():
     catalog_fn = join(CATALOGDIR, "aws_data.yml")
     data_catalog = DataCatalog(data_libs=[catalog_fn])
     da = data_catalog.get_rasterdataset(
@@ -104,7 +103,6 @@ def test_aws_copdem(tmpdir):
         bbox=[12.0, 46.0, 12.5, 46.50],
     )
     assert da.name == "landuse"
-    assert da.max().values == 100
 
 
 def test_rasterdataset_zoomlevels(rioda_large, tmpdir):


### PR DESCRIPTION
## Issue addressed
Fixes #499 

## Explanation
The `filesystem` property is now detected from the path (and hence optional in the data catalog).
The `storage_options` argument is set outside the `driver_kwargs` argument as it is not passed to the driver, but to the fsspec filesystems method. (needs to be updated in future data catalogs, now backwards compatible).

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
