### PR TITLE
Write geojson file with WGS84 coordinates in Model.write_geoms()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ Fixed
 - Bug in `raster.set_crs` if input_crs is of type CRS. (#659)
 - Export CLI now actually parses provided geoms. (#660)
 - Bug in stats.skills for computation of pbias and MSE / RMSE. (#666)
+- `Model.write_geoms` now enforces GeoJSON to write coordinates in WGS84 if specified (#510)
 
 Deprecated
 ----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,7 +27,7 @@ Fixed
 - Bug in `raster.set_crs` if input_crs is of type CRS. (#659)
 - Export CLI now actually parses provided geoms. (#660)
 - Bug in stats.skills for computation of pbias and MSE / RMSE. (#666)
-- `Model.write_geoms` now enforces GeoJSON to write coordinates in WGS84 if specified (#510)
+- `Model.write_geoms` ow has an option to write GeoJSON coordinates in WGS84 if specified (#510)
 
 Deprecated
 ----------

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -1259,6 +1259,8 @@ class Model(object, metaclass=ABCMeta):
         fn : str, optional
             filename relative to model root and should contain a {name} placeholder,
             by default 'geoms/{name}.geojson'
+        to_wgs84: bool, optional
+            Option to enforce writing GeoJSONs with WGS84(EPSG:4326) coordinates.
         \**kwargs:
             Additional keyword arguments that are passed to the
             `geopandas.to_file` function.

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -1269,8 +1269,6 @@ class Model(object, metaclass=ABCMeta):
             self.logger.debug("No geoms data found, skip writing.")
             return
         self._assert_write_mode()
-        if "driver" not in kwargs:
-            kwargs.update(driver="GeoJSON")  # default
         for name, gdf in self.geoms.items():
             if not isinstance(gdf, (gpd.GeoDataFrame, gpd.GeoSeries)) or len(gdf) == 0:
                 self.logger.warning(
@@ -1281,8 +1279,11 @@ class Model(object, metaclass=ABCMeta):
             _fn = join(self.root, fn.format(name=name))
             if not isdir(dirname(_fn)):
                 os.makedirs(dirname(_fn))
-            if kwargs.get("driver") == "GeoJSON" and to_wgs84:
-                gdf.to_crs(4326, inplace=True)
+            if to_wgs84 and (
+                kwargs.get("driver") == "GeoJSON"
+                or str(fn).lower().endswith(".geojson")
+            ):
+                gdf = gdf.to_crs(4326)
             gdf.to_file(_fn, **kwargs)
 
     @property

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -1222,7 +1222,7 @@ class Model(object, metaclass=ABCMeta):
             self.logger.warning(f"Replacing geom: {name}")
         if hasattr(self, "crs"):
             # Verify if a geom is set to model crs and if not sets geom to model crs
-            if self.crs.to_epsg() != geom.crs.to_epsg():
+            if self.crs and self.crs != geom.crs:
                 geom.to_crs(self.crs.to_epsg(), inplace=True)
         self._geoms[name] = geom
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -375,18 +375,7 @@ def test_model_write_geoms(tmpdir):
     bbox = box(*[4.221067, 51.949474, 4.471006, 52.073727])
     geom = gpd.GeoDataFrame(geometry=[bbox], crs=4326)
     geom.to_crs(epsg=28992, inplace=True)
-    fn_region = str(join(tmpdir, "region.gpkg"))
-    geom.to_file(fn_region, driver="GPKG")
-    model.data_catalog.from_dict(
-        {
-            "region": {
-                "path": fn_region,
-                "data_type": "GeoDataFrame",
-                "driver": "vector",
-            }
-        }
-    )
-    model.setup_region({"geom": "region"})
+    model.set_geoms(geom=geom, name="region")
     model.write_geoms(to_wgs84=True)
     region_geom = gpd.read_file(str(join(tmpdir, "geoms/region.geojson")))
     assert region_geom.crs.to_epsg() == 4326

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -385,11 +385,9 @@ def test_model_set_geoms(tmpdir):
     bbox = box(*[4.221067, 51.949474, 4.471006, 52.073727])
     geom = gpd.GeoDataFrame(geometry=[bbox], crs=4326)
     geom_28992 = geom.to_crs(epsg=28992)
-    # fn_region = str(join(tmpdir, "region.gpkg"))
-    # geom_28992.to_file(fn_region, driver="GPKG")
     model = Model(root=str(tmpdir), mode="w")
-    model.setup_region({"geom": geom_28992})
-    model.set_geoms(geom, "geom_wgs84")
+    model.setup_region({"geom": geom_28992})  # set model crs based on epsg28992
+    model.set_geoms(geom, "geom_wgs84")  # this should convert the geom crs to epsg28992
     assert model._geoms["geom_wgs84"].crs.to_epsg() == model.crs.to_epsg()
 
 


### PR DESCRIPTION
GeoJSON should be written with WGS84 coordinates according to the [2016 GeoJSON specs](https://datatracker.ietf.org/doc/html/rfc7946). Model.write_geoms() writes the geometries in model CRS normally. I added a option so that write_geoms can write GeoJSONs with WGS84 coordinates.

## Issue addressed
Fixes #510 

## Explanation
Added an to_wgs84 option in Model.write_geoms(). If set to True and the driver is GeoJSON the geometry will be set to EPSG:4326.

Also added a check in set_geoms so that new geometries are set to the model crs if the model has a crs. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
