### PR TITLE
Add datacatalog test script

### DIFF
--- a/data/catalogs/test_data_catalog.py
+++ b/data/catalogs/test_data_catalog.py
@@ -23,6 +23,7 @@ import argparse
 import json
 
 from dask.distributed import Client
+from pydantic_core import ValidationError
 
 from hydromt import DataCatalog
 from hydromt.log import setuplog
@@ -114,5 +115,9 @@ if __name__ == "__main__":
         test_data_catalog(args, datacatalog)
     # Validate data catalog yaml
     logger.info("Validating data catalog")
-    DataCatalogValidator().from_yml(args.data_catalog)
-    logger.info("Data catalog is valid!")
+    try:
+        DataCatalogValidator().from_yml(args.data_catalog)
+        logger.info("Data catalog is valid!")
+    except ValidationError as e:
+        logger.error("Data catalog is not valid!")
+        logger.error(e)

--- a/data/catalogs/test_data_catalog.py
+++ b/data/catalogs/test_data_catalog.py
@@ -1,10 +1,13 @@
 """Script for testing predefined data catalogs."""
 import argparse
-import os
+
+from dask.distributed import Client
 
 from hydromt import DataCatalog
 from hydromt.log import setuplog
+from hydromt.validators.data_catalog import DataCatalogValidator
 
+client = Client(processes=False)
 logger = setuplog()
 
 parser = argparse.ArgumentParser("Test predefined data catalog")
@@ -13,8 +16,15 @@ parser.add_argument(
     "-ds", "--dataset", help="The name of the dataset to test", required=False
 )
 parser.add_argument(
-    "-dsv" "--dataset_version",
+    "-dsv",
+    "--dataset_version",
     help="Optional version of the dataset to test for",
+    required=False,
+)
+parser.add_argument(
+    "-bbox",
+    "--boundingbox",
+    help="Bounding box for testing clipping spatial data",
     required=False,
 )
 
@@ -23,21 +33,50 @@ datacatalog = DataCatalog(data_libs=args.data_catalog)
 error_count = 0
 
 if args.dataset:
-    # test dataset
+    source = datacatalog.get_source(source=args.dataset, version=args.dataset_version)
+    if args.boundingbox:
+        bbox = args.boundingbox
+    else:
+        bbox = [
+            4.333409,
+            51.962159,
+            4.42835,
+            52.006873,
+        ]  # small area surrounding Deltares Delft office
+    logger.info(
+        f"Retrieving {args.dataset} {source.data_type} and clipping by {bbox} bounding box"
+    )
+    if source.data_type == "GeoDataFrame":
+        dataset = datacatalog.get_geodataframe(args.dataset, bbox=bbox)
+    elif source.data_type == "GeoDataset":
+        dataset = datacatalog.get_geodataset(args.dataset, bbox=bbox)
+    elif source.data_type == "RasterDataset":
+        dataset = datacatalog.get_rasterdataset(args.dataset, bbox=bbox)
+    elif source.data_type == "DataFrame":
+        dataset = datacatalog.get_dataframe(args.dataset)
+    elif source.data_type == "Dataset":
+        dataset = datacatalog.get_dataset(args.dataset)
+
     pass
 
-logger.info("Checking paths of data catalog sources")
-for source in datacatalog.sources.keys():
-    logger.info(f"Checking paths of {source}")
-    paths = datacatalog.get_source(source)._resolve_paths()
-    for path in paths:
+else:
+    logger.info("Checking paths of data catalog sources")
+    for source in datacatalog.get_source_names():
         try:
-            assert os.path.exists(path)
-        except AssertionError:
+            logger.info(f"Checking paths of {source}")
+            paths = datacatalog.get_source(source)._resolve_paths()
+        except FileNotFoundError as e:
+            logger.error(f"File not found for dataset source {source}: {e}")
+
             error_count += 1
-            logger.error(f"{source} file not found in path: {path}")
+        except ValueError as e:
+            logger.error(
+                f"Something went wrong with creating path string for dataset source {source}: {e}"
+            )
+            error_count += 1
+    logger.info(f"Encountered {error_count} errors")
 
 
-# Use resolve paths to check if the files exist
-# Validate data catalog yaml with hydromt.validators.data_catalog
-logger.info(f"Encountered {error_count} errors")
+# Validate data catalog yaml
+logger.info("Validating data catalog")
+DataCatalogValidator().from_yml(args.data_catalog)

--- a/data/catalogs/test_data_catalog.py
+++ b/data/catalogs/test_data_catalog.py
@@ -10,9 +10,10 @@ Separate data catalog sources can be tested by giving the dataset source name as
 an extra argument. The argument should be preceded by -ds. It is also possible to specify
 the version of the dataset source by supplying the call with a -dsv flag and version
 number. The dataset is opened and if the dataset contains geo data the dataset is clipped
