### PR TITLE
Data Catalog roots

### DIFF
--- a/data/catalogs/artifact_data.yml
+++ b/data/catalogs/artifact_data.yml
@@ -1,7 +1,8 @@
 meta:
   version: v0.0.8
-  hydromt_version: '>=0.9, <1.0'
-  root: https://github.com/DirkEilander/hydromt-artifacts/releases/download/0.0.8/data.tar.gz
+  hydromt_version: '>=1.0, <2.0'
+  roots:
+    - https://github.com/DirkEilander/hydromt-artifacts/releases/download/0.0.8/data.tar.gz
 
 chelsa:
   crs: 4326

--- a/data/catalogs/artifact_data.yml
+++ b/data/catalogs/artifact_data.yml
@@ -266,7 +266,7 @@ gebco:
     unit: m+MSL
   path: gebco.tif
 ghs-smod_2015_v2:
-  crs: 54009
+  crs: ESRI:54009
   data_type: RasterDataset
   driver: raster
   meta:
@@ -292,7 +292,7 @@ ghs_pop_2015:
     source_version: R2019A_v1.0
   path: ghs_pop_2015.tif
 ghs_pop_2015_54009:
-  crs: 54009
+  crs: ESRI:54009
   data_type: RasterDataset
   driver: raster
   meta:
@@ -303,7 +303,7 @@ ghs_pop_2015_54009:
     source_url: https://ghsl.jrc.ec.europa.eu/download.php?ds=pop
   path: ghs_pop_2015_54009.tif
 ghs_smod_2015:
-  crs: 54009
+  crs: ESRI:54009
   data_type: RasterDataset
   driver: raster
   meta:

--- a/data/catalogs/artifact_data.yml
+++ b/data/catalogs/artifact_data.yml
@@ -1,6 +1,6 @@
 meta:
   version: v0.0.8
-  hydromt_version: '>=1.0, <2.0'
+  hydromt_version: '>=1.0a, <2.0'
   roots:
     - https://github.com/DirkEilander/hydromt-artifacts/releases/download/0.0.8/data.tar.gz
 

--- a/data/catalogs/aws_data.yml
+++ b/data/catalogs/aws_data.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   version: 2024.1.30
-  hydromt_version: '>=0.9, <1.0'
+  hydromt_version: '>=1.0, <2.0'
 
 
 esa_worldcover_2020_v100:

--- a/data/catalogs/aws_data.yml
+++ b/data/catalogs/aws_data.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   version: 2024.1.30
-  hydromt_version: '>=1.0a, <2.0'
+  hydromt_version: '>=0.9, <2.0'
 
 
 esa_worldcover_2020_v100:

--- a/data/catalogs/aws_data.yml
+++ b/data/catalogs/aws_data.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   version: 2024.1.30
-  hydromt_version: '>=1.0, <2.0'
+  hydromt_version: '>=1.0a, <2.0'
 
 
 esa_worldcover_2020_v100:

--- a/data/catalogs/deltares_data.yml
+++ b/data/catalogs/deltares_data.yml
@@ -4,7 +4,7 @@ meta:
     - p:/wflow_global/hydromt
     - /mnt/p/wflow_global/hydromt
   version: 2024.1.30
-  hydromt_version: '>=1.0, <2.0'
+  hydromt_version: '>=1.0a, <2.0'
 
 
 basin_atlas_level12_v10:

--- a/data/catalogs/deltares_data.yml
+++ b/data/catalogs/deltares_data.yml
@@ -3,6 +3,7 @@ meta:
   roots:
     - p:/wflow_global/hydromt
     - /mnt/p/wflow_global/hydromt
+    - /p/wflow_global/hydromt
   version: 2024.1.30
   hydromt_version: '>=1.0a, <2.0'
 

--- a/data/catalogs/deltares_data.yml
+++ b/data/catalogs/deltares_data.yml
@@ -2,6 +2,7 @@
 meta:
   roots:
     - p:/wflow_global/hydromt
+    - /mnt/p/wflow_global/hydromt
   version: 2024.1.30
   hydromt_version: '>=0.9, <1.0'
 

--- a/data/catalogs/deltares_data.yml
+++ b/data/catalogs/deltares_data.yml
@@ -1,6 +1,7 @@
 ---
 meta:
