### PR TITLE
Update installation of examples

### DIFF
--- a/.github/workflows/update-examples-env.yml
+++ b/.github/workflows/update-examples-env.yml
@@ -1,0 +1,29 @@
+---
+name: Update examples environment
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - pyproject.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - pyproject.toml
+
+jobs:
+  generate_examples_environment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate environment file
+        run: pip install tomli && python make_env.py slim -n hydromt -r -o ./examples/environment.yml
+
+      - name: Commit environment file
+        uses: actions/update-file@v4
+        with:
+          path: ./examples/environment.yml
+          content: |
+            {{ include('examples/environment.yml') }}

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ ENV/
 env.bak/
 venv.bak/
 *environment.yml
+!/examples/environment.yml
 
 # Spyder project settings
 .spyderproject

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -1,0 +1,20 @@
+name: hydromt
+
+channels:
+- conda-forge
+
+dependencies:
+- cartopy
+- gcsfs
+- hydromt
+- jupyterlab
+- matplotlib-base
+- notebook
+- openpyxl
+- pillow
+- pip
+- requests
+- s3fs
+- xugrid>=0.6.5
+- pip:
+  - pyet

--- a/make_env.py
+++ b/make_env.py
@@ -48,6 +48,7 @@ parser.add_argument("--output", "-o", default="environment.yml")
 parser.add_argument("--channels", "-c", default=None)
 parser.add_argument("--name", "-n", default=None)
 parser.add_argument("--py-version", "-p", default=None)
+parser.add_argument("-r", "--release", action="store_true")
 args = parser.parse_args()
 
 #
@@ -72,7 +73,10 @@ print(f"Environment name: {name}")
 
 # parse dependencies groups and flavours
 # "min" equals no optional dependencies
-deps_to_install = deps.copy()
+if args.release:
+    deps_to_install = ["hydromt"]
+else:
+    deps_to_install = deps.copy()
 if args.profile not in ["", "min"]:
     extra_deps = _parse_profile(args.profile, opt_deps, project_name)
     deps_to_install.extend(extra_deps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "entrypoints",       # Provide access for Plugins
   "fsspec",            # general file systems utilities
   "geopandas>=0.10",   # pandas but geo, wraps fiona and shapely
-  "mercantile",        # tile handling
+#  "mercantile",        # tile handling
   "numba",             # speed up computations (used in e.g. stats)
   "numpy>=1.20",       # pin necessary to ensure compatability with C headers
   "netcdf4",           # netcfd IO


### PR DESCRIPTION
## Issue addressed
Fixes #465

## Explanation
I think we should encourage users to install hydromt via conda-forge as much as possible and installing examples should also be made easy for users that are not too familiar with python/git.

In this PR, I then generate and commit on the fly an environment.yml for the examples if pyproject.toml is modified so that users can install hydromt from conda-forge as well as the optional dependencies.
In addition, we have a new command line for users to download the examples folder based on their installed hydromt version.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed
