### PR TITLE
Bump numpy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # there is no conda support for dependabot so this is the closest analog
+  # since the conda deps are also built from pyproject.toml it should work well enough
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "mercantile",        # tile handling
   "netcdf4",           # netcfd IO
   "numba",             # speed up computations (used in e.g. stats)
-  "numpy>=1.22",       # pin necessary to ensure compatability with C headers
+  "numpy>=1.23",       # pin necessary to ensure compatability with C headers
   "packaging",         # compare versions of hydromt
   "pandas",            # Dataframes
   "pyflwdir>=0.5.4",   # Hight models and derivatives

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "mercantile",        # tile handling
   "netcdf4",           # netcfd IO
   "numba",             # speed up computations (used in e.g. stats)
-  "numpy>=1.20",       # pin necessary to ensure compatability with C headers
+  "numpy>=1.22",       # pin necessary to ensure compatability with C headers
   "packaging",         # compare versions of hydromt
   "pandas",            # Dataframes
   "pyflwdir>=0.5.4",   # Hight models and derivatives


### PR DESCRIPTION
## Issue addressed
Fixes #614 

## Explanation
Since numpy 1.22 is EOL now, it would be good to update so that people don't use unsupported versions. Since 1.22's EOL is in 2 months (source: https://endoflife.date/numpy) I've decided to just bump it to 1.23 directly. this gives us 8 months before we need to update further so that seems like a good idea. Currently the numpy version esolves to 1.24 (in my environment) so using 1.23 should be fine for the time being. 

I've also added a dependabot alerting so that we are notified of these things a bit more frequently. Sadly it doesn't support conda dependencies, but since our conda dependencies mirror that of pip (it's built from pyproject.toml) having alerts for pip EOLs is a close enough analog imo, we can always investigate further from there if necessary. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
