### PR TITLE
fix COG zoom level bug

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Fixed
 - Reading Vector formats that consist of more than one file via geopandas. (#691)
 - Handle NoDataStrategy consistently when reading data in adapters (#738)
 - add option to ignore empty data sets when exporting data (#743)
+- Fix bug when reading COGs at requested zoom level (#758)
 
 v0.9.2 (2024-01-09)
 ===================

--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -2111,7 +2111,7 @@ class RasterDataArray(XRasterBase):
                 # out of bounds -> return empty array
                 if isinstance(other, xr.Dataset):
                     other = other[list(other.data_vars.keys())[0]]
-                da = full_like(other, nodata=self.nodata)
+                da = full_like(other.astype(da_clip.dtype), nodata=self.nodata)
                 da.name = self._obj.name
             else:
                 da = da_clip.raster.reproject(

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -178,14 +178,12 @@ def test_rasterdataset_zoomlevels(rioda_large, tmpdir):
     cog_fn = str(tmpdir.join("test_cog.tif"))
     rioda_large.raster.to_raster(cog_fn, driver="COG", overviews="auto")
     # test COG zoom levels
+    # return native resolution
     res = np.asarray(rioda_large.raster.res)
-    da1 = data_catalog.get_rasterdataset(
-        cog_fn, zoom_level=0
-    )  # return native resolution
+    da1 = data_catalog.get_rasterdataset(cog_fn, zoom_level=0)
     assert np.allclose(da1.raster.res, res)
-    da1 = data_catalog.get_rasterdataset(
-        cog_fn, zoom_level=(res[0] * 2, "degree")
-    )  # reurn zl 1
+    # reurn zoom level 1
+    da1 = data_catalog.get_rasterdataset(cog_fn, zoom_level=(res[0] * 2, "degree"))
     assert np.allclose(da1.raster.res, res * 2)
     # test if file hase no overviews
     tif_fn = str(tmpdir.join("test_tif_no_overviews.tif"))

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -178,9 +178,15 @@ def test_rasterdataset_zoomlevels(rioda_large, tmpdir):
     cog_fn = str(tmpdir.join("test_cog.tif"))
     rioda_large.raster.to_raster(cog_fn, driver="COG", overviews="auto")
     # test COG zoom levels
-    da1 = data_catalog.get_rasterdataset(cog_fn, zoom_level=(0.01, "degree"))
-    assert da1.raster.shape == (256, 250)
-    assert len(data_catalog.get_source("test_cog.tif").zoom_levels) == 3
+    res = np.asarray(rioda_large.raster.res)
+    da1 = data_catalog.get_rasterdataset(
+        cog_fn, zoom_level=0
+    )  # return native resolution
+    assert np.allclose(da1.raster.res, res)
+    da1 = data_catalog.get_rasterdataset(
+        cog_fn, zoom_level=(res[0] * 2, "degree")
+    )  # reurn zl 1
+    assert np.allclose(da1.raster.res, res * 2)
     # test if file hase no overviews
     tif_fn = str(tmpdir.join("test_tif_no_overviews.tif"))
     rioda_large.raster.to_raster(tif_fn, driver="GTiff")

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -348,6 +348,7 @@ def test_reproject():
     assert np.all(np.isnan(da2_empty))
     assert da2_empty.raster.identical_grid(da2)
     assert da2_empty.name == da0.name
+    assert da2_empty.dtype == da0.dtype
     # flipud
     assert ds1.raster.flipud().raster.res[1] == -ds1.raster.res[1]
     # reproject nearest index


### PR DESCRIPTION
## Issue addressed
Fixes #754

## Explanation
When reading GOCs, the `rioxarray.open_raster(..., overview_level=0)` opens the first overview which is zoom_level 1. To read the native resolution the `overview_level` level argument should not be used, and for actual zoom levels we can use `overview_level = zoom_level - 1`

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