-to a small bounding box surrounding Deltares Delft office.
+to a small bounding box surrounding Deltares Delft office ( 4.333409, 51.962159,
+4.42835, 52.006873,).
 Example dataset source test call:
-    'python test_data_catalog.py path/to/datacatalog.yml -ds chelsa -dsv 1.2
+    'python test_data_catalog.py path/to/datacatalog.yml -d chelsa -v 1.2
     -r "{'bbox':[4.333409,51.962159,4.42835,52.006873]}"'
 
 In addition the passed data catalog yaml is checked if it is a valid data catalog yaml.
@@ -26,9 +27,6 @@ from dask.distributed import Client
 from hydromt import DataCatalog
 from hydromt.log import setuplog
 from hydromt.validators.data_catalog import DataCatalogValidator
-
-client = Client(processes=False)
-logger = setuplog()
 
 
 def test_dataset(args, datacatalog):
@@ -82,17 +80,20 @@ def test_data_catalog(args, datacatalog):
                 f"Something went wrong with creating path string for dataset source {source}: {e}"
             )
             error_count += 1
-    logger.info(f"Encountered {error_count} errors")
+    if error_count > 0:
+        logger.error(f"Encountered {error_count} errors")
 
 
 if __name__ == "__main__":
+    client = Client(processes=False)
+    logger = setuplog()
     parser = argparse.ArgumentParser("Test predefined data catalog")
     parser.add_argument("data_catalog", help="The data catalog to test")
     parser.add_argument(
-        "-ds", "--dataset", help="The name of the dataset to test", required=False
+        "-d", "--dataset", help="The name of the dataset to test", required=False
     )
     parser.add_argument(
-        "-dsv",
+        "-v",
         "--dataset_version",
         help="Optional version of the dataset to test for",
         required=False,

--- a/data/catalogs/test_data_catalog.py
+++ b/data/catalogs/test_data_catalog.py
@@ -1,7 +1,11 @@
 """Script for testing predefined data catalogs."""
 import argparse
+import os
 
 from hydromt import DataCatalog
+from hydromt.log import setuplog
+
+logger = setuplog()
 
 parser = argparse.ArgumentParser("Test predefined data catalog")
 parser.add_argument("data_catalog", help="The data catalog to test")
@@ -16,9 +20,24 @@ parser.add_argument(
 
 args = parser.parse_args()
 datacatalog = DataCatalog(data_libs=args.data_catalog)
+error_count = 0
 
 if args.dataset:
     # test dataset
     pass
 
+logger.info("Checking paths of data catalog sources")
+for source in datacatalog.sources.keys():
+    logger.info(f"Checking paths of {source}")
+    paths = datacatalog.get_source(source)._resolve_paths()
+    for path in paths:
+        try:
+            assert os.path.exists(path)
+        except AssertionError:
+            error_count += 1
+            logger.error(f"{source} file not found in path: {path}")
+
+
+# Use resolve paths to check if the files exist
 # Validate data catalog yaml with hydromt.validators.data_catalog
+logger.info(f"Encountered {error_count} errors")

--- a/data/catalogs/test_new_datacatalog_item.py
+++ b/data/catalogs/test_new_datacatalog_item.py
@@ -1,0 +1,24 @@
+"""Script for testing predefined data catalogs."""
+import argparse
+
+from hydromt import DataCatalog
+
+parser = argparse.ArgumentParser("Test predefined data catalog")
+parser.add_argument("data_catalog", help="The data catalog to test")
+parser.add_argument(
+    "-ds", "--dataset", help="The name of the dataset to test", required=False
+)
+parser.add_argument(
+    "-dsv" "--dataset_version",
+    help="Optional version of the dataset to test for",
+    required=False,
+)
+
+args = parser.parse_args()
+datacatalog = DataCatalog(data_libs=args.data_catalog)
+
+if args.dataset:
+    # test dataset
+    pass
+
+# Validate data catalog yaml with hydromt.validators.data_catalog

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Unreleased
 
 Added
 -----
+- Test script for testing predefined catalogs locally. (#735)
 
 Changed
 -------


### PR DESCRIPTION
## Issue addressed
Fixes #735 

## Explanation
I made a script for testing the predefined data catalogs. It works with command line arguments. For instance this call will test the chelsa dataset source of version 1.2:

`python path/to/datacatalog.yml -d chelsa -v 1.2`

This call will open the dataset and clip the dataset to a small bounding box if the dataset contains geo data. This can take some time. It also possible to supply your own bounding box with the -r flag. Bounding box must be a dict containing a list of xmin, ymin, xmax, ymax coordinates in EPSG 4326.

The script can also check if all the paths mentioned in the data catalog exist. This is done by calling the script and giving only the path to the data catalog.
The script will also always check if the given .yml is a valid data catalog.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Let me know if you have more ideas for testing the dataset sources.
