### PR TITLE
Fix meridian offset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ Changed
 Fixed
 -----
 - Bug in zoom level detection in `RasterDatasetAdapter` for Tifs without overviews and paths with placeholders. (#642)
+- Bug in gis_utils.meridian_offset for grids with rounding errors. (#649)
 
 Deprecated
 ----------

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -536,11 +536,9 @@ class RasterDatasetAdapter(DataAdapter):
             crs4326 = pyproj.CRS.from_epsg(4326)
             bbox = rasterio.warp.transform_bounds(crs4326, crs, *bbox)
         # work with 4326 data that is defined at 0-360 degrees longtitude
-        if epsg == 4326:
-            e = ds.raster.bounds[2]
-            if e > 180 or (bbox is not None and (bbox[0] < -180 or bbox[2] > 180)):
-                x_dim = ds.raster.x_dim
-                ds = gis_utils.meridian_offset(ds, x_dim, bbox).sortby(x_dim)
+        w, _, e, _ = ds.raster.bounds
+        if epsg == 4326 and (e - w) >= (360 - 1e-3):  # allow for rounding errors
+            ds = gis_utils.meridian_offset(ds, bbox)
 
         # clip with bbox
         if bbox is not None:

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -537,7 +537,7 @@ class RasterDatasetAdapter(DataAdapter):
             bbox = rasterio.warp.transform_bounds(crs4326, crs, *bbox)
         # work with 4326 data that is defined at 0-360 degrees longtitude
         w, _, e, _ = ds.raster.bounds
-        if epsg == 4326 and (e - w) >= (360 - 1e-3):  # allow for rounding errors
+        if epsg == 4326 and np.isclose(e - w, 360):  # allow for rounding errors
             ds = gis_utils.meridian_offset(ds, bbox)
 
         # clip with bbox

--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -306,7 +306,11 @@ def axes_attrs(crs):
 def meridian_offset(ds, bbox=None):
     """re-arrange data along x dim."""
     w, _, e, _ = ds.raster.bounds
-    if ds.raster.crs is None or ds.raster.crs.is_projected or (e - w) < (360 - 1e-3):
+    if (
+        ds.raster.crs is None
+        or ds.raster.crs.is_projected
+        or not np.isclose(e - w, 360)
+    ):
         raise ValueError("The method is only applicable to global geographic CRS")
     x_name = ds.raster.x_dim
     lons = np.copy(ds[x_name].values)
@@ -314,7 +318,7 @@ def meridian_offset(ds, bbox=None):
         lons = np.where(lons > 0, lons - 360, lons)
     elif bbox is not None and bbox[2] > e and bbox[2] > 180:  # 180W - 180E > 0E-360E
         lons = np.where(lons < 0, lons + 360, lons)
-    elif e >= (360 - 1e-3):  # 0E-360E > 180W - 180E (allow for rounding errors)
+    elif np.isclose(e, 360):  # 0W - 360E > 180W - 180E (allow for rounding errors)
         lons = np.where(lons > 180, lons - 360, lons)
     else:
         return ds

--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -313,7 +313,7 @@ def meridian_offset(ds, x_name="x", bbox=None):
         lons = np.where(lons > 0, lons - 360, lons)
     elif bbox is not None and bbox[2] > e and bbox[2] > 180:  # 180W - 180E > 0E-360E
         lons = np.where(lons < 0, lons + 360, lons)
-    elif e > 181 and w > -1:  # 0E-360E > 180W - 180E, temp fix for rounding errors
+    elif e > 180:  # 0E-360E > 180W - 180E
         lons = np.where(lons > 180, lons - 360, lons)
     else:
         return ds

--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -2372,7 +2372,8 @@ class RasterDataArray(XRasterBase):
                     for d, s in zip(dims, pad_sizes):
                         if s > 0:
                             coords = temp[d].values
-                            coords[-s:] = np.arange(1, s + 1) * dst_res + coords[-s - 1]
+                            res = dst_res if d == x_dim else -dst_res
+                            coords[-s:] = np.arange(1, s + 1) * res + coords[-s - 1]
                             temp[d] = xr.IndexVariable(d, coords)
 
                 temp.raster.set_nodata(nodata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,6 @@ channels = ["conda-forge"]
 deps_not_in_conda = [
   "sphinx_autosummary_accessors",
   "sphinx_design",
-  "pyet",
-  "rio-vrt",
 ]
 
 

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -596,17 +596,12 @@ def test_detect_extent():
 
     # raster dataset
     name = "chirps_global"
-    bbox = (
-        11.599998474121094,
-        45.20000076293945,
-        13.000083923339844,
-        46.79985427856445,
-    )
+    bbox = 11.60, 45.20, 13.00, 46.80
     expected_temporal_range = tuple(pd.to_datetime(["2010-02-02", "2010-02-15"]))
     ds = cast(RasterDatasetAdapter, data_catalog.get_source(name))
     detected_spatial_range = to_geographic_bbox(*ds.get_bbox(detect=True))
     detected_temporal_range = ds.get_time_range(detect=True)
-    assert np.all(np.equal(detected_spatial_range, bbox))
+    assert np.allclose(detected_spatial_range, bbox)
     assert detected_temporal_range == expected_temporal_range
 
     # geodataframe

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -134,9 +134,6 @@ def test_attrs_errors(rioda):
     with pytest.raises(ValueError, match="dimension not found"):
         rioda.raster.set_spatial_dims()
     rioda = rioda.rename({"yyyy": "y"})
-    rioda["x"] = np.random.rand(rioda["x"].size)
-    with pytest.raises(ValueError, match="only applies to regular grids"):
-        rioda.raster.set_spatial_dims()
     with pytest.raises(ValueError, match="Invalid dimension order."):
         rioda.transpose("x", "y").raster._check_dimensions()
 


### PR DESCRIPTION
## Issue addressed
Fixes #624 

## Explanation
The error was because the the meridian_offset function created an irregular grid as some cells where incorrectly shifted.
The solution checks if the grid is global (x spans 360 degrees) before shifting which is required to keep a regular grid.
In addition we check if the grid is regular when computing the resolution to avoid these funny downstream errors.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
