### PR TITLE
Update example installation instructions in docs

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -77,6 +77,11 @@ Install HydroMT in a new environment
 
     This is our recommended way of installing HydroMT!
 
+.. Note::
+
+    If you intend to run the most up to date examples, you should follow the instalation guide at `the dev guide <https://deltares.github.io/hydromt/latest/dev/dev_install.html>`_ instead, as the dev version of hydromt is necessary to run the current examples. WIth the version installed through the steps
+    in this page, you will be able to run the examples at the time of the last release.
+
 To install HydroMT in a new environment called `hydromt` from the conda-forge channel do:
 
 .. code-block:: console

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -12,11 +12,12 @@ Local installation
 
 To run these examples on your local machine you need a copy of the repository and
 an installation of HydroMT including some additional packages. The most reliable
-way to do this installation is by creating a new environment as described below.
+way to do this installation is by using the binder imlementation provided above, however
+if you wish to exectute them locally you should create a new environment as described below.
 
 1 - Install python and conda/mamba
 **********************************
-If not already done, you'll need Python 3.8 or greater and a package manager such as conda or mamba. These package managers help you to install (Python) packages and
+If not already done, you'll need Python 3.9 or greater and a package manager such as conda or mamba. These package managers help you to install (Python) packages and
 `manage environments <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_ such that different installations do not conflict.
 
 We recommend using the `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_ Python distribution. This installs Python and the
@@ -29,20 +30,7 @@ If you already have a python & conda installation but do not yet have mamba inst
 
   $ conda install mamba -n base -c conda-forge
 
-2 - Install HydroMT and the other python dependencies in a separate Python environment
-**************************************************************************************
-The last step is to install all the python dependencies required to run the notebooks, including HydroMT. All required dependencies can be found
-in the `environment.yml <https://github.com/Deltares/hydromt/blob/main/environment.yml>`_ file in the root of the repository. This will create
-a new environment called **hydromt**. If you already have this environment with this name either remove it with `conda env remove -n hydromt`
-**or** set a new name for the environment by adding `-n <name>` to the line below.
-
-Note that you can exchange mamba for conda in the line below if you don't have mamba installed (see above for how to install mamba).
-
-.. code-block:: console
-
-  $ mamba env create -f https://raw.githubusercontent.com/Deltares/hydromt/main/environment.yml
-
-3 - Download the content of the HydroMT github repository
+2 - Download the content of the HydroMT github repository
 *********************************************************
 To run the examples locally, you will need to download the content of the HydroMT repository. You can either do a
 `manual download <https://github.com/Deltares/hydromt/archive/refs/heads/main.zip>`_ and extract the content of the downloaded ZIP folder
@@ -51,6 +39,30 @@ To run the examples locally, you will need to download the content of the HydroM
 .. code-block:: console
 
   $ git clone https://github.com/Deltares/hydromt.git
+
+3 - Install HydroMT and the other python dependencies in a separate Python environment
+**************************************************************************************
+The next step is to install all the python dependencies required to run the notebooks, including HydroMT.
+
+For a more detailed explanation please refer to `the dev instalation guide <https://deltares.github.io/hydromt/latest/dev/dev_install.html>`_
+
+It should be noted however, that due to our release cycle the examples in the repository might not be
+compatible with the version of hydromt you have installed, particulary if you followed the guide on
+`Getting Started <https://deltares.github.io/hydromt/latest/getting_started/installation.html>`_ which
+or installed hydromt through either pip or conda forge. The examples in the repositroy are compatible
+with the latest `dev` version of hydromt. If you follow the dev instalation guide linked above, everything
+should work as intended. However if you already have a version of hydromt installed, you will have to checkout that release in the repository.
+
+For example let's say you want to try out the examples and you already have version 0.7.1 installed.
+Then you can retrieve the correct examples by executing the following command from within the
+hydromt folder you created in the last step:
+
+.. code-block:: console
+
+  $ git checkout v0.7.1
+
+this will give you the example files in the state they were at the time of that release.
+
 
 4 - Running the examples
 ************************


### PR DESCRIPTION
## Issue addressed
Fixes #546 
Fixes #465 

## Explanation
I've decided to solve both of the issues above by simply explaining in the examples that either you need a dev installation for the latest examples, or you should check out the examples of the version you have installed. I have done this for a couple of reasons:
1. if you want to run the examples you already need the repository, at which point, making a dev install is a small step beyond that
2. given that you already have the repo, we can assume the user has at least some very rudimentary git knowledge, so checking out the tag of the version installed which has the versions of the examples they want is a simple operations
3. We also have binder for running the examples. 
4. it is by far the simplest option on our side. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
One other thing we could do is make the documentation link we list point to the latest stable release instead of the latest/dev version. That way people will find the examples that should be compatible with the versions they install from conda/pip. This would require a slight adjustment in how the docs are generated so I'll leave that for another issue/PR to figure out if that is something we want, but I did want to bring up the idea at least. 
