### PR TITLE
fix small issues with access cloud and cog files

### DIFF
--- a/hydromt/data_adapter/data_adapter.py
+++ b/hydromt/data_adapter/data_adapter.py
@@ -378,7 +378,7 @@ class DataAdapter(object, metaclass=ABCMeta):
                 os.environ["AWS_NO_SIGN_REQUEST"] = "YES"
             else:
                 os.environ["AWS_NO_SIGN_REQUEST"] = "NO"
-        # expand path with glob and check if files existW
+# expand path with glob and check if files exists
         fns_out = []
         for fn in list(set(fns)):
             if "*" in str(fn):

--- a/hydromt/data_adapter/data_adapter.py
+++ b/hydromt/data_adapter/data_adapter.py
@@ -365,16 +365,21 @@ class DataAdapter(object, metaclass=ABCMeta):
         else:
             fns.append(path)
 
-        # expand path with glob and check if files existW
-        fns_out = []
         protocol = str(path).split("://")[0] if "://" in path else ""
+        if protocol and self.filesystem is None:
+            self.filesystem = protocol
         # For s3, anonymous connection still requires --no-sign-request profile to
         # read the data setting environment variable works
-        if self.storage_options and protocol in ["s3"]:
-            if "anon" in self.storage_options:
+        # assume anonymous connection if storage_options is not set
+        if protocol in ["s3"]:
+            if not self.storage_options:
+                self.storage_options = {"anon": True}
+            if self.storage_options.get("anon", False):
                 os.environ["AWS_NO_SIGN_REQUEST"] = "YES"
             else:
                 os.environ["AWS_NO_SIGN_REQUEST"] = "NO"
