### PR TITLE
fix get_mesh after xugrid update

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Fixed
 -----
 - Bug in `raster.transform` with lazy coordinates. (#801)
 - Bug in `workflows.mesh.mesh2d_from_rasterdataset` with multi-dimensional coordinates. (#843)
+- Bug in `MeshModel.get_mesh` after xugrid update to 0.9.0.
 
 
 v0.9.4 (2024-02-26)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,7 +17,7 @@ Fixed
 -----
 - Bug in `raster.transform` with lazy coordinates. (#801)
 - Bug in `workflows.mesh.mesh2d_from_rasterdataset` with multi-dimensional coordinates. (#843)
-- Bug in `MeshModel.get_mesh` after xugrid update to 0.9.0.
+- Bug in `MeshModel.get_mesh` after xugrid update to 0.9.0. (#848)
 
 
 v0.9.4 (2024-02-26)

--- a/hydromt/models/model_mesh.py
+++ b/hydromt/models/model_mesh.py
@@ -401,11 +401,11 @@ class MeshMixin(object):
                 drop_coords = [c for c in uds.coords if not c.startswith(grid_name)]
                 uds = uds.drop_vars(drop_coords)
             elif variables and len(variables) == len(self.mesh.data_vars):
-                uds = self.mesh.copy()
-            else:
                 grid = self.mesh_grids[grid_name]
                 uds = xu.UgridDataset(grid.to_dataset(optional_attributes=True))
                 uds.ugrid.grid.set_crs(grid.crs)
+            else:
+                uds = self.mesh.copy()
 
             return uds
 

--- a/hydromt/models/model_mesh.py
+++ b/hydromt/models/model_mesh.py
@@ -387,11 +387,9 @@ class MeshMixin(object):
             for var in self.mesh.data_vars:
                 if hasattr(self.mesh[var], "ugrid"):
                     if self.mesh[var].ugrid.grid.name != grid_name:
-                        # uds[var] = self.mesh[var]
                         variables.append(var)
-                # additionnal topology properties
+                # additional topology properties
                 elif not var.startswith(grid_name):
-                    # uds[var] = self.mesh[var]
                     variables.append(var)
                 # else is global property (not grid specific)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -840,5 +840,7 @@ def test_meshmodel_setup(griduda, world):
         resampling_method=["mode", "centroid"],
         grid_name="mesh2d",
     )
+    ds_mesh2d = mod1.get_mesh("mesh2d", include_data=True)
+    assert "landuse" in ds_mesh2d
     assert "roughness_manning" in mod1.mesh.data_vars
     assert np.all(mod1.mesh["landuse"].values == mod1.mesh["vito"].values)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -841,6 +841,6 @@ def test_meshmodel_setup(griduda, world):
         grid_name="mesh2d",
     )
     ds_mesh2d = mod1.get_mesh("mesh2d", include_data=True)
-    assert "landuse" in ds_mesh2d
+    assert "vito" in ds_mesh2d
     assert "roughness_manning" in mod1.mesh.data_vars
     assert np.all(mod1.mesh["landuse"].values == mod1.mesh["vito"].values)


### PR DESCRIPTION
## Issue addressed
None defined: MeshModel.get_mesh method returns error after xugrid update to 0.9.0

```
hydromt/models/components/mesh.py:369: in get_mesh
    uds[var] = self.data[var]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <xarray.Dataset> Size: 386kB
Dimensions:        (mesh2d_nNodes: 2790, mesh2d_nFaces: 5248,
                    mesh2d_...int64 42kB 0 1 2 3 4 ... 5244 5245 5246 5247
Data variables:
    *empty*
Attributes:
    Conventions:  CF-1.9 UGRID-1.0
key = 'elevation'
value = <xarray.DataArray 'elevation' (mesh2d_nFaces: 5248)> Size: 21kB
[5248 values with dtype=float32]
Coordinates:
    mesh...2kB ...
  * mesh2d_nFaces  (mesh2d_nFaces) int64 42kB 0 1 2 3 4 ... 5244 5245 5246 5247
Attributes:
    unit:     m NAP

    def __setitem__(self, key, value):
        # TODO: check with topology
        if isinstance(value, UgridDataArray):
            append = True
            # Check if the dimensions occur in self.
            # if they don't, the grid should be added.
            if self.grids is not None:
                alldims = set(
                    chain.from_iterable([grid.dimensions for grid in self.grids])
                )
                matching_dims = set(value.grid.dimensions).intersection(alldims)
                if matching_dims:
                    append = False
                    # If they do match: the grids should match.
                    grids = {
                        dim: grid for grid in self.grids for dim in grid.dimensions
                    }
                    firstdim = next(iter(matching_dims))
                    grid_to_check = grids[firstdim]
                    if not grid_to_check.equals(value.grid):
>                       raise ValueError(
                            "Grids share dimension names but do not are not identical. "
                            f"Matching dimensions: {matching_dims}"
                        )
E                       ValueError: Grids share dimension names but do not are not identical. Matching dimensions: {'mesh2d_nEdges', 'mesh2d_nNodes', 'mesh2d_nFaces'}
```

## Explanation
Xugrid does not support well having data variables that are not part of the grid definition and their new check grid is too restrictive on optional ugrid dims that are not part of the data variable dims.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst
