### PR TITLE
Release 0.9.2

### DIFF
--- a/data/catalogs/changelog.rst
+++ b/data/catalogs/changelog.rst
@@ -15,6 +15,7 @@ changed
 added
 ^^^^^
 - Added waterdemand pcr_globwb dataset
+- Added GADM 4.1 as FlatGeoBuff files to deltares_data catalog (#686)
 
 
 version: 2023.2

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -43,6 +43,12 @@
 
   },
   {
+    "name":"v0.9.2",
+    "version":"0.9.2",
+    "url":"https://deltares.github.io/hydromt/v0.9.2/"
+
+  },
+  {
     "name":"latest",
     "version":"latest",
     "url":"https://deltares.github.io/hydromt/latest/"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,10 +13,22 @@ Unreleased
 
 Added
 -----
+
+Changed
+-------
+
+Fixed
+-----
+
+v0.9.2 (2024-01-09)
+===================
+This release adds additional bug fixes for the meridian offset functinality, and improvements to the new CLI commands.
+
+Added
+-----
 - Export CLI now also accepts time tuples (#660)
 - New stats.skills VE and RSR (#666)
 - Check CLI command can now validate bbox and geom regions (#664)
-- Added GADM 4.1 as FlatGeoBuff files to deltares_data catalog (#686)
 
 Changed
 -------
@@ -33,9 +45,6 @@ Fixed
 - Fix bug with lazy spatial_ref coordinate (#682)
 - Bug in gis_utils.meridian_offset. (#692)
 
-
-Deprecated
-----------
 
 v0.9.1 (2023-11-16)
 ===================

--- a/hydromt/__init__.py
+++ b/hydromt/__init__.py
@@ -1,7 +1,7 @@
 """HydroMT: Automated and reproducible model building and analysis."""
 
 # version number without 'v' at start
-__version__ = "0.9.2.dev"
+__version__ = "0.9.2"
 
 # pkg_resource deprication warnings originate from dependencies
 # so silence them for now


### PR DESCRIPTION
Added
-----
- Export CLI now also accepts time tuples (#660)
- New stats.skills VE and RSR (#666)
- Check CLI command can now validate bbox and geom regions (#664)
- Added GADM 4.1 as FlatGeoBuff files to deltares_data catalog (#686)

Changed
-------
- Export CLI now uses '-s' for source, '-t' for time and '-i' for config. (#660)

Fixed
-----
- Removed deprecated entrypoints library. (#676)
- Bug in `raster.set_crs` if input_crs is of type CRS. (#659)
- Export CLI now actually parses provided geoms. (#660)
- Bug in stats.skills for computation of pbias and MSE / RMSE. (#666)
- `Model.write_geoms` ow has an option to write GeoJSON coordinates in WGS84 if specified (#510)
- Fix bug with lazy spatial_ref coordinate (#682)
- Bug in gis_utils.meridian_offset. (#692)
