### PR TITLE
remove explicit gdal dep

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,7 +1,7 @@
 # currently we haven't published an official hydromt image yet, so for now
 # I import from an export I've put on my own account. this should be moved
 # to the official image as soon as it's published.
-FROM savente/hydromt:slim as binder
+FROM deltares/hydromt:slim as binder
 # Binder hard requires all of these steps when they build the imae
 # therefore these steps aren't taken sooner
 

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -34,7 +34,7 @@ jobs:
       - name: generate envs
         run: |
           pip install tomli
-          make full-environment.yml
+          python make_env.py -p 3.11 -o full-environment.yml full
 
       - name: Build and test
         uses: docker/build-push-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   "entrypoints",       # Provide access for Plugins
   "fsspec",            # general file systems utilities
   "geopandas>=0.10",   # pandas but geo, wraps fiona and shapely
-  "gdal>=3.1",         # enable geospacial data manipulation, both  raster and victor
   "mercantile",        # tile handling
   "numba",             # speed up computations (used in e.g. stats)
   "numpy>=1.20",       # pin necessary to ensure compatability with C headers

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -8,9 +8,9 @@ import dask
 import geopandas as gpd
 import numpy as np
 import pytest
+import rasterio
 import xarray as xr
 from affine import Affine
-from osgeo import gdal
 from shapely.geometry import LineString, Point, box
 
 from hydromt import gis_utils, open_raster, raster
@@ -114,9 +114,9 @@ def test_gdal(tmpdir):
     # Write to netcdf and reopen with gdal
     fn_nc = str(tmpdir.join("gdal_test.nc"))
     da.to_netcdf(fn_nc)
-    gdal.Info(fn_nc)
-    ds = gdal.Open(fn_nc)
-    assert da[raster.GEO_MAP_COORD].attrs["crs_wkt"] == ds.GetProjection()
+    with rasterio.open(fn_nc) as dst:
+        dst.read()
+        assert da.raster.crs == dst.crs
 
 
 def test_attrs_errors(rioda):


### PR DESCRIPTION
## Issue addressed
remove gdal dependency 
links to https://github.com/Deltares/hydromt_delft3dfm/issues/13

## Explanation
gdal is not directly imported, so not a direct dependency of hydromt and could potentially make hydromt pip installable.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
