### PR TITLE
Bugfix raster.set_crs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,23 @@ Unreleased
 
 Added
 -----
+
+Changed
+-------
+
+Fixed
+-----
+- Bug in `raster.set_crs` if input_crs is of type CRS. (#659)
+
+Deprecated
+----------
+
+v0.9.1 (2023-11-16)
+===================
+This release contains several bugfixes to 0.9.0 as well two new CLI methods and support for STAC.
+
+Added
+-----
 - Support for exporting data catalogs to STAC catalog formats. (#617)
 - Support for reading data catalogs from STAC catalog formats. (#625)
 - Pixi is now available as an additional task runner. (#634)
@@ -29,9 +46,6 @@ Fixed
 -----
 - Bug in zoom level detection in `RasterDatasetAdapter` for Tifs without overviews and paths with placeholders. (#642)
 - Bug in gis_utils.meridian_offset for grids with rounding errors. (#649)
-
-Deprecated
-----------
 
 v0.9.0 (2023-10-19)
 ===================

--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -296,7 +296,7 @@ class XGeoBase(object):
         # look in grid_mapping and data variable attributes
         elif input_crs is not None and not isinstance(input_crs, CRS):
             raise ValueError(f"Invalid CRS type: {type(input_crs)}")
-        else:
+        elif not isinstance(input_crs, CRS):
             crs = None
             for name in crs_names:
                 # check default > GEO_MAP_COORDS attrs, then global attrs

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -79,6 +79,7 @@ def test_vector(geoda, geodf):
     da1 = geoda.vector.to_crs(3857)
     gdf1 = geodf.to_crs(3857)
     assert np.all(da1.vector.geometry == gdf1.geometry)
+    assert da1.vector.crs == gdf1.crs
 
 
 def test_from_gdf(geoda, geodf):


### PR DESCRIPTION
## Issue addressed
Fixes #613 

## Explanation
Function was modified but did not account that input_crs could be directly of type CRS anymore
Also modified changelog to take into account release 0.9.1

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

