### PR TITLE
Osgeo

### DIFF
--- a/hydromt/vector.py
+++ b/hydromt/vector.py
@@ -11,9 +11,6 @@ import shapely
 import xarray as xr
 from geopandas import GeoDataFrame, GeoSeries
 from rasterio import gdal_version
-
-# TODO try getting this version without importing osgeo to avoid
-# conflicts with geopandas/rasterio
 from shapely.geometry.base import BaseGeometry
 
 from hydromt import gis_utils, raster

--- a/hydromt/vector.py
+++ b/hydromt/vector.py
@@ -10,15 +10,16 @@ import pyproj
 import shapely
 import xarray as xr
 from geopandas import GeoDataFrame, GeoSeries
+from rasterio import gdal_version
 
 # TODO try getting this version without importing osgeo to avoid
 # conflicts with geopandas/rasterio
-from osgeo import __version__ as GDAL_VERSION
 from shapely.geometry.base import BaseGeometry
 
 from hydromt import gis_utils, raster
 
 logger = logging.getLogger(__name__)
+GDAL_VERSION = gdal_version()
 
 
 class GeoBase(raster.XGeoBase):


### PR DESCRIPTION
## Issue addressed
Partially Fixes #586 

## Explanation
As raised in the linked issue the current pip install version of HydroMT raises an import error. The fix suggested in the issue does resolve the import error, however a lot of tests fail because of missing dependencies on the pip install. I think we should consider in what capacity we want to support a pip-installable HydroMT, and if this is something we want to maintain, then I think it should be tested along with the other versions.  Opening this PR on request, but solution remains to be discussed. 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
