### PR TITLE
fix workflows and enable windows testing

### DIFF
--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.9','3.10','3.11']
-    name: py ${{ matrix.python-version }}
+    name: py ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     # note absence of cucurrency, this one should only be run one at a time
     steps:
@@ -52,7 +52,7 @@ jobs:
           path: |
             /usr/share/miniconda3
             ~/pycache
-          key: test-py${{ matrix.python-version }}-${{ hashFiles('environment.yml')  }}
+          key: test-py${{ matrix.python-version }}-${{ matrix.os }}-${{ hashFiles('environment.yml')  }}
         id: test-cache
 
   rebuild-docs-cache:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, v1]
     paths:
       - tests/*
       - hydromt/*
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
     paths:
       - tests/*
       - hydromt/*
@@ -27,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.9','3.10','3.11']
     name: py ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.python-version }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ matrix.python-version }}-${{ matrix.os}}-${{ github.ref }}
       cancel-in-progress: true
     steps:
 


### PR DESCRIPTION
## Issue addressed
N/A

## Explanation
Currently the tests are not run properly on the v1 branches. In addition because of how the caching works they cannot test on windows which is required for the cross platform tests. This should enable that. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
