### PR TITLE
Release v0.9.4

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -45,6 +45,11 @@
     "url": "https://deltares.github.io/hydromt/v0.9.3/"
   },
   {
+    "name": "v0.9.4",
+    "version": "0.9.4",
+    "url": "https://deltares.github.io/hydromt/v0.9.4/"
+  },
+  {
     "name": "latest",
     "version": "latest",
     "url": "https://deltares.github.io/hydromt/latest/"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,17 +8,15 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 
 
 
-Unreleased
+v0.9.4 (2024-02-26)
 ==========
-These additions/ fixes have not been released yet.
-
-Added
------
+This release fixes a performance regression when reading geometry masks, relaxed warnings for empty raster datasets and updated the documention of the new hydromt commands.
 
 Fixed
 -----
-- Added back geometry mask when reading vector files with `fiona` as engine/ driver
-- Relaxed empty data checking on `RasterDatasetAdapter`
+- Added back geometry mask when reading vector files with `fiona` as engine/ driver. (#777)
+- Relaxed empty data checking on `RasterDatasetAdapter`. (#782)
+- Add documentation for `hydromt check` and `hydromt export` commands. (#767)
 
 v0.9.3 (2024-02-08)
 ===================

--- a/hydromt/__init__.py
+++ b/hydromt/__init__.py
@@ -1,7 +1,7 @@
 """HydroMT: Automated and reproducible model building and analysis."""
 
 # version number without 'v' at start
-__version__ = "0.9.4.dev0"
+__version__ = "0.9.4"
 
 # pkg_resource deprication warnings originate from dependencies
 # so silence them for now


### PR DESCRIPTION
This release fixes a performance regression when reading geometry masks, relaxed warnings for empty raster datasets and updated the documention of the new hydromt commands.

Fixed
--------
- Added back geometry mask when reading vector files with `fiona` as engine/ driver. (#777)
- Relaxed empty data checking on `RasterDatasetAdapter`. (#782)
- Add documentation for `hydromt check` and `hydromt export` commands. (#767)
