### PR TITLE
Release v0.9.3

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,57 +1,52 @@
 [
-
   {
-    "name":"v0.5.0",
-    "version":"0.5.0",
-    "url":"https://deltares.github.io/hydromt/v0.5.0/"
-
+    "name": "v0.5.0",
+    "version": "0.5.0",
+    "url": "https://deltares.github.io/hydromt/v0.5.0/"
   },
   {
-    "name":"v0.6.0",
-    "version":"0.6.0",
-    "url":"https://deltares.github.io/hydromt/v0.6.0/"
-
+    "name": "v0.6.0",
+    "version": "0.6.0",
+    "url": "https://deltares.github.io/hydromt/v0.6.0/"
   },
   {
-    "name":"v0.7.0",
-    "version":"0.7.0",
-    "url":"https://deltares.github.io/hydromt/v0.7.0/"
-
+    "name": "v0.7.0",
+    "version": "0.7.0",
+    "url": "https://deltares.github.io/hydromt/v0.7.0/"
   },
   {
-    "name":"v0.7.1",
-    "version":"0.7.1",
-    "url":"https://deltares.github.io/hydromt/v0.7.1/"
-
+    "name": "v0.7.1",
+    "version": "0.7.1",
+    "url": "https://deltares.github.io/hydromt/v0.7.1/"
   },
   {
-    "name":"v0.8.0",
-    "version":"0.8.0",
-    "url":"https://deltares.github.io/hydromt/v0.8.0/"
-
+    "name": "v0.8.0",
+    "version": "0.8.0",
+    "url": "https://deltares.github.io/hydromt/v0.8.0/"
   },
   {
-    "name":"v0.9.0",
-    "version":"0.9.0",
-    "url":"https://deltares.github.io/hydromt/v0.9.0/"
-
+    "name": "v0.9.0",
+    "version": "0.9.0",
+    "url": "https://deltares.github.io/hydromt/v0.9.0/"
   },
   {
-    "name":"v0.9.1",
-    "version":"0.9.1",
-    "url":"https://deltares.github.io/hydromt/v0.9.1/"
-
+    "name": "v0.9.1",
+    "version": "0.9.1",
+    "url": "https://deltares.github.io/hydromt/v0.9.1/"
   },
   {
-    "name":"v0.9.2",
-    "version":"0.9.2",
-    "url":"https://deltares.github.io/hydromt/v0.9.2/"
-
+    "name": "v0.9.2",
+    "version": "0.9.2",
+    "url": "https://deltares.github.io/hydromt/v0.9.2/"
   },
   {
-    "name":"latest",
-    "version":"latest",
-    "url":"https://deltares.github.io/hydromt/latest/"
-
+    "name": "v0.9.3",
+    "version": "0.9.3",
+    "url": "https://deltares.github.io/hydromt/v0.9.3/"
+  },
+  {
+    "name": "latest",
+    "version": "latest",
+    "url": "https://deltares.github.io/hydromt/latest/"
   }
 ]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,16 +8,14 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 
 
 
-Unreleased
-==========
+v0.9.3 (2024-02-08)
+===================
+This release fixes several bugs. Most notably the `NoDataSrategy` is available in much more data reading methods so plugins can use it more directly. Additionally there are some bug fixes relating to reading shapefiles and reading COGs.
 
 Added
 -----
 - Test script for testing predefined catalogs locally. (#735)
 - Option to write a data catalog to a csv file (#425)
-
-Changed
--------
 
 Fixed
 -----

--- a/hydromt/__init__.py
+++ b/hydromt/__init__.py
@@ -1,7 +1,7 @@
 """HydroMT: Automated and reproducible model building and analysis."""
 
 # version number without 'v' at start
-__version__ = "0.9.3.dev0"
+__version__ = "0.9.3"
 
 # pkg_resource deprication warnings originate from dependencies
 # so silence them for now


### PR DESCRIPTION
This release fixes several bugs. Most notably the `NoDataSrategy` is available in much more data reading methods so plugins can use it more directly. Additionally there are some bug fixes relating to reading shapefiles and reading COGs.