### PR TITLE
Transform boundary fix

### DIFF
--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -313,7 +313,7 @@ def meridian_offset(ds, x_name="x", bbox=None):
         lons = np.where(lons > 0, lons - 360, lons)
     elif bbox is not None and bbox[2] > e and bbox[2] > 180:  # 180W - 180E > 0E-360E
         lons = np.where(lons < 0, lons + 360, lons)
-    elif e > 180:  # 0E-360E > 180W - 180E
+    elif e > 181 and w > -1:  # 0E-360E > 180W - 180E, temp fix for rounding errors
         lons = np.where(lons > 180, lons - 360, lons)
     else:
         return ds


### PR DESCRIPTION
## Issue addressed
Fixes #624

## Explanation
I added a quick fix for global rasterdatasets that have rounding errors regarding their outer boundaries. The fix could be a more elegant, but for now it fixes the issue #624, which was breaking for @dalmijn.  

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
