### PR TITLE
avoid lazy spatial ref coordinate

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ Fixed
 - Bug in `raster.set_crs` if input_crs is of type CRS. (#659)
 - Export CLI now actually parses provided geoms. (#660)
 - Bug in stats.skills for computation of pbias and MSE / RMSE. (#666)
+- Fix bug with lazy spatial_ref coordinate (#682)
 
 Deprecated
 ----------

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -334,40 +334,40 @@ def test_reproject():
     kwargs = dict(name="test", crs=4326)
     transform, shape = testdata[1][0], (9, 5, 5)
     da0 = raster.full_from_transform(transform, shape, **kwargs)
-    da0.data = np.random.random(da0.shape)
-    ds0 = da0.to_dataset()
+    # da0.data = np.random.random(da0.shape)
+    # ds0 = da0.to_dataset()
     ds1 = raster.full_from_transform(*testdata[1], **kwargs).to_dataset()
-    da2 = raster.full_from_transform(*testdata[3], **kwargs).to_dataset()
-    assert np.all(ds1.raster.bounds == ds1.raster.transform_bounds(ds1.raster.crs))
-    # test out of bounds -> return empty grid
-    ds2_empty = ds0.raster.reproject_like(da2)
-    assert ds2_empty.raster.identical_grid(da2)
-    assert np.all(np.isnan(ds2_empty))
-    assert ds2_empty.data_vars.keys() == ds0.data_vars.keys()
-    da2_empty = da0.raster.reproject_like(da2)
-    assert np.all(np.isnan(da2_empty))
-    assert da2_empty.raster.identical_grid(da2)
-    assert da2_empty.name == da0.name
-    # flipud
-    assert ds1.raster.flipud().raster.res[1] == -ds1.raster.res[1]
-    # reproject nearest index
-    ds2 = ds1.raster.reproject(dst_crs=3857, method="nearest_index")
-    assert ds2.raster.crs.to_epsg() == 3857
-    ds2 = ds1.raster.reproject(dst_crs=3857, dst_res=1000, align=True)
-    assert np.all(np.asarray(ds2.raster.bounds)) // 1000 == 0
-    ds2 = ds1.raster.reproject(dst_width=4, dst_height=2, method="average")
-    assert np.all(ds2.raster.shape == (2, 4))
-    ds2 = ds1.raster.reproject_like(ds0)
-    assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
-    ds2 = da0.raster.reproject_like(ds1, method="nearest_index")
-    assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
+    # da2 = raster.full_from_transform(*testdata[3], **kwargs).to_dataset()
+    # assert np.all(ds1.raster.bounds == ds1.raster.transform_bounds(ds1.raster.crs))
+    # # test out of bounds -> return empty grid
+    # ds2_empty = ds0.raster.reproject_like(da2)
+    # assert ds2_empty.raster.identical_grid(da2)
+    # assert np.all(np.isnan(ds2_empty))
+    # assert ds2_empty.data_vars.keys() == ds0.data_vars.keys()
+    # da2_empty = da0.raster.reproject_like(da2)
+    # assert np.all(np.isnan(da2_empty))
+    # assert da2_empty.raster.identical_grid(da2)
+    # assert da2_empty.name == da0.name
+    # # flipud
+    # assert ds1.raster.flipud().raster.res[1] == -ds1.raster.res[1]
+    # # reproject nearest index
+    # ds2 = ds1.raster.reproject(dst_crs=3857, method="nearest_index")
+    # assert ds2.raster.crs.to_epsg() == 3857
+    # ds2 = ds1.raster.reproject(dst_crs=3857, dst_res=1000, align=True)
+    # assert np.all(np.asarray(ds2.raster.bounds)) // 1000 == 0
+    # ds2 = ds1.raster.reproject(dst_width=4, dst_height=2, method="average")
+    # assert np.all(ds2.raster.shape == (2, 4))
+    # ds2 = ds1.raster.reproject_like(ds0)
+    # assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
+    # ds2 = da0.raster.reproject_like(ds1, method="nearest_index")
+    # assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
     ds2 = ds1.raster.reproject(dst_crs="utm")
     assert ds2.raster.crs.is_projected
     index = ds1.raster.nearest_index(dst_crs="utm")
-    assert isinstance(index, xr.DataArray)
-    assert np.all(index.values >= -1)  ## -1 for invalid indices (outside domain)
+    # assert isinstance(index, xr.DataArray)
+    # assert np.all(index.values >= -1)  ## -1 for invalid indices (outside domain)
     ds2_index = ds1.raster.reindex2d(index)
-    assert np.all([np.all(ds2_index[c] == ds2[c]) for c in ds2_index.coords])
+    # assert np.all([np.all(ds2_index[c] == ds2[c]) for c in ds2_index.coords])
     # test with chunks
     da2_lazy = da0.chunk({da0.raster.dim0: 3}).raster.reproject(dst_crs="utm")
     assert isinstance(da2_lazy.data, dask.array.core.Array)
@@ -377,6 +377,8 @@ def test_reproject():
     )
     assert isinstance(da2_lazy.data, dask.array.core.Array)
     assert np.all(ds2_index["test"] == da2_lazy.compute())
+    # make sure spatial ref is not lazy
+    assert not isinstance(da2_lazy.spatial_ref.data, dask.array.Array)
     # check error messages
     with pytest.raises(ValueError, match="Resampling method unknown"):
         ds1.raster.reproject(dst_crs=3857, method="unknown")

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -334,40 +334,40 @@ def test_reproject():
     kwargs = dict(name="test", crs=4326)
     transform, shape = testdata[1][0], (9, 5, 5)
     da0 = raster.full_from_transform(transform, shape, **kwargs)
-    # da0.data = np.random.random(da0.shape)
-    # ds0 = da0.to_dataset()
+    da0.data = np.random.random(da0.shape)
+    ds0 = da0.to_dataset()
     ds1 = raster.full_from_transform(*testdata[1], **kwargs).to_dataset()
-    # da2 = raster.full_from_transform(*testdata[3], **kwargs).to_dataset()
-    # assert np.all(ds1.raster.bounds == ds1.raster.transform_bounds(ds1.raster.crs))
-    # # test out of bounds -> return empty grid
-    # ds2_empty = ds0.raster.reproject_like(da2)
-    # assert ds2_empty.raster.identical_grid(da2)
-    # assert np.all(np.isnan(ds2_empty))
-    # assert ds2_empty.data_vars.keys() == ds0.data_vars.keys()
-    # da2_empty = da0.raster.reproject_like(da2)
-    # assert np.all(np.isnan(da2_empty))
-    # assert da2_empty.raster.identical_grid(da2)
-    # assert da2_empty.name == da0.name
-    # # flipud
-    # assert ds1.raster.flipud().raster.res[1] == -ds1.raster.res[1]
-    # # reproject nearest index
-    # ds2 = ds1.raster.reproject(dst_crs=3857, method="nearest_index")
-    # assert ds2.raster.crs.to_epsg() == 3857
-    # ds2 = ds1.raster.reproject(dst_crs=3857, dst_res=1000, align=True)
-    # assert np.all(np.asarray(ds2.raster.bounds)) // 1000 == 0
-    # ds2 = ds1.raster.reproject(dst_width=4, dst_height=2, method="average")
-    # assert np.all(ds2.raster.shape == (2, 4))
-    # ds2 = ds1.raster.reproject_like(ds0)
-    # assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
-    # ds2 = da0.raster.reproject_like(ds1, method="nearest_index")
-    # assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
+    da2 = raster.full_from_transform(*testdata[3], **kwargs).to_dataset()
+    assert np.all(ds1.raster.bounds == ds1.raster.transform_bounds(ds1.raster.crs))
+    # test out of bounds -> return empty grid
+    ds2_empty = ds0.raster.reproject_like(da2)
+    assert ds2_empty.raster.identical_grid(da2)
+    assert np.all(np.isnan(ds2_empty))
+    assert ds2_empty.data_vars.keys() == ds0.data_vars.keys()
+    da2_empty = da0.raster.reproject_like(da2)
+    assert np.all(np.isnan(da2_empty))
+    assert da2_empty.raster.identical_grid(da2)
+    assert da2_empty.name == da0.name
+    # flipud
+    assert ds1.raster.flipud().raster.res[1] == -ds1.raster.res[1]
+    # reproject nearest index
+    ds2 = ds1.raster.reproject(dst_crs=3857, method="nearest_index")
+    assert ds2.raster.crs.to_epsg() == 3857
+    ds2 = ds1.raster.reproject(dst_crs=3857, dst_res=1000, align=True)
+    assert np.all(np.asarray(ds2.raster.bounds)) // 1000 == 0
+    ds2 = ds1.raster.reproject(dst_width=4, dst_height=2, method="average")
+    assert np.all(ds2.raster.shape == (2, 4))
+    ds2 = ds1.raster.reproject_like(ds0)
+    assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
+    ds2 = da0.raster.reproject_like(ds1, method="nearest_index")
+    assert np.all(ds2.raster.xcoords == ds0.raster.xcoords)
     ds2 = ds1.raster.reproject(dst_crs="utm")
     assert ds2.raster.crs.is_projected
     index = ds1.raster.nearest_index(dst_crs="utm")
-    # assert isinstance(index, xr.DataArray)
-    # assert np.all(index.values >= -1)  ## -1 for invalid indices (outside domain)
+    assert isinstance(index, xr.DataArray)
+    assert np.all(index.values >= -1)  ## -1 for invalid indices (outside domain)
     ds2_index = ds1.raster.reindex2d(index)
-    # assert np.all([np.all(ds2_index[c] == ds2[c]) for c in ds2_index.coords])
+    assert np.all([np.all(ds2_index[c] == ds2[c]) for c in ds2_index.coords])
     # test with chunks
     da2_lazy = da0.chunk({da0.raster.dim0: 3}).raster.reproject(dst_crs="utm")
     assert isinstance(da2_lazy.data, dask.array.core.Array)


### PR DESCRIPTION
## Issue addressed
Fixes #680

## Explanation
Somehow with `DataArray.map_blocks` methods turns the spatial_ref coordinate into a dask array. This method is used for reprojection of lazy arrays. When reprojecting from such DataArray the spatial_ref attributes get corrupted (not sure how or why). The solution is to simply avoid the spatial_ref coord to be lazy.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
