### PR TITLE
fix docs version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           export PATH=/usr/share/miniconda3/bin:$PATH
           PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt sphinx-build docs docs/_build
-          echo "DOC_VERSION=$(python -c 'from hydromt import __version__ as v; print("dev" if "dev" in v else "v"+v.replace(".dev",""))')" >> $GITHUB_ENV
+          echo "DOC_VERSION=$(mamba run -n hydromt python -c 'from hydromt import __version__ as v; print("dev" if "dev" in v else "v"+v.replace(".dev",""))')" >> $GITHUB_ENV
 
       - name: Upload to GitHub Pages
         if: ${{ github.event_name != 'pull_request' && !github.event.act }}


### PR DESCRIPTION
## Issue addressed
Committing the build docs to the gh-pages deletes all files resulting in 404 errors.

## Explanation
The hydromt version cannot be read from the package in the conda base environment, hence the results are written to the gh-pages root.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
