### PR TITLE
Actually build the docs when not a PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Generate docs
         if: ${{ github.event_name != 'pull_request' && !github.event.act }}
         run: |
+          pixi run --locked -e full-py311 html
           echo "DOC_VERSION=$(pixi run --locked -e full-py311 python -c 'from hydromt import __version__ as v; print("dev" if "dev" in v else "v"+v.replace(".dev",""))')" >> $GITHUB_ENV
 
       - name: Upload to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
       - docs/*
       - examples/*
       - pyproject.toml
+      - .github/workflows/docs.yml
   pull_request:
     branches: [main]
     paths:
@@ -20,6 +21,7 @@ on:
       - docs/*
       - examples/*
       - pyproject.toml
+      - .github/workflows/docs.yml
 
 jobs:
   test-docs:


### PR DESCRIPTION
## Explanation
I accidentally removed the line where the build docs happened. The dummy docs are building fine, but the real deal was not. So I added the pixi command to actually build the docs to html. But it won't hit these lines when running it in a PR.

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed
- [ ] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
