### PR TITLE
Move formatting from black to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -12,15 +12,11 @@ repos:
       - id: debug-statements
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.270
+    rev: v0.1.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        args: [--config=pyproject.toml]
+      - id: ruff-format
   # - repo: https://github.com/python-jsonschema/check-jsonschema
   #   rev: 0.24.0
   #   hooks:

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -279,7 +279,7 @@ Docstrings
 
 Code format
 ^^^^^^^^^^^
-- We use the `black code style <https://black.readthedocs.io/en/stable/the_black_code_style.html>`_ and `pre-commit <https://pre-commit.com>`_ to keep everything formatted. Please make sure all hooks pass before commiting. Pre-commit will do this for you if it's installed correctly.
+- We use the `black code style <https://black.readthedocs.io/en/stable/the_black_code_style.html>`_ and `pre-commit <https://pre-commit.com>`_ to keep everything formatted. We use the formatter included with `ruff <https://docs.astral.sh/ruff/formatter/>`_ which is black compatible, but much faster. Please make sure all hooks pass before commiting. Pre-commit will do this for you if it's installed correctly.
 
 You can install pre-commit by running:
 
@@ -330,10 +330,11 @@ Then you can add the new feature to the git staging area and try to commit as us
     - exit code: 1
     - files were modified by this hook
 
+    ruff-format..............................................................Passed
+
     hydromt/new_feature.py:1:1: D100 Missing docstring in public module
     Found 2 errors (1 fixed, 1 remaining).
 
-    black....................................................................Passed
 
 This means that pre-commit has found issues in the code you submitted. In the case of the import it was able to fix it automatically. However `ruff` has also detected that you have not added a docstring for the new feature. You can find this out by running:
 
@@ -364,7 +365,6 @@ After you've fixed this problem by for example adding the docstring """Implement
   Mixed line ending........................................................Passed
   Format YAML files....................................(no files to check)Skipped
   ruff.....................................................................Passed
-  black....................................................................Passed
   [linting a5e9b683] The feature you've all been waiting for.
    1 file changed, 4 insertions(+)
    create mode 100644 hydromt/new_feature.py

--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -2353,9 +2353,7 @@ class RasterDataArray(XRasterBase):
                 temp = obj[u : u + h, l : l + w].load()
                 if zl != 0:
                     temp = (
-                        temp.coarsen(
-                            {x_dim: 2**diff, y_dim: 2**diff}, boundary="pad"
-                        )
+                        temp.coarsen({x_dim: 2**diff, y_dim: 2**diff}, boundary="pad")
                         .mean()
                         .fillna(nodata)
                         .astype(dtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,17 +114,15 @@ deps_not_in_conda = [
   "rio-vrt",
 ]
 
-[tool.black]
-line-length = 88
-target-version = ['py39']
 
 [tool.ruff]
 line-length = 88
+target-version = "py39"
 
 # enable pydocstyle (E), pyflake (F) and isort (I), pytest-style (PT), bugbear (B)
 select = ["E", "F", "I", "PT", "D", "B"]
 ignore-init-module-imports = true
-ignore = ["D211", "D213", "E741", "D105", "E712", "B904"]
+ignore = ["D211", "D213", 'D206', 'E501', "E741", "D105", "E712", "B904"]
 exclude = ["docs"]
 
 [tool.ruff.per-file-ignores]

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -203,7 +203,8 @@ def test_versioned_catalog_entries(tmpdir):
     source_aws2 = aws_and_legacy_catalog.get_source("esa_worldcover", provider="aws")
     assert source_aws2 == source_aws
     source_loc = aws_and_legacy_catalog.get_source(
-        "esa_worldcover", provider="legacy_esa_worldcover"  # provider is filename
+        "esa_worldcover",
+        provider="legacy_esa_worldcover",  # provider is filename
     )
     assert Path(source_loc.path).name == "esa-worldcover.vrt"
     # test round trip to and from dict


### PR DESCRIPTION
## Explanatin
Ruff just implemented a formater that is compatible with black (they claim 99.9% the same behavior) but is an order of magnitude faster. Since we also already install ruff for the pre-commit hooks and CIs it also simplifies that process. Therefore it would make sense to switch to that. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
