### PR TITLE
fix meridian offset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ Fixed
 - Export CLI now actually parses provided geoms. (#660)
 - Bug in stats.skills for computation of pbias and MSE / RMSE. (#666)
 - Fix bug with lazy spatial_ref coordinate (#682)
+- Bug in gis_utils.meridian_offset. (#688)
 
 Deprecated
 ----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,7 +28,7 @@ Fixed
 - Export CLI now actually parses provided geoms. (#660)
 - Bug in stats.skills for computation of pbias and MSE / RMSE. (#666)
 - Fix bug with lazy spatial_ref coordinate (#682)
-- Bug in gis_utils.meridian_offset. (#688)
+- Bug in gis_utils.meridian_offset. (#692)
 
 Deprecated
 ----------

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -551,6 +551,12 @@ class RasterDatasetAdapter(DataAdapter):
                     handle_nodata,
                     logger,
                 )
+            # check if bbox is fully covered
+            w, s, e, n = ds.raster.bounds
+            if not (w <= bbox[0] and s <= bbox[1] and e >= bbox[2] and n >= bbox[3]):
+                logger.warning(
+                    f"Dataset does [{w}, {s}, {e}, {n}] does not fully cover bbox [{bbox_str}]"
+                )
 
         return ds
 

--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -306,11 +306,11 @@ def axes_attrs(crs):
 
 
 def meridian_offset(ds, bbox=None):
-    """Shift data along the x-axis of global datasets avoid issues along the 180 meridian.
+    """Shift data along the x-axis of global datasets to avoid issues along the 180 meridian.
 
     Without a bbox the data is shifted to span 180W to 180E.
-    With bbox the data is shifted to span the bbox west to east, also if the bbox
-    crosses the 180 meridian.
+    With bbox the data is shifted to at least span the bbox west to east,
+    also if the bbox crosses the 180 meridian.
 
     Note that this method is only applicable to data that spans 360 degrees longitude
     and is set in a global geographic CRS (WGS84).

--- a/tests/test_gis_utils.py
+++ b/tests/test_gis_utils.py
@@ -41,17 +41,30 @@ def test_affine_to_coords():
 
 
 def test_meridian_offset():
-    # create grid with x from 0-360E
-    transform = from_origin(0, 90, 1, 1)  # upper left corner
-    shape = (180, 360)
-    da = full_from_transform(transform, shape, crs=4326)
-    assert np.allclose(da.raster.origin, np.array([0, 90]))
-    da1 = gu.meridian_offset(da)
-    assert da1.raster.bounds[0] == -180
-    da2 = gu.meridian_offset(da1, bbox=[170, 0, 190, 10])
-    assert da2.raster.bounds[0] == 0
-    da3 = gu.meridian_offset(da1, bbox=[-190, 0, -170, 10])
-    assert da3.raster.bounds[2] == 0
+    # test global grids with different west origins
+    for x0 in [-180, 0, -360, 1]:
+        da = full_from_transform(
+            transform=Affine.identity() * Affine.translation(x0, -90),
+            shape=(180, 360),
+            crs="epsg:4326",
+        )
+        # return W180-E180 grid if no bbox is provided
+        da1 = gu.meridian_offset(da)
+        assert da1.raster.bounds == (-180, -90, 180, 90)
+        # make sure bbox is respected
+        for bbox in [
+            [-2, -2, 2, 2],  # bbox crossing 0
+            [178, -2, 182, 2],  # bbox crossing 180
+            [-10, -2, 190, 2],  # bbox crossing 0 and 180
+            [-190, -2, 170, 2],  # bbox crossing -180
+        ]:
+            da2 = gu.meridian_offset(da, bbox=bbox)
+            assert (
+                da2.raster.bounds[0] <= bbox[0]
+            ), f"{da2.raster.bounds[0]} <= {bbox[0]}"
+            assert (
+                da2.raster.bounds[2] >= bbox[2]
+            ), f"{da2.raster.bounds[2]} >= {bbox[2]}"
 
     # test error
     with pytest.raises(ValueError, match="The method is only applicable to"):

--- a/tests/test_gis_utils.py
+++ b/tests/test_gis_utils.py
@@ -44,7 +44,7 @@ def test_meridian_offset():
     # test global grids with different west origins
     for x0 in [-180, 0, -360, 1]:
         da = full_from_transform(
-            transform=Affine.identity() * Affine.translation(x0, -90),
+            transform=Affine(1.0, 0.0, x0, 0.0, -1.0, 90.0),
             shape=(180, 360),
             crs="epsg:4326",
         )
@@ -56,7 +56,7 @@ def test_meridian_offset():
             [-2, -2, 2, 2],  # bbox crossing 0
             [178, -2, 182, 2],  # bbox crossing 180
             [-10, -2, 190, 2],  # bbox crossing 0 and 180
-            [-190, -2, 170, 2],  # bbox crossing -180
+            [-190, -2, -170, 2],  # bbox crossing -180
         ]:
             da2 = gu.meridian_offset(da, bbox=bbox)
             assert (
@@ -67,7 +67,7 @@ def test_meridian_offset():
             ), f"{da2.raster.bounds[2]} >= {bbox[2]}"
 
     # test error
-    with pytest.raises(ValueError, match="The method is only applicable to"):
+    with pytest.raises(ValueError, match="This method is only applicable to data"):
         gu.meridian_offset(da.raster.clip_bbox([0, 0, 10, 10]))
 
 


### PR DESCRIPTION
## Issue addressed
Fixes #687

## Explanation
The only real check that is required is that the grid is global (i.e., spanning 360 degrees), see also #649. 
Other checks on east and west coordinates are actually not required.
Therefore, the function itself can be largely simplified. 
I've added thorough testing to make sure it works for all use cases I can think off.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
