### PR TITLE
Add better error message on incompatible nodata

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,7 @@ Fixed
 - when a model component (eg maps, forcing, grid) is updated using the set_ methods, it will first be read to avoid loosing data. (PR #460)
 - open_geodataset with driver vector also works for other geometry type than points. (PR #509)
 - overwrite model in update mode. (PR #534)
+- raster gives better error on incompatible nodata (PR #544)
 
 Deprecated
 ----------

--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -1748,16 +1748,24 @@ class RasterDataArray(XRasterBase):
         # Only numerical nodata values are supported
         if np.issubdtype(type(nodata), np.number):
             # python naitive types don't play very nice
-            if isinstance(nodata, float):
-                nodata_cast = np.float32(nodata)
-            elif isinstance(nodata, int):
-                nodata_cast = np.int32(nodata)
-            else:
-                nodata_cast = nodata
+            try:
+                if isinstance(nodata, float):
+                    nodata_cast = np.float32(nodata)
+                elif isinstance(nodata, int):
+                    nodata_cast = np.int32(nodata)
+                else:
+                    nodata_cast = nodata
 
-            # cast to float since using int causes inconsistent casting
-            self._obj.rio.set_nodata(nodata_cast, inplace=True)
-            self._obj.rio.write_nodata(nodata_cast, inplace=True)
+                # cast to float since using int causes inconsistent casting
+                self._obj.rio.set_nodata(nodata_cast, inplace=True)
+                self._obj.rio.write_nodata(nodata_cast, inplace=True)
+            except ValueError:
+                raise ValueError(
+                    f"Nodata value {nodata} of type {type(nodata).__name__} is "
+                    f"incompatible with raster dtype {self._obj.dtype}. Please provide"
+                    " a compatible nodata value for example by specifiying it in the"
+                    " data catalog."
+                )
         else:
             logger.warning("No numerical nodata value found, skipping set_nodata")
             self._obj.attrs.pop("_FillValue", None)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -409,6 +409,8 @@ def test_interpolate_na():
     da3 = da0.fillna(-9999).astype(np.int32)
     da3.raster.set_nodata(-9999)
     assert da3.raster.interpolate_na().dtype == np.int32
+    with pytest.raises(ValueError, match="Nodata value nan of type float"):
+        da3.raster.set_nodata(np.nan)
 
 
 def test_vector_grid(rioda):


### PR DESCRIPTION
## Issue addressed
Fixes #298 

## Explanation
Add a better error message if writing no data fails in raster.py

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
