### PR TITLE
Fix windows tests

### DIFF
--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -6,6 +6,11 @@ on:
     - cron: 0 0 * * Sun # run on main every sunday at 00:00
   workflow_dispatch:
 
+# only one of this flow should run at the same time.
+concurrency:
+  group: refresh-ci-cache
+  cancel-in-progress: true
+
 jobs:
   clear-cache:
     uses: ./.github/workflows/purge_all_caches.yml
@@ -19,13 +24,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9','3.10','3.11']
+        include:
+          - os: windows-latest
+            miniconda-path: C:\Users\runneradmin\miniconda3
+            pycache-path: C:\Users\runneradmin\pycache
+          - os: ubuntu-latest
+            miniconda-path: ~/miniconda3
+            pycache-path: ~/pycache
     name: py ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # note absence of cucurrency, this one should only be run one at a time
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
             python-version: ${{ matrix.python-version }}
             miniforge-variant: Mambaforge
@@ -36,22 +47,23 @@ jobs:
         run: |
           pip install tomli
           python make_env.py test,io,extra -p ${{ matrix.python-version}} -n hydromt
+          # here we used the conda-incubator action so we cna just use mamba normally
           mamba env create -f environment.yml
           mamba run -n hydromt pip install -e .
 
       # run tests first so that we can also cache all of the artefacts
+      # here we used the original mamba action so mamba is in our path
       - name: Test
         run: |
           export NUMBA_DISABLE_JIT=1
-          PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt python -m pytest --verbose --cov=hydromt --cov-report xml
+          PYTHONPYCACHEPREFIX=${{ matrix.pycache-path }} mamba run -n hydromt python -m pytest --verbose --cov=hydromt --cov-report xml
 
       - name: Upload cache
-        uses: actions/cache/save@v3
-        if: always()
+        uses: actions/cache/save@v4
         with:
           path: |
-            /usr/share/miniconda3
-            ~/pycache
+            ${{ matrix.miniconda-path }}
+            ${{ matrix.pycache-path }}
           key: test-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('environment.yml')  }}
         id: test-cache
 
@@ -61,14 +73,16 @@ jobs:
       run:
         shell: bash -l {0}
     runs-on: ubuntu-latest
+    # for docs platform doesn't matter (yet) so we just run that on ubuntu
+    # as it's much much faster than windows
     env:
       DOC_PYTHON_VERSION: '3.11'
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
             python-version: ${{ env.DOC_PYTHON_VERSION }}
             miniforge-variant: Mambaforge
@@ -79,21 +93,19 @@ jobs:
       - name: Setup env
         run: |
           pip install tomli
-          python make_env.py test,io,extra,doc -p $DOC_PYTHON_VERSION -n hydromt
+          python make_env.py test,io,extra,doc -p ${{ env.DOC_PYTHON_VERSION }} -n hydromt
           mamba env create -f environment.yml
           mamba run -n hydromt pip install -e .
 
       # run tests first so that we can also cache all of the artefacts
       - name: Generate docs
-        run: PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt sphinx-build -M html ./docs ./docs/_build
+        run: mamba run -n hydromt sphinx-build docs/source docs/_build
 
       - name: Upload cache
-        uses: actions/cache/save@v3
-        if: always()
+        uses: actions/cache/save@v4
         with:
           path: |
-            /usr/share/miniconda3
-            ~/pycache
-            ./docs/_build
+            ~/miniconda3
+            ~/docs/_build
           key: docs-${{ hashFiles('environment.yml')  }}
         id: docs-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,11 +85,11 @@ jobs:
           export PATH=/usr/share/miniconda3/bin:$PATH
           mamba env update -n hydromt -f environment.yml
 
-      - name: Conda info
-        run: |
-          export PATH=/usr/share/miniconda3/bin:$PATH
-          conda info
-          conda list -n hydromt
+      # - name: Conda info
+      #   run: |
+      #     export PATH=/usr/share/miniconda3/bin:$PATH
+      #     conda info
+      #     conda list -n hydromt
 
       - name: Test
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,14 +2,10 @@ name: Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
   push:
-    branches: [main, v1]
+    branches:
+      - main
+      - v1
     paths:
       - tests/*
       - hydromt/*
@@ -36,32 +32,44 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9','3.10','3.11']
+        include:
+          - os: windows-latest
+            # this mamba path will be interpreted by bash instead of the file system
+            # hence the double \\ are necessary
+            mamba-path: C:\\Users\\runneradmin\\miniconda3\\condabin\\mamba
+            miniconda-path: C:\Users\runneradmin\miniconda3
+            pycache-path: C:\Users\runneradmin\pycache
+          - os: ubuntu-latest
+            miniconda-path: ~/miniconda3
+            mamba-path: ~/miniconda3/condabin/mamba
+            pycache-path: ~/pycache
+
     name: py ${{ matrix.python-version }} (${{ matrix.os}})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.python-version }}-${{ matrix.os}}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ matrix.os}}-${{ matrix.python-version }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # we need environment.yml to see if we have a cache hit
       - name: Generate env spec
         run: pip install tomli && python make_env.py test,io,extra -p ${{ matrix.python-version}} -n hydromt
 
+
       - name: load from cache
         id: cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
-            /usr/share/miniconda3
-            ~/pycache
-          # the below two settings mean we'll alway srestore the cache
+            ${{ matrix.miniconda-path }}
+            ${{ matrix.pycache-path }}
+          # the below two settings mean we'll always restore the cache
           # but the cache hit output can tell us if we have to update afterwards
           key: test-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('environment.yml')  }}
           restore-keys: |
-            test-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('environment.yml')  }}
             test-${{ matrix.os }}-py${{ matrix.python-version }}
             test-${{ matrix.os }}
 
@@ -78,21 +86,23 @@ jobs:
 
       # by avoiding the mamba setup stage by loading it from cache instead we save
       # a lot of setup time, but we do have to do our own PATH management
-      # hence the exports
+      # hence the matrix variable
       - name: Update environment
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          export PATH=/usr/share/miniconda3/bin:$PATH
-          mamba env update -n hydromt -f environment.yml
+          ${{ matrix.miniconda-path }} env update -n hydromt -f environment.yml
 
-      # - name: Conda info
-      #   run: |
-      #     export PATH=/usr/share/miniconda3/bin:$PATH
-      #     conda info
-      #     conda list -n hydromt
+      - name: Conda info
+        run: |
+          ${{ matrix.mamba-path }} info
+          ${{ matrix.mamba-path }} list -n hydromt
 
       - name: Test
         run: |
-          export PATH=/usr/share/miniconda3/bin:$PATH
           export NUMBA_DISABLE_JIT=1
-          PYTHONPYCACHEPREFIX=~/pycache mamba run -n hydromt python -m pytest --verbose --cov=hydromt --cov-report xml
+          ${{ matrix.mamba-path }} run -n hydromt python -m pytest --verbose --cov=hydromt --cov-report xml
+
+      # enable for CI debugging
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -126,7 +126,9 @@ def test_aws_worldcover():
     assert da.name == "landuse"
 
 
-@pytest.mark.skipif(system() == "Windows", reason="Temprorarily disable failing test")
+@pytest.mark.skipif(
+    system() == "Windows", reason="fails due to expired certificate at dest"
+)
 def test_http_data():
     dc = DataCatalog().from_dict(
         {


### PR DESCRIPTION
## Issue addressed
Fixes #774 

## Explanation
adjusting the mamba setup to work with the windows runner. The workflows need a cache that can't be generated until this PR is merged, so testing for now will be limited, but I did the testing in another repo where it worked, so it should all be good.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
