### PR TITLE
fix to_stac test on widows

### DIFF
--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -649,9 +649,12 @@ def test_to_stac(tmpdir):
 
     assert sorted(list(map(lambda x: x.id, stac_catalog.get_children()))) == sources
     # the two empty strings are for the root and self link which are destinct
-    assert sorted(list(map(lambda x: x.get_href(), stac_catalog.get_links()))) == [
-        join(".", p, "catalog.json") for p in ["", *sources, str(tmpdir)]
-    ]
+    assert sorted(
+        [
+            Path(join(tmpdir, x.get_href())) if x != str(tmpdir) else tmpdir
+            for x in stac_catalog.get_links()
+        ]
+    ) == sorted([Path(join(tmpdir, p, "catalog.json")) for p in ["", *sources, ""]])
 
 
 def test_from_stac(tmpdir):


### PR DESCRIPTION


## Explanation
Tests was broken due to different paths handling on windows. Shouldn't have made a difference on the actual behavior, but it's better to have the tests fixed. Now works with Paths so should be cross platform. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
