### PR TITLE
always upload chaches on main

### DIFF
--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Upload cache
         uses: actions/cache/save@v3
+        if: always()
         with:
           path: |
             /usr/share/miniconda3
@@ -86,6 +87,7 @@ jobs:
 
       - name: Upload cache
         uses: actions/cache/save@v3
+        if: always()
         with:
           path: |
             /usr/share/miniconda3


### PR DESCRIPTION
## Issue addressed
NA

## Explanation
We have a few flaky tests that can sometimes fail due to time out. This can prevent the cache being generated needed for the test CI to be run. I'd rather not, but assuming that tests on main should always pass is one of the loosest assumptions I think we can make in this context. Therefore, with this PR, the cache CI should always save the cache, regardless of the test outcome. If we ever manage to address the flaky tests, this should be removed again. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
