### PR TITLE
locate docs cache in home in CI

### DIFF
--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -85,7 +85,7 @@ jobs:
 
       # run tests first so that we can also cache all of the artefacts
       - name: Generate docs
-        run: PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt sphinx-build docs docs/_build
+        run: PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt sphinx-build ~/docs ~/docs/_build
 
       - name: Upload cache
         uses: actions/cache/save@v3


### PR DESCRIPTION
This needs to be on main for testing, my apologies for the messy commits. Putting the cache in the home dir instead of the current directory because I'm not sure how the cache action deals with changing directories and I'd rather avoid that. 