### PR TITLE
geodataframe reading stop opening

### DIFF
--- a/hydromt/gis_utils.py
+++ b/hydromt/gis_utils.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import glob
 import logging
 import os
-from io import IOBase
 from os.path import dirname
 from typing import Optional, Tuple, Union
 
@@ -200,7 +199,9 @@ def filter_gdf(gdf, geom=None, bbox=None, crs=None, predicate="intersects"):
         raise ValueError("Either geom or bbox is required.")
     if not isinstance(geom, BaseGeometry):
         # reproject
-        if gdf.crs is not None and geom.crs != gdf.crs:
+        if geom.crs is None and gdf.crs is not None:
+            geom = geom.set_crs(gdf.crs)
+        elif gdf.crs is not None and geom.crs != gdf.crs:
             geom = geom.to_crs(gdf.crs)
         # convert geopandas to geometry
         geom = geom.unary_union
@@ -595,7 +596,7 @@ def to_geographic_bbox(bbox, source_crs):
 
 
 def bbox_from_file_and_filters(
-    fn: IOBase,
+    fn: str,
     bbox: Union[GEOM_TYPES, None] = None,
     mask: GEOM_TYPES | None = None,
     crs: CRS | None = None,
@@ -610,8 +611,8 @@ def bbox_from_file_and_filters(
 
     Parameters
     ----------
-    fn: IOBase,
-        opened file
+    fn: str,
+        uri to the filename.
     bbox: GeoDataFrame | GeoSeries | BaseGeometry
         bounding box to filter the data while reading
     mask: GeoDataFrame | GeoSeries | BaseGeometry

--- a/hydromt/io.py
+++ b/hydromt/io.py
@@ -626,8 +626,10 @@ def open_vector(
             bbox_shapely = box(*bbox)
         else:
             bbox_shapely = None
-        bbox_reader = gis_utils.bbox_from_file_and_filters(fn, bbox_shapely, geom, crs)
-        gdf = gpd.read_file(fn, bbox=bbox_reader, mode=mode, **kwargs)
+        bbox_reader = gis_utils.bbox_from_file_and_filters(
+            str(fn), bbox_shapely, geom, crs
+        )
+        gdf = gpd.read_file(str(fn), bbox=bbox_reader, mode=mode, **kwargs)
 
     # check geometry type
     if assert_gtype is not None:

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -487,7 +487,7 @@ def test_geodataframe(geodf, tmpdir):
     assert np.all(gdf1 == geodf)
     # testt read shapefile using mask
     mask = gpd.GeoDataFrame({"geometry": [box(*geodf.total_bounds)]})
-    gdf1 = hydromt.open_vector(fn_shp, mask=mask)
+    gdf1 = hydromt.open_vector(fn_shp, geom=mask)
     assert np.all(gdf1 == geodf)
     # test read with buffer
     gdf1 = data_catalog.get_geodataframe(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -55,7 +55,7 @@ def test_open_vector(engine, tmpdir, df, geodf, world):
     gdf1 = hydromt.open_vector(fn_shp, bbox=list(geodf.total_bounds))
     assert np.all(gdf1 == geodf)
     mask = gpd.GeoDataFrame({"geometry": [box(*geodf.total_bounds)]})
-    gdf1 = hydromt.open_vector(fn_shp, mask=mask)
+    gdf1 = hydromt.open_vector(fn_shp, geom=mask)
     assert np.all(gdf1 == geodf)
     # read geopackage
     gdf1 = hydromt.open_vector(fn_gpkg)


### PR DESCRIPTION
## Issue addressed
Fixes #742

## Explanation
Stopped using the `.open` functionality on UPath. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
May break specific UPath options on other filesystems, but UPath breaks with geopandas. Should wait for v1 fix