+        # expand path with glob and check if files existW
+        fns_out = []
         for fn in list(set(fns)):
             if "*" in str(fn):
                 for fn0 in self.fs.glob(fn):

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -135,7 +135,6 @@ class RasterDatasetAdapter(DataAdapter):
         """
         driver_kwargs = driver_kwargs or {}
         extent = extent or {}
-        zoom_levels = zoom_levels or {}
         if kwargs:
             warnings.warn(
                 "Passing additional keyword arguments to be used by the "
@@ -163,6 +162,7 @@ class RasterDatasetAdapter(DataAdapter):
             version=version,
         )
         self.crs = crs
+        # should be None or non-empty dict when initialized
         self.zoom_levels = zoom_levels
         self.extent = extent
 

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import warnings
 from datetime import datetime
-from os.path import abspath, basename, exists, isdir, isfile, join
+from os.path import abspath, basename, isdir, isfile, join
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Tuple, TypedDict, Union, cast
 
@@ -1248,15 +1248,12 @@ class DataCatalog(object):
             if isinstance(data_like, str) and data_like in self.sources:
                 name = data_like
                 source = self.get_source(name, provider=provider, version=version)
-            elif exists(abspath(data_like)):
-                path = str(abspath(data_like))
+            else:
                 if "provider" not in kwargs:
-                    kwargs.update({"provider": "local"})
-                source = RasterDatasetAdapter(path=path, **kwargs)
+                    kwargs.update({"provider": "user"})
+                source = RasterDatasetAdapter(path=str(data_like), **kwargs)
                 name = basename(data_like)
                 self.add_source(name, source)
-            else:
-                raise FileNotFoundError(f"No such file or catalog source: {data_like}")
         elif isinstance(data_like, (xr.DataArray, xr.Dataset)):
             data_like = RasterDatasetAdapter._slice_data(
                 data_like,
@@ -1352,15 +1349,12 @@ class DataCatalog(object):
             if str(data_like) in self.sources:
                 name = str(data_like)
                 source = self.get_source(name, provider=provider, version=version)
-            elif exists(abspath(data_like)):
-                path = str(abspath(data_like))
+            else:
                 if "provider" not in kwargs:
-                    kwargs.update({"provider": "local"})
-                source = GeoDataFrameAdapter(path=path, **kwargs)
+                    kwargs.update({"provider": "user"})
+                source = GeoDataFrameAdapter(path=str(data_like), **kwargs)
                 name = basename(data_like)
                 self.add_source(name, source)
-            else:
-                raise FileNotFoundError(f"No such file or catalog source: {data_like}")
         elif isinstance(data_like, gpd.GeoDataFrame):
             return GeoDataFrameAdapter._slice_data(
                 data_like, variables, geom, bbox, buffer, predicate, logger=self.logger
@@ -1448,15 +1442,12 @@ class DataCatalog(object):
             if isinstance(data_like, str) and data_like in self.sources:
                 name = data_like
                 source = self.get_source(name, provider=provider, version=version)
-            elif exists(abspath(data_like)):
-                path = str(abspath(data_like))
+            else:
                 if "provider" not in kwargs:
-                    kwargs.update({"provider": "local"})
-                source = GeoDatasetAdapter(path=path, **kwargs)
+                    kwargs.update({"provider": "user"})
+                source = GeoDatasetAdapter(path=str(data_like), **kwargs)
                 name = basename(data_like)
                 self.add_source(name, source)
-            else:
-                raise FileNotFoundError(f"No such file or catalog source: {data_like}")
         elif isinstance(data_like, (xr.DataArray, xr.Dataset)):
             data_like = GeoDatasetAdapter._slice_data(
                 data_like,
@@ -1527,15 +1518,12 @@ class DataCatalog(object):
             if isinstance(data_like, str) and data_like in self.sources:
                 name = data_like
                 source = self.get_source(name, provider=provider, version=version)
-            elif exists(abspath(data_like)):
-                path = str(abspath(data_like))
+            else:
                 if "provider" not in kwargs:
-                    kwargs.update({"provider": "local"})
-                source = DataFrameAdapter(path=path, **kwargs)
+                    kwargs.update({"provider": "user"})
+                source = DataFrameAdapter(path=str(data_like), **kwargs)
                 name = basename(data_like)
                 self.add_source(name, source)
-            else:
-                raise FileNotFoundError(f"No such file or catalog source: {data_like}")
         elif isinstance(data_like, pd.DataFrame):
             return DataFrameAdapter._slice_data(
                 data_like, variables, time_tuple, logger=self.logger

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -69,7 +69,7 @@ def test_rasterdataset(rioda, tmpdir):
     geom = rioda.raster.box
     da1 = data_catalog.get_rasterdataset("test.tif", geom=geom)
     assert np.all(da1 == rioda_utm)
-    with pytest.raises(FileNotFoundError, match="No such file or catalog source"):
+    with pytest.raises(FileNotFoundError, match="No such file"):
         data_catalog.get_rasterdataset("no_file.tif")
     with pytest.raises(IndexError, match="RasterDataset: No data within"):
         data_catalog.get_rasterdataset("test.tif", bbox=[40, 50, 41, 51])
@@ -162,7 +162,7 @@ def test_rasterdataset_zoomlevels(rioda_large, tmpdir):
     # test COG zoom levels
     da1 = data_catalog.get_rasterdataset(cog_fn, zoom_level=(0.01, "degree"))
     assert da1.raster.shape == (256, 250)
-    assert (data_catalog.get_source("test_cog.tif").zoom_levels) == 3
+    assert len(data_catalog.get_source("test_cog.tif").zoom_levels) == 3
 
 
 def test_rasterdataset_driver_kwargs(artifact_data: DataCatalog, tmpdir):
@@ -248,7 +248,7 @@ def test_geodataset(geoda, geodf, ts, tmpdir):
     ).sortby("index")
     assert np.allclose(da3, geoda)
     assert da3.vector.crs.to_epsg() == 4326
-    with pytest.raises(FileNotFoundError, match="No such file or catalog source"):
+    with pytest.raises(FileNotFoundError, match="No such file"):
         data_catalog.get_geodataset("no_file.geojson")
     with tempfile.TemporaryDirectory() as td:
         # Test nc file writing to file
@@ -306,7 +306,7 @@ def test_geodataframe(geodf, tmpdir):
         "test.geojson", bbox=geodf.total_bounds, buffer=1000, rename={"test": "test1"}
     )
     assert np.all(gdf1 == geodf)
-    with pytest.raises(FileNotFoundError, match="No such file or catalog source"):
+    with pytest.raises(FileNotFoundError, match="No such file"):
         data_catalog.get_geodataframe("no_file.geojson")
 
 

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -162,6 +162,7 @@ def test_rasterdataset_zoomlevels(rioda_large, tmpdir):
     # test COG zoom levels
     da1 = data_catalog.get_rasterdataset(cog_fn, zoom_level=(0.01, "degree"))
     assert da1.raster.shape == (256, 250)
+    assert (data_catalog.get_source("test_cog.tif").zoom_levels) == 3
 
 
 def test_rasterdataset_driver_kwargs(artifact_data: DataCatalog, tmpdir):


### PR DESCRIPTION
## Issue addressed
- the detection of zoom levels from COG files was broken because of initialization of zoom_levels with an empty dict instead of None
- DataCatalog.get_*data methods did not work for files that are not on the local filesystem because of a file exist check. This check is also done downstream in the get_data method so I removed it at this stage.
- the filesystem is now inferred from the path if not set. This is required for proper access of cloud data without a data catalog entry

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
