### PR TITLE
remove load and caching from docker

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -63,7 +63,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          load: true
           target: ${{ matrix.flavour }} #
           push:  ${{ env.should_publish }}
           tags: deltares/hydromt:${{ env.version }}-${{ matrix.flavour }}
@@ -73,7 +72,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          load: true
           target: ${{ matrix.flavour }} #
           push:  ${{ env.should_publish }}
           tags: deltares/hydromt:${{ env.version }}, deltares/hydromt:latest

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -41,11 +41,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          load: true
           target: full
           tags: hydromt
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Run Tests
         run: docker run --env NUMBA_DISABLE_JIT=1 --rm hydromt pytest


### PR DESCRIPTION
## Issue addressed
Fixes #712 

## Explanation
Tested with a manual workflow and it seems to work. Given how infrequently we have to build docker images I just disabled the caching in the workflow. I think this is fine, the image still built in a couple of minutes. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