-  root: p:/wflow_global/hydromt
+  roots:
+    - p:/wflow_global/hydromt
   version: 2024.1.30
   hydromt_version: '>=0.9, <1.0'
 

--- a/data/catalogs/deltares_data.yml
+++ b/data/catalogs/deltares_data.yml
@@ -4,7 +4,7 @@ meta:
     - p:/wflow_global/hydromt
     - /mnt/p/wflow_global/hydromt
   version: 2024.1.30
-  hydromt_version: '>=0.9, <1.0'
+  hydromt_version: '>=1.0, <2.0'
 
 
 basin_atlas_level12_v10:

--- a/data/catalogs/gcs_cmip6_data.yml
+++ b/data/catalogs/gcs_cmip6_data.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   version: 2024.1.30
-  hydromt_version: '>=0.8.1, <1.0'
+  hydromt_version: '>=1.0, <2.0'
 
 cmip6_{model}_historical_{member}_{timestep}:
   crs: 4326

--- a/data/catalogs/gcs_cmip6_data.yml
+++ b/data/catalogs/gcs_cmip6_data.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   version: 2024.1.30
-  hydromt_version: '>=1.0a, <2.0'
+  hydromt_version: '>=0.9, <2.0'
 
 cmip6_{model}_historical_{member}_{timestep}:
   crs: 4326

--- a/data/catalogs/gcs_cmip6_data.yml
+++ b/data/catalogs/gcs_cmip6_data.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   version: 2024.1.30
-  hydromt_version: '>=1.0, <2.0'
+  hydromt_version: '>=1.0a, <2.0'
 
 cmip6_{model}_historical_{member}_{timestep}:
   crs: 4326

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,12 @@ Added
 - Added Driver class for customizable io
 - Added MetaDataResolver class for customizable metadata discovery
 - Added DataSource class to represent and validate DataCatalog entries.
