### PR TITLE
fix typing annotation for py39

### DIFF
--- a/hydromt/data_adapter/geodataframe.py
+++ b/hydromt/data_adapter/geodataframe.py
@@ -506,13 +506,12 @@ class GeoDataFrameAdapter(DataAdapter):
             bbox = list(bbox)
             props = {**self.meta, "crs": crs}
             ext = splitext(self.path)[-1]
-            match ext:
-                case ".gpkg":
-                    media_type = MediaType.GEOPACKAGE
-                case _:
-                    raise RuntimeError(
-                        f"Unknown extention: {ext} cannot determine media type"
-                    )
+            if ext == ".gpkg":
+                media_type = MediaType.GEOPACKAGE
+            else:
+                raise RuntimeError(
+                    f"Unknown extention: {ext} cannot determine media type"
+                )
         except (IndexError, KeyError, CRSError) as e:
             if on_error == ErrorHandleMethod.SKIP:
                 logger.warning(

--- a/hydromt/data_adapter/geodataset.py
+++ b/hydromt/data_adapter/geodataset.py
@@ -630,13 +630,12 @@ class GeoDatasetAdapter(DataAdapter):
             end_dt = pd.to_datetime(end_dt)
             props = {**self.meta, "crs": crs}
             ext = splitext(self.path)[-1]
-            match ext:
-                case ".nc" | ".vrt":
-                    media_type = MediaType.HDF5
-                case _:
-                    raise RuntimeError(
-                        f"Unknown extention: {ext} cannot determine media type"
-                    )
+            if ext in [".nc", ".vrt"]:
+                media_type = MediaType.HDF5
+            else:
+                raise RuntimeError(
+                    f"Unknown extention: {ext} cannot determine media type"
+                )
         except (IndexError, KeyError, CRSError) as e:
             if on_error == ErrorHandleMethod.SKIP:
                 logger.warning(

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -852,19 +852,18 @@ class RasterDatasetAdapter(DataAdapter):
             end_dt = pd.to_datetime(end_dt)
             props = {**self.meta, "crs": crs}
             ext = splitext(self.path)[-1]
-            match ext:
-                case ".nc" | ".vrt":
-                    media_type = MediaType.HDF5
-                case ".tiff":
-                    media_type = MediaType.TIFF
-                case ".cog":
-                    media_type = MediaType.COG
-                case ".png":
-                    media_type = MediaType.PNG
-                case _:
-                    raise RuntimeError(
-                        f"Unknown extention: {ext} cannot determine media type"
-                    )
+            if ext == ".nc" or ext == ".vrt":
+                media_type = MediaType.HDF5
+            elif ext == ".tiff":
+                media_type = MediaType.TIFF
+            elif ext == ".cog":
+                media_type = MediaType.COG
+            elif ext == ".png":
+                media_type = MediaType.PNG
+            else:
+                raise RuntimeError(
+                    f"Unknown extention: {ext} cannot determine media type"
+                )
         except (IndexError, KeyError, CRSError) as e:
             if on_error == ErrorHandleMethod.SKIP:
                 logger.warning(

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -229,22 +229,21 @@ class DataCatalog(object):
         for item in stac_catalog.get_items(recursive=True):
             source_name = item.id
             for _asset_name, asset in item.get_assets().items():
-                match asset.media_type:
-                    case (
-                        MediaType.HDF
-                        | MediaType.HDF5
-                        | MediaType.COG
-                        | MediaType.TIFF
-                    ):
-                        adapter_kind = RasterDatasetAdapter
-                    case MediaType.GEOPACKAGE | MediaType.FLATGEOBUF:
-                        adapter_kind = GeoDataFrameAdapter
-                    case MediaType.GEOJSON:
-                        adapter_kind = GeoDatasetAdapter
-                    case MediaType.JSON:
-                        adapter_kind = DataFrameAdapter
-                    case _:
-                        continue
+                if asset.media_type in [
+                    MediaType.HDF,
+                    MediaType.HDF5,
+                    MediaType.COG,
+                    MediaType.TIFF,
+                ]:
+                    adapter_kind = RasterDatasetAdapter
+                elif asset.media_type in [MediaType.GEOPACKAGE, MediaType.FLATGEOBUF]:
+                    adapter_kind = GeoDataFrameAdapter
+                elif asset.media_type == MediaType.GEOJSON:
+                    adapter_kind = GeoDatasetAdapter
+                elif asset.media_type == MediaType.JSON:
+                    adapter_kind = DataFrameAdapter
+                else:
+                    continue
 
                 adapter = adapter_kind(str(asset.get_absolute_href()))
                 self.add_source(source_name, adapter)

--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """GIS related convenience functions."""
+from __future__ import annotations
+
 import glob
 import logging
 import os

--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -9,7 +9,7 @@ import logging
 import os
 from io import IOBase
 from os.path import dirname
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import geopandas as gpd
 import numpy as np
@@ -69,8 +69,8 @@ GDAL_DRIVER_CODE_MAP = {
 }
 GDAL_EXT_CODE_MAP = {v: k for k, v in GDAL_DRIVER_CODE_MAP.items()}
 
-GPD_TYPES = gpd.GeoDataFrame | gpd.GeoSeries
-GEOM_TYPES = GPD_TYPES | BaseGeometry
+GPD_TYPES = Union[gpd.GeoDataFrame, gpd.GeoSeries]
+GEOM_TYPES = Union[GPD_TYPES, BaseGeometry]
 
 ## GEOM functions
 
@@ -569,7 +569,7 @@ def to_geographic_bbox(bbox, source_crs):
 
 def bbox_from_file_and_filters(
     fn: IOBase,
-    bbox: GEOM_TYPES | None = None,
+    bbox: Union[GEOM_TYPES, None] = None,
     mask: GEOM_TYPES | None = None,
     crs: CRS | None = None,
 ) -> Tuple[float, float, float, float] | None:

--- a/make_env.py
+++ b/make_env.py
@@ -47,7 +47,9 @@ parser.add_argument("profile", default="dev,test", nargs="?")
 parser.add_argument("--output", "-o", default="environment.yml")
 parser.add_argument("--channels", "-c", default=None)
 parser.add_argument("--name", "-n", default=None)
-parser.add_argument("--py-version", "-p", default=None)
+parser.add_argument(
+    "--py-version", "-p", default="3.11", choices=["3.9", "3.10", "3.11"]
+)
 parser.add_argument("-r", "--release", action="store_true")
 args = parser.parse_args()
 
@@ -89,7 +91,7 @@ for dep in deps_to_install:
     else:
         conda_deps.append(dep)
 if args.py_version is not None:
-    conda_deps.append(f"python~={args.py_version}")
+    conda_deps.append(f"python~={args.py_version}.0")
 
 # add pip as a conda dependency if we have pip deps
 if len(pip_deps) > 0:

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@ dev = { depends_on = [
   "dev-install-hydromt",
   "dev-install-pre-commit",
 ] }
-dev-env-file = "python make_env.py full -n hydromt-dev"
+dev-env-file = "python make_env.py full -n hydromt-dev -p 3.9"
 dev-create-mamba-env = "mamba env remove -n hydromt-dev; mamba env create -f environment.yml"
 dev-install-hydromt = "mamba run -n hydromt-dev pip install -e ."
 dev-install-pre-commit = "mamba run -n hydromt-dev pre-commit install"


### PR DESCRIPTION
## Issue addressed
Fixes typing issue when hydromt.gis_utils is loaded in py39

```
ImportError while loading conftest '/home/runner/work/hydromt_sfincs/hydromt_sfincs/tests/conftest.py'.
tests/conftest.py:7: in <module>
    from hydromt_sfincs.sfincs import SfincsModel
hydromt_sfincs/__init__.py:11: in <module>
    from .sfincs import *
hydromt_sfincs/sfincs.py:14: in <module>
    import hydromt
/usr/share/miniconda/envs/hydromt-sfincs-dev/lib/python3.[9](https://github.com/Deltares/hydromt_sfincs/actions/runs/6902656342/job/18779801237?pr=147#step:6:10)/site-packages/hydromt/__init__.py:17: in <module>
    from . import cli, flw, raster, stats, vector, workflows
/usr/share/miniconda/envs/hydromt-sfincs-dev/lib/python3.9/site-packages/hydromt/flw.py:[12](https://github.com/Deltares/hydromt_sfincs/actions/runs/6902656342/job/18779801237?pr=147#step:6:13): in <module>
    from . import gis_utils
/usr/share/miniconda/envs/hydromt-sfincs-dev/lib/python3.9/site-packages/hydromt/gis_utils.py:70: in <module>
    GPD_TYPES = gpd.GeoDataFrame | gpd.GeoSeries
E   TypeError: unsupported operand type(s) for |: 'type' and 'type'
```
https://github.com/Deltares/hydromt_sfincs/actions/runs/6902656342/job/18779801237?pr=147

## Explanation
Adding `from __future__ import annotations` to gis_utils.py
@savente93 @Jaapel Any idea why this error did not appear in our py39 tests? It woud be good to update the tests also in this PR so that we identify these bugs earlier..

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.

