### PR TITLE
move pyogrio to mandatory imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "packaging",         # compare versions of hydromt
   "pandas",            # Dataframes
   "pyflwdir>=0.5.4",   # Hight models and derivatives
+  "pyogrio>=0.6",      # io for geopandas dataframes
   "pyproj",            # projections for Coordinate reference systems
   "pyyaml",            # yaml interface
   "rasterio",          # raster wrapper around gdal
@@ -55,7 +56,6 @@ dynamic = ['version', 'description']
 io = [
   "gcsfs",        # google cloud file system
   "openpyxl",     # excel IO
-  "pyogrio>=0.6", # io for geopandas dataframes
   "fastparquet",  # parquet IO
   "pillow",       # image IO
   "rio-vrt",      # write VRT files


### PR DESCRIPTION
## Issue addressed
pyogrio is imported in gis_utils.py. As it will be mandatory to use with geopandas soon anyways, why not move it to required packages instead of doing dynamic imports?

## Explanation
moved the dependency in the pyproject.toml

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
