### PR TITLE
Revert actions-gh-pages versoin

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,12 +78,12 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && !github.event.act }}
         run: |
           export PATH=/usr/share/miniconda3/bin:$PATH
-          PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt sphinx-build docs docs/_build
+          PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt sphinx-build "docs" "docs/_build"
           echo "DOC_VERSION=$(mamba run -n hydromt python -c 'from hydromt import __version__ as v; print("dev" if "dev" in v else "v"+v.replace(".dev",""))')" >> $GITHUB_ENV
 
       - name: Upload to GitHub Pages
         if: ${{ github.event_name != 'pull_request' && !github.event.act }}
-        uses: peaceiris/actions-gh-pages@v3.9.3
+        uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html


### PR DESCRIPTION
## Issue addressed
Currently the docs are being generated correctly, but not being published. 

## Explanation
Why exactly this is happening is unclear, but around when this started happening I'd updated the version of the action used. So with this I'm reverting that in the hope the docs will start publishing again. Then I can investigate later what was going wrong. 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
