### PR TITLE
move binder to use official docker image

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,8 +1,5 @@
-# currently we haven't published an official hydromt image yet, so for now
-# I import from an export I've put on my own account. this should be moved
-# to the official image as soon as it's published.
-FROM savente/hydromt:slim as binder
-# Binder hard requires all of these steps when they build the imae
+FROM deltares/hydromt:slim as binder
+# Binder hard requires all of these steps when they build the image
 # therefore these steps aren't taken sooner
 
 ENV HOME=/home/mambauser \


### PR DESCRIPTION
## Issue addressed
Fixes #567 

## Explanation
update the reference in the binder workflow to use the official docker image that is now available within the deltares dockehrub org.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
