### PR TITLE
Datacatalog to csv

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Unreleased
 Added
 -----
 - Test script for testing predefined catalogs locally. (#735)
+- Option to write a data catalog to a csv file (#425)
 
 Changed
 -------

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -600,6 +600,8 @@ class Model(object, metaclass=ABCMeta):
             If True, export only data entries kept in used_data list. By default True
         append: bool, optional
             If True, append to an existing
+        save_csv: bool, optional
+            If True, save the data catalog also as an csv table. By default False.
         """
         path = data_lib_fn if isabs(data_lib_fn) else join(self.root, data_lib_fn)
         cat = DataCatalog(logger=self.logger, fallback_lib=None)

--- a/hydromt/models/model_api.py
+++ b/hydromt/models/model_api.py
@@ -584,6 +584,7 @@ class Model(object, metaclass=ABCMeta):
         data_lib_fn: StrPath = "hydromt_data.yml",
         used_only: bool = True,
         append: bool = True,
+        save_csv: bool = False,
     ):
         """Write the data catalog to data_lib_fn.
 
@@ -611,6 +612,12 @@ class Model(object, metaclass=ABCMeta):
         # write data catalog
         if cat.sources:
             self._assert_write_mode()
+            if save_csv:
+                csv_path = os.path.splitext(path)[0] + ".csv"
+                cat.to_dataframe().reset_index().to_csv(
+                    csv_path, sep=",", index=False, header=True
+                )
+
             cat.to_yml(path, root=root)
 
     # model configuration

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -167,7 +167,10 @@ def test_write_data_catalog(tmpdir):
     # test writing table of datacatalog as csv
     model.write_data_catalog(used_only=False, save_csv=True)
     assert isfile(join(model.root, "hydromt_data.csv"))
-    assert not pd.read_csv(join(model.root, "hydromt_data.csv")).empty
+    data_catalog_df = pd.read_csv(join(model.root, "hydromt_data.csv"))
+    assert len(data_catalog_df) == len(sources)
+    assert data_catalog_df.iloc[0, 0] == sources[0]
+    assert data_catalog_df.iloc[-1, 0] == sources[-1]
 
 
 def test_model(model, tmpdir):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,6 +6,7 @@ from os.path import abspath, dirname, isfile, join
 
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from shapely.geometry import box
@@ -163,6 +164,10 @@ def test_write_data_catalog(tmpdir):
     model1.data_catalog.get_source(sources[0]).mark_as_used()
     model1.write_data_catalog(append=True)
     assert list(DataCatalog(data_lib_fn).sources.keys()) == sources[:2]
+    # test writing table of datacatalog as csv
+    model.write_data_catalog(used_only=False, save_csv=True)
+    assert isfile(join(model.root, "hydromt_data.csv"))
+    assert not pd.read_csv(join(model.root, "hydromt_data.csv")).empty
 
 
 def test_model(model, tmpdir):


### PR DESCRIPTION
## Issue addressed
Fixes #425 

## Explanation
Added a save_csv option to Model.write_data_catalog.
## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [ ] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