+- Data catalogs can now list multiple roots which will be searched for files. (#786)
+
+Changed
+-------
+- The `root` meta key of data catalogs has become `roots` (#786)
+- support for `artifact_keys` has now been removed. (#786)
 
 
 Unreleased

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,8 +19,11 @@ Added
 Changed
 -------
 - The `root` meta key of data catalogs has become `roots` (#786)
-- support for `artifact_keys` has now been removed. (#786)
 
+
+Removed
+-------
+- support for `artifact_keys` has now been removed. (#786)
 
 Unreleased
 ==========

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,16 +14,16 @@ Added
 - Added Driver class for customizable io
 - Added MetaDataResolver class for customizable metadata discovery
 - Added DataSource class to represent and validate DataCatalog entries.
-- Data catalogs can now list multiple version of the roots which will be searched for files depending on the system used (linux, windows etc). (#786)
+- Data catalogs can now list multiple roots depending on the system used (linux, windows etc). where the first existing root will be used. (#786)
 
 Changed
 -------
-- The `root` meta key of data catalogs has become `roots` (#786)
+- The `root` meta key of data catalogs yaml files has become `roots` (#786)
 
 
 Removed
 -------
-- support for `artifact_keys` has now been removed. (#786)
+- support for `**artifact_keys` when initializing the DataCatalog has been removed. (#786)
 
 Unreleased
 ==========

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ Added
 - Added Driver class for customizable io
 - Added MetaDataResolver class for customizable metadata discovery
 - Added DataSource class to represent and validate DataCatalog entries.
-- Data catalogs can now list multiple roots which will be searched for files. (#786)
+- Data catalogs can now list multiple version of the roots which will be searched for files depending on the system used (linux, windows etc). (#786)
 
 Changed
 -------

--- a/docs/user_guide/data_prepare_cat.rst
+++ b/docs/user_guide/data_prepare_cat.rst
@@ -30,7 +30,7 @@ The ``rename``, ``nodata``, ``unit_add`` and ``unit_mult`` options are set per v
 
     meta:
       roots:
-        - /linxu/path/to/data_root/
+        - /linux/path/to/data_root/
         - C:\Windows\path\to\data_root
       version: version
       name: data_catalog_name
@@ -70,7 +70,7 @@ The yaml file has an *optional* global **meta** data section:
   If not provided the folder of where the yaml file is located will be used as root.
   This is used in combination with each data source **path** argument to avoid repetition.
   The roots listed will be checked in the order they are provided. The first one to be found to exist will be used as the actual root.
-  This can be used for corss platform and corss machiene compatability as can be seen above.
+  This can be used for cross platform and cross machine compatibility as can be seen above.
 - **version** (recommended): data catalog version; we recommend `calendar versioning <https://calver.org/>`_
 - **hydromt_version**: range of hydromt version that can read this catalog. Format should be acording to `PEP 440 <https://peps.python.org/pep-0440/#version-specifiers>`_.
 - **category** (optional): used if all data source in catalog belong to the same category. Usual categories within HydroMT are

--- a/docs/user_guide/data_prepare_cat.rst
+++ b/docs/user_guide/data_prepare_cat.rst
@@ -29,7 +29,10 @@ The ``rename``, ``nodata``, ``unit_add`` and ``unit_mult`` options are set per v
 .. code-block:: yaml
 
     meta:
-      root: /path/to/data_root/
+      roots:
+        - /first/path/to/data_root/
+        - /second/path/to/data_root/
+        - C:\Windows\path\to\data_root
       version: version
       name: data_catalog_name
     my_dataset:
@@ -64,7 +67,7 @@ The ``rename``, ``nodata``, ``unit_add`` and ``unit_mult`` options are set per v
 
 The yaml file has an *optional* global **meta** data section:
 
-- **root** (optional): root folder for all the data sources in the yaml file.
+- **roots**: root folder for all the data sources in the yaml file.
   If not provided the folder of where the yaml file is located will be used as root.
   This is used in combination with each data source **path** argument to avoid repetition.
 - **version** (recommended): data catalog version; we recommend `calendar versioning <https://calver.org/>`_

--- a/docs/user_guide/data_prepare_cat.rst
+++ b/docs/user_guide/data_prepare_cat.rst
@@ -30,8 +30,7 @@ The ``rename``, ``nodata``, ``unit_add`` and ``unit_mult`` options are set per v
 
     meta:
       roots:
-        - /first/path/to/data_root/
-        - /second/path/to/data_root/
+        - /linxu/path/to/data_root/
         - C:\Windows\path\to\data_root
       version: version
       name: data_catalog_name
@@ -67,11 +66,13 @@ The ``rename``, ``nodata``, ``unit_add`` and ``unit_mult`` options are set per v
 
 The yaml file has an *optional* global **meta** data section:
 
-- **roots**: root folder for all the data sources in the yaml file.
+- **roots**: root folders for all the data sources in the yaml file.
   If not provided the folder of where the yaml file is located will be used as root.
   This is used in combination with each data source **path** argument to avoid repetition.
+  The roots listed will be checked in the order they are provided. The first one to be found to exist will be used as the actual root.
+  This can be used for corss platform and corss machiene compatability as can be seen above.
 - **version** (recommended): data catalog version; we recommend `calendar versioning <https://calver.org/>`_
-- **hydromt_version** (recommended): range of hydromt version that can read this catalog. Format should be acording to `PEP 440 <https://peps.python.org/pep-0440/#version-specifiers>`_.
+- **hydromt_version**: range of hydromt version that can read this catalog. Format should be acording to `PEP 440 <https://peps.python.org/pep-0440/#version-specifiers>`_.
 - **category** (optional): used if all data source in catalog belong to the same category. Usual categories within HydroMT are
   *geography*, *topography*, *hydrography*, *meteo*, *landuse*, *ocean*, *socio-economic*, *observed data*
   but the user is free to define its own categories.

--- a/docs/user_guide/data_prepare_cat.rst
+++ b/docs/user_guide/data_prepare_cat.rst
@@ -73,7 +73,7 @@ The yaml file has an *optional* global **meta** data section:
   This should be used for cross platform and cross machine compatibility only, as can be seen above. Note that in the end
   only one of the roots will be used, so all data should still be located in the same folder tree.
 - **version** (recommended): data catalog version; we recommend `calendar versioning <https://calver.org/>`_
-- **hydromt_version**: range of hydromt version that can read this catalog. Format should be acording to `PEP 440 <https://peps.python.org/pep-0440/#version-specifiers>`_.
+- **hydromt_version** (recommended): range of hydromt version that can read this catalog. Format should be acording to `PEP 440 <https://peps.python.org/pep-0440/#version-specifiers>`_.
 - **category** (optional): used if all data source in catalog belong to the same category. Usual categories within HydroMT are
   *geography*, *topography*, *hydrography*, *meteo*, *landuse*, *ocean*, *socio-economic*, *observed data*
   but the user is free to define its own categories.

--- a/docs/user_guide/data_prepare_cat.rst
+++ b/docs/user_guide/data_prepare_cat.rst
@@ -66,11 +66,12 @@ The ``rename``, ``nodata``, ``unit_add`` and ``unit_mult`` options are set per v
 
 The yaml file has an *optional* global **meta** data section:
 
-- **roots**: root folders for all the data sources in the yaml file.
+- **roots** (optional): root folders for all the data sources in the yaml file.
   If not provided the folder of where the yaml file is located will be used as root.
   This is used in combination with each data source **path** argument to avoid repetition.
   The roots listed will be checked in the order they are provided. The first one to be found to exist will be used as the actual root.
-  This can be used for cross platform and cross machine compatibility as can be seen above.
+  This should be used for cross platform and cross machine compatibility only, as can be seen above. Note that in the end
+  only one of the roots will be used, so all data should still be located in the same folder tree.
 - **version** (recommended): data catalog version; we recommend `calendar versioning <https://calver.org/>`_
 - **hydromt_version**: range of hydromt version that can read this catalog. Format should be acording to `PEP 440 <https://peps.python.org/pep-0440/#version-specifiers>`_.
 - **category** (optional): used if all data source in catalog belong to the same category. Usual categories within HydroMT are

--- a/hydromt/__init__.py
+++ b/hydromt/__init__.py
@@ -1,7 +1,7 @@
 """HydroMT: Automated and reproducible model building and analysis."""
 
 # version number without 'v' at start
-__version__ = "0.9.9-alpha"
+__version__ = "1.0.0-alpha"
 
 # pkg_resource deprication warnings originate from dependencies
 # so silence them for now

--- a/hydromt/_validators/data_catalog.py
+++ b/hydromt/_validators/data_catalog.py
@@ -63,7 +63,7 @@ class DataCatalogMetaData(BaseModel):
     def _check_version_compatible(self) -> "DataCatalogMetaData":
         if self.hydromt_version is None:
             warning(
-                f"No hydromt version was specified for the data catalog, thus compatability between used hydromt version ({HYDROMT_VERSION}) and the catalog could not be determined."
+                f"No hydromt version was specified for the data catalog, thus compatibility between used hydromt version ({HYDROMT_VERSION}) and the catalog could not be determined."
             )
             return self
         requested = SpecifierSet(self.hydromt_version, prereleases=True)

--- a/hydromt/_validators/data_catalog.py
+++ b/hydromt/_validators/data_catalog.py
@@ -1,4 +1,5 @@
 """Pydantic models for the validation of Data catalogs."""
+from logging import warning
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -51,7 +52,7 @@ class DataCatalogMetaData(BaseModel):
 
     roots: Optional[List[Path]] = None
     version: Optional[Union[str, Number]] = None
-    hydromt_version: str
+    hydromt_version: Optional[str] = None
     name: Optional[str] = None
     model_config: ConfigDict = ConfigDict(
         str_strip_whitespace=True,
@@ -60,6 +61,11 @@ class DataCatalogMetaData(BaseModel):
 
     @model_validator(mode="after")
     def _check_version_compatible(self) -> "DataCatalogMetaData":
+        if self.hydromt_version is None:
+            warning(
+                f"No hydromt version was specified for the data catalog, thus compatability between used hydromt version ({HYDROMT_VERSION}) and the catalog could not be determined."
+            )
+            return self
         requested = SpecifierSet(self.hydromt_version, prereleases=True)
         version = Version(HYDROMT_VERSION)
 

--- a/hydromt/_validators/data_catalog.py
+++ b/hydromt/_validators/data_catalog.py
@@ -49,7 +49,7 @@ class Extent(BaseModel):
 class DataCatalogMetaData(BaseModel):
     """The metadata section of a Hydromt data catalog."""
 
-    roots: List[Path]
+    roots: Optional[List[Path]] = None
     version: Optional[Union[str, Number]] = None
     hydromt_version: str
     name: Optional[str] = None

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -741,7 +741,7 @@ class DataCatalog(object):
     def from_yml(
         self,
         urlpath: Union[Path, str],
-        roots: Optional[str] = None,
+        root: Optional[StrPath] = None,
         catalog_name: Optional[str] = None,
         mark_used: bool = False,
     ) -> DataCatalog:
@@ -804,13 +804,14 @@ class DataCatalog(object):
         self.logger.info(f"Parsing data catalog from {urlpath}")
         yml = _yml_from_uri_or_path(urlpath)
         if catalog_name is None:
-            catalog_name = cast(
-                str,
-                yml.get("meta", {}).get(
-                    "name", "".join(basename(urlpath).split(".")[:-1])
-                ),
-            )
-        self.from_dict(yml, root=urlpath, mark_used=mark_used)
+            if "meta" in yml and "name" in yml["meta"]:
+                catalog_name = cast(str, yml["meta"]["name"])
+            else:
+                catalog_name = cast(str, "".join(splitext(basename(urlpath))[:-1]))
+
+        if root is None:
+            root = urlpath
+        self.from_dict(yml, root=root, catalog_name=catalog_name, mark_used=mark_used)
         return self
 
     def _is_compatible(

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -915,12 +915,10 @@ class DataCatalog(object):
             self.root = root
         elif "roots" in meta:
             self.root = self._determine_catalog_root(meta)
-        else:
-            raise ValueError("Could not determine catalog root")
 
         self.logger.info(f"Data Catalog is using root: {self.root}")
 
-        if splitext(self.root)[-1] in ["gz", "zip"]:
+        if self.root is not None and splitext(self.root)[-1] in ["gz", "zip"]:
             # if root is an archive, unpack it at the cache dir
             self.root = self._cache_archive(
                 self.root, name=catalog_name, version=version

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import warnings
 from datetime import datetime
-from os.path import abspath, basename, exists, isdir, isfile, join, splitext
+from os.path import abspath, basename, dirname, exists, isdir, isfile, join, splitext
 from pathlib import Path
 from typing import (
     Any,
@@ -808,10 +808,10 @@ class DataCatalog(object):
             if "name" in meta:
                 catalog_name = cast(str, meta["name"])
             else:
-                catalog_name = cast(str, "".join(splitext(basename(urlpath))[:-1]))
+                catalog_name = cast(str, "".join(splitext(dirname(urlpath))[:-1]))
 
             if "roots" not in meta:
-                meta["roots"] = [urlpath]
+                meta["roots"] = [dirname(urlpath)]
 
         yml["meta"] = meta
         self.from_dict(yml, root=root, catalog_name=catalog_name, mark_used=mark_used)

--- a/tests/data/test_sources.yml
+++ b/tests/data/test_sources.yml
@@ -3,7 +3,7 @@ meta:
   roots:
     - d:/hydromt_testdata
     - ~/.hydromt_testdata
-  hydromt_version: '<1'
+  hydromt_version: '>=1.0, <2.0'
 era5:
   path: ERA5/daily/era5_{year}_daily.nc
   data_type: RasterDataset

--- a/tests/data/test_sources.yml
+++ b/tests/data/test_sources.yml
@@ -3,7 +3,7 @@ meta:
   roots:
     - d:/hydromt_testdata
     - ~/.hydromt_testdata
-  hydromt_version: '>=1.0, <2.0'
+  hydromt_version: '>=1.0a, <2.0'
 era5:
   path: ERA5/daily/era5_{year}_daily.nc
   data_type: RasterDataset

--- a/tests/data/test_sources.yml
+++ b/tests/data/test_sources.yml
@@ -1,6 +1,9 @@
 ---
 meta:
-  root: d:/hydromt_testdata
+  roots:
+    - d:/hydromt_testdata
+    - ~/.hydromt_testdata
+  hydromt_version: '<1'
 era5:
   path: ERA5/daily/era5_{year}_daily.nc
   data_type: RasterDataset

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -2,7 +2,7 @@
 
 import os
 from os import mkdir
-from os.path import abspath, dirname, isfile, join, realpath
+from os.path import abspath, dirname, isfile, join
 from pathlib import Path
 from typing import cast
 
@@ -44,16 +44,6 @@ def test_errors_on_no_root_found(tmpdir):
     }
     with pytest.raises(ValueError, match="None of the specified roots were found"):
         _ = DataCatalog().from_dict(d)
-
-
-def test_uses_current_dir_if_no_root_specified(tmpdir):
-    d = {
-        "meta": {
-            "hydromt_version": "<1",
-        },
-    }
-    r = DataCatalog().from_dict(d)
-    assert r.root == Path(realpath("."))
 
 
 def test_finds_later_roots(tmpdir):

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -37,7 +37,7 @@ DATADIR = join(dirname(abspath(__file__)), "data")
 def test_errors_on_no_root_found(tmpdir):
     d = {
         "meta": {
-            "hydromt_version": "<1",
+            "hydromt_version": ">=1.0a,<2",
             "roots": list(
                 map(lambda p: join(tmpdir, p), ["a", "b", "c", "d", "4", "⽀"])
             ),
@@ -51,7 +51,7 @@ def test_finds_later_roots(tmpdir):
     mkdir(join(tmpdir, "asasdfasdf"))
     d = {
         "meta": {
-            "hydromt_version": "<1",
+            "hydromt_version": ">=1.0a,<2",
             "roots": list(
                 map(lambda p: join(tmpdir, p), ["a", "b", "c", "d", "4", "asasdfasdf"])
             ),
@@ -67,7 +67,7 @@ def test_finds_roots_in_correct_order(tmpdir):
         mkdir(p)
 
     d = {
-        "meta": {"hydromt_version": "<1", "roots": paths},
+        "meta": {"hydromt_version": ">=1.0a,<2", "roots": paths},
     }
     cat = DataCatalog().from_dict(d)
     assert cat.root == Path(join(tmpdir, "a"))
@@ -75,7 +75,7 @@ def test_finds_roots_in_correct_order(tmpdir):
 
 def test_from_yml_no_root(tmpdir):
     d = {
-        "meta": {"hydromt_version": "<1"},
+        "meta": {"hydromt_version": ">=1.0a,<2"},
     }
 
     cat_file = join(tmpdir, "cat.yml")

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -33,7 +33,7 @@ CATALOGDIR = join(dirname(abspath(__file__)), "..", "data", "catalogs")
 DATADIR = join(dirname(abspath(__file__)), "data")
 
 
-def test_errors_on_no_root(tmpdir):
+def test_errors_on_no_root_found(tmpdir):
     d = {
         "meta": {
             "hydromt_version": "<1",

--- a/tests/test_data_catalog.py
+++ b/tests/test_data_catalog.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from yaml import dump
 
 from hydromt._typing import NoDataStrategy
 from hydromt.data_adapter import (
@@ -70,6 +71,19 @@ def test_finds_roots_in_correct_order(tmpdir):
     }
     cat = DataCatalog().from_dict(d)
     assert cat.root == Path(join(tmpdir, "a"))
+
+
+def test_from_yml_no_root(tmpdir):
+    d = {
+        "meta": {"hydromt_version": "<1"},
+    }
+
+    cat_file = join(tmpdir, "cat.yml")
+    with open(cat_file, "w") as f:
+        dump(d, f)
+
+    cat = DataCatalog().from_yml(cat_file)
+    assert cat.root == Path(tmpdir)
 
 
 def test_parser(mock_driver: GeoDataFrameDriver, mock_resolver: MetaDataResolver):

--- a/tests/validators/test_data_catalog_validation.py
+++ b/tests/validators/test_data_catalog_validation.py
@@ -15,29 +15,30 @@ from hydromt._validators.data_catalog import (
 from hydromt.data_catalog import _yml_from_uri_or_path
 
 
-def test_deltares_data_catalog():
-    p = "data/catalogs/deltares_data.yml"
-    yml_dict = _yml_from_uri_or_path(p)
-    # whould raise error if something goes wrong
-    _ = DataCatalogValidator.from_dict(yml_dict)
-
-
-def test_artifact_data_catalog():
-    p = "data/catalogs/artifact_data.yml"
-    yml_dict = _yml_from_uri_or_path(p)
-    # whould raise error if something goes wrong
-    _ = DataCatalogValidator.from_dict(yml_dict)
-
-
-def test_aws_data_catalog():
-    p = "data/catalogs/aws_data.yml"
-    yml_dict = _yml_from_uri_or_path(p)
-    # whould raise error if something goes wrong
-    _ = DataCatalogValidator.from_dict(yml_dict)
-
-
-def test_gcs_cmip6_data_catalog():
-    p = "data/catalogs/gcs_cmip6_data.yml"
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "deltares_data",
+            "path": "data/catalogs/deltares_data.yml",
+        },
+        {
+            "name": "artifact_data",
+            "path": "data/catalogs/artifact_data.yml",
+        },
+        {
+            "name": "aws_data",
+            "path": "data/catalogs/aws_data.yml",
+        },
+        {
+            "name": "gcs_cmip6_data",
+            "path": "data/catalogs/gcs_cmip6_data.yml",
+        },
+    ],
+    ids=lambda x: x["name"],
+)
+def test_deltares_data_catalog(test_case):
+    p = test_case["path"]
     yml_dict = _yml_from_uri_or_path(p)
     # whould raise error if something goes wrong
     _ = DataCatalogValidator.from_dict(yml_dict)

--- a/tests/validators/test_data_catalog_validation.py
+++ b/tests/validators/test_data_catalog_validation.py
@@ -154,6 +154,15 @@ def test_dangling_alias_catalog_entry():
         _ = DataCatalogValidator.from_dict(d)
 
 
+def test_no_hydrmt_version_loggs_warning(caplog):
+    d = {
+        "meta": {"roots": [""]},
+    }
+
+    _ = DataCatalogValidator.from_dict(d)
+    assert "No hydromt version" in caplog.text
+
+
 def test_valid_alias_catalog_entry():
     d = {
         "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},

--- a/tests/validators/test_data_catalog_validation.py
+++ b/tests/validators/test_data_catalog_validation.py
@@ -58,6 +58,7 @@ def test_geodataframe_entry_validation():
 
 def test_valid_catalog_with_alias():
     d = {
+        "meta": {"hydromt_version": "<1", "roots": [""]},
         "chelsa": {"alias": "chelsa_v1.2"},
         "chelsa_v1.2": {
             "crs": 4326,
@@ -85,6 +86,7 @@ def test_valid_catalog_with_alias():
 
 def test_valid_catalog_variants():
     d = {
+        "meta": {"hydromt_version": "<1", "roots": [""]},
         "esa_worldcover": {
             "crs": 4326,
             "data_type": "RasterDataset",
@@ -116,13 +118,14 @@ def test_valid_catalog_variants():
                     "storage_options": {"anon": True},
                 },
             ],
-        }
+        },
     }
     _ = DataCatalogValidator.from_dict(d)
 
 
 def test_dangling_alias_catalog_entry():
     d = {
+        "meta": {"hydromt_version": "<1", "roots": [""]},
         "chelsa": {"alias": "chelsa_v1.2"},
     }
 
@@ -132,6 +135,7 @@ def test_dangling_alias_catalog_entry():
 
 def test_valid_alias_catalog_entry():
     d = {
+        "meta": {"hydromt_version": "<1", "roots": [""]},
         "chelsa": {"alias": "chelsa_v1.2"},
         "chelsa_v1.2": {
             "crs": 4326,
@@ -147,11 +151,12 @@ def test_valid_alias_catalog_entry():
 
 def test_catalog_metadata_validation():
     d = {
-        "root": "p:/wflow_global/hydromt",
+        "hydromt_version": "<1",
+        "roots": ["p:/wflow_global/hydromt"],
         "version": "2023.3",
     }
     catalog_metadata = DataCatalogMetaData.from_dict(d)
-    assert catalog_metadata.root == Path("p:/wflow_global/hydromt")
+    assert catalog_metadata.roots == [Path("p:/wflow_global/hydromt")]
     assert catalog_metadata.version == "2023.3"
 
 

--- a/tests/validators/test_data_catalog_validation.py
+++ b/tests/validators/test_data_catalog_validation.py
@@ -152,11 +152,14 @@ def test_valid_alias_catalog_entry():
 def test_catalog_metadata_validation():
     d = {
         "hydromt_version": "<1",
-        "roots": ["p:/wflow_global/hydromt"],
+        "roots": ["p:/wflow_global/hydromt", "/mnt/p/wflow_global/hydromt"],
         "version": "2023.3",
     }
     catalog_metadata = DataCatalogMetaData.from_dict(d)
-    assert catalog_metadata.roots == [Path("p:/wflow_global/hydromt")]
+    assert catalog_metadata.roots == [
+        Path("p:/wflow_global/hydromt"),
+        Path("/mnt/p/wflow_global/hydromt"),
+    ]
     assert catalog_metadata.version == "2023.3"
 
 

--- a/tests/validators/test_data_catalog_validation.py
+++ b/tests/validators/test_data_catalog_validation.py
@@ -22,6 +22,27 @@ def test_deltares_data_catalog():
     _ = DataCatalogValidator.from_dict(yml_dict)
 
 
+def test_artifact_data_catalog():
+    p = "data/catalogs/artifact_data.yml"
+    yml_dict = _yml_from_uri_or_path(p)
+    # whould raise error if something goes wrong
+    _ = DataCatalogValidator.from_dict(yml_dict)
+
+
+def test_aws_data_catalog():
+    p = "data/catalogs/aws_data.yml"
+    yml_dict = _yml_from_uri_or_path(p)
+    # whould raise error if something goes wrong
+    _ = DataCatalogValidator.from_dict(yml_dict)
+
+
+def test_gcs_cmip6_data_catalog():
+    p = "data/catalogs/gcs_cmip6_data.yml"
+    yml_dict = _yml_from_uri_or_path(p)
+    # whould raise error if something goes wrong
+    _ = DataCatalogValidator.from_dict(yml_dict)
+
+
 def test_geodataframe_entry_validation():
     d = {
         "crs": 4326,

--- a/tests/validators/test_data_catalog_validation.py
+++ b/tests/validators/test_data_catalog_validation.py
@@ -58,7 +58,7 @@ def test_geodataframe_entry_validation():
 
 def test_valid_catalog_with_alias():
     d = {
-        "meta": {"hydromt_version": "<1", "roots": [""]},
+        "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
         "chelsa": {"alias": "chelsa_v1.2"},
         "chelsa_v1.2": {
             "crs": 4326,
@@ -86,7 +86,7 @@ def test_valid_catalog_with_alias():
 
 def test_valid_catalog_variants():
     d = {
-        "meta": {"hydromt_version": "<1", "roots": [""]},
+        "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
         "esa_worldcover": {
             "crs": 4326,
             "data_type": "RasterDataset",
@@ -125,7 +125,7 @@ def test_valid_catalog_variants():
 
 def test_dangling_alias_catalog_entry():
     d = {
-        "meta": {"hydromt_version": "<1", "roots": [""]},
+        "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
         "chelsa": {"alias": "chelsa_v1.2"},
     }
 
@@ -135,7 +135,7 @@ def test_dangling_alias_catalog_entry():
 
 def test_valid_alias_catalog_entry():
     d = {
-        "meta": {"hydromt_version": "<1", "roots": [""]},
+        "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
         "chelsa": {"alias": "chelsa_v1.2"},
         "chelsa_v1.2": {
             "crs": 4326,
@@ -151,7 +151,7 @@ def test_valid_alias_catalog_entry():
 
 def test_catalog_metadata_validation():
     d = {
-        "hydromt_version": "<1",
+        "hydromt_version": ">=1.0a,<2",
         "roots": ["p:/wflow_global/hydromt", "/mnt/p/wflow_global/hydromt"],
         "version": "2023.3",
     }


### PR DESCRIPTION
# Functional Requirements

## Solved
- [x] Data catalogs can not specify multiple roots to make the catalogs more portable and give better cross platform support as these can be either Windows or POSIX paths
- [x] Roots provided will be checked in order, first one to be found will be used. 
- [x] When none of the provided roots are found an error is raised 
- [x] if no roots are specified anywhere, the current working directory will be used. 

## Postponed
- [ ] Removing the other cross platform path transformations (Fixed in #788)
- [ ] Re enable Model Root logger file path handling  (Fixed in #788)

## To be agreed on
None so far that I am aware of
