### PR TITLE
Move grid region parsing functionality to region component

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -424,13 +424,13 @@ Attributes
    ModelComponent.logger
    ModelComponent.model_root
 
-ModelRegionComponent
+RegionComponent
 ====================
 
 .. autosummary::
    :toctree: _generated
 
-   ModelRegionComponent
+   RegionComponent
 
 Attributes
 ----------
@@ -438,13 +438,13 @@ Attributes
 .. autosummary::
    :toctree: _generated
 
-   ModelRegionComponent.data
-   ModelRegionComponent.model
-   ModelRegionComponent.crs
-   ModelRegionComponent.bounds
-   ModelRegionComponent.data_catalog
-   ModelRegionComponent.logger
-   ModelRegionComponent.model_root
+   RegionComponent.data
+   RegionComponent.model
+   RegionComponent.crs
+   RegionComponent.bounds
+   RegionComponent.data_catalog
+   RegionComponent.logger
+   RegionComponent.model_root
 
 General Methods
 ---------------
@@ -452,9 +452,9 @@ General Methods
 .. autosummary::
    :toctree: _generated
 
-   ModelRegionComponent.set
-   ModelRegionComponent.read
-   ModelRegionComponent.write
+   RegionComponent.set
+   RegionComponent.read
+   RegionComponent.write
 
 Data Methods
 ------------
@@ -462,7 +462,7 @@ Data Methods
 .. autosummary::
    :toctree: _generated
 
-   ModelRegionComponent.create
+   RegionComponent.create
 
 
 GridComponent

--- a/docs/dev/migrating-to-v1.rst
+++ b/docs/dev/migrating-to-v1.rst
@@ -246,8 +246,8 @@ The `Model.__init__` function can be used to add default components by plugins l
 class ExampleModel(Model):
 	def __init__(self):
 		self.root: ModelRoot = ModelRoot(".")
-		self.add_component("region", ModelRegionComponent)
-		self.add_component("grid", GridComponent)
+		self.add_component("region", RegionComponent(self))
+		self.add_component("grid", GridComponent(self))
 		...
 
 ```
@@ -265,8 +265,8 @@ class ExampleEditModel(Model):
         # Recursively update the components with any defaults that are missing in the components provided by the user.
         components = components or {}
         default_components = {
-            "region": {"type": "ModelRegionComponent"},
-            "grid": {"type": GridComponent},
+            "region": {"type": RegionComponent.__name__},
+            "grid": {"type": GridComponent.__name__},
         }
         components = hydromt.utils.deep_merge.deep_merge(
             default_components, components
@@ -288,9 +288,9 @@ Making the model region its own component
 The model region is a very integral part for the functioning of HydroMT. Additionally
 there was a lot of logic to handle the different ways of specifying a region
 through the code. To simplify this, highlight the importance of the model region,
-make this part of the code easier to customise and consolidate a lot of functionality
+make this part of the code easier to customize and consolidate a lot of functionality
 for easier maintenance, we decided to bring all this functionality together in
-the `ModelRegionComponent` class. This is a required component for a HydroMT model,
+the `RegionComponent` class. This is a required component for a HydroMT model,
 and should contain all functionality necessary to deal with it.
 
 

--- a/hydromt/_utils/constants.py
+++ b/hydromt/_utils/constants.py
@@ -1,0 +1,1 @@
+DEFAULT_REGION_COMPONENT = "region"

--- a/hydromt/cli/main.py
+++ b/hydromt/cli/main.py
@@ -210,7 +210,6 @@ def main(ctx, models, components, plugins):
 @arg_root
 @opt_cli
 @opt_config
-@region_opt
 @data_opt
 @deltares_data_opt
 @overwrite_opt
@@ -224,7 +223,6 @@ def build(
     model_root,
     opt,
     config,
-    region,
     data,
     dd,
     fo,
@@ -253,9 +251,6 @@ def build(
     opt = _utils.parse_config(config, opt_cli=opt)
     kwargs = opt.pop("global", {})
     modeltype = opt.pop("modeltype", model)
-    # Set region to None if empty string json
-    if len(region) == 0:
-        region = None
     # parse data catalog options from global section in config and cli options
     data_libs = np.atleast_1d(kwargs.pop("data_libs", [])).tolist()  # from global
     data_libs += list(data)  # add data catalogs from cli
@@ -273,7 +268,7 @@ def build(
         )
         mod.data_catalog.cache = cache
         # build model
-        mod.build(region, opt=opt)
+        mod.build(opt=opt)
     except Exception as e:
         logger.exception(e)  # catch and log errors
         raise

--- a/hydromt/components/__init__.py
+++ b/hydromt/components/__init__.py
@@ -2,10 +2,10 @@
 
 from hydromt.components.base import ModelComponent
 from hydromt.components.grid import GridComponent
-from hydromt.components.region import ModelRegionComponent
+from hydromt.components.region import RegionComponent
 
 __all__ = [
-    "ModelRegionComponent",
+    "RegionComponent",
     "ModelComponent",
     "GridComponent",
 ]

--- a/hydromt/components/grid.py
+++ b/hydromt/components/grid.py
@@ -19,7 +19,7 @@ from hydromt.components.base import ModelComponent
 from hydromt.components.region import (
     DEFAULT_BASIN_INDEX_FN,
     DEFAULT_HYDROGRAPHY_FN,
-    ModelRegionComponent,
+    RegionComponent,
 )
 from hydromt.gis import raster
 from hydromt.io.readers import read_nc
@@ -225,7 +225,7 @@ class GridComponent(ModelComponent):
         ----------
         region : dict
             Dictionary describing region of interest, e.g.:
-            See :func:`ModelRegionComponent.create` for details.
+            See :func:`RegionComponent.create` for details.
         res: float
             Resolution used to generate 2D grid [unit of the CRS], required if region
             is not based on 'grid'.
@@ -266,7 +266,7 @@ class GridComponent(ModelComponent):
 
         # Pass region creation information to model.region.
         region_component = self._model.get_component(
-            self._region_component, ModelRegionComponent
+            self._region_component, RegionComponent
         )
         if region is not None:
             region_component.create(

--- a/hydromt/components/grid.py
+++ b/hydromt/components/grid.py
@@ -15,6 +15,7 @@ from hydromt import hydromt_step
 from hydromt._typing.error import NoDataStrategy, _exec_nodata_strat
 from hydromt._typing.type_def import DeferedFileClose
 from hydromt.components.base import ModelComponent
+from hydromt.components.region import ModelRegionComponent
 from hydromt.gis import raster
 from hydromt.io.readers import read_nc
 from hydromt.io.writers import write_nc
@@ -262,15 +263,18 @@ class GridComponent(ModelComponent):
         self._logger.info("Preparing 2D grid.")
 
         # Pass region creation information to model.region.
+        region_component = self._model.get_component(
+            self._region_component, ModelRegionComponent
+        )
         if region is not None:
-            self._model.region.create(
+            region_component.create(
                 region=region,
                 basin_index_fn=basin_index_fn,
                 hydrography_fn=hydrography_fn,
             )
 
-        kind = self._model.region.kind
-        geom = self._model.region.data
+        kind = region_component.kind
+        geom = region_component.data
 
         # Derive xcoords, ycoords and geom for the different kind options
         if kind in ["bbox", "geom"]:

--- a/hydromt/components/grid.py
+++ b/hydromt/components/grid.py
@@ -14,8 +14,13 @@ from shapely.geometry import box
 from hydromt import hydromt_step
 from hydromt._typing.error import NoDataStrategy, _exec_nodata_strat
 from hydromt._typing.type_def import DeferedFileClose
+from hydromt._utils.constants import DEFAULT_REGION_COMPONENT
 from hydromt.components.base import ModelComponent
-from hydromt.components.region import ModelRegionComponent
+from hydromt.components.region import (
+    DEFAULT_BASIN_INDEX_FN,
+    DEFAULT_HYDROGRAPHY_FN,
+    ModelRegionComponent,
+)
 from hydromt.gis import raster
 from hydromt.io.readers import read_nc
 from hydromt.io.writers import write_nc
@@ -32,6 +37,8 @@ if TYPE_CHECKING:
 
 __all__ = ["GridComponent"]
 
+DEFAULT_FN = "grid/grid.nc"
+
 
 class GridComponent(ModelComponent):
     """ModelComponent class for grid components.
@@ -44,7 +51,7 @@ class GridComponent(ModelComponent):
     def __init__(
         self,
         model: "Model",
-        region: str = "region",
+        region: str = DEFAULT_REGION_COMPONENT,
     ):
         """Initialize a GridComponent.
 
@@ -105,7 +112,7 @@ class GridComponent(ModelComponent):
     @hydromt_step
     def write(
         self,
-        fn: str = "grid/grid.nc",
+        fn: str = DEFAULT_FN,
         gdal_compliant: bool = False,
         rename_dims: bool = False,
         force_sn: bool = False,
@@ -154,7 +161,7 @@ class GridComponent(ModelComponent):
     @hydromt_step
     def read(
         self,
-        fn: str = "grid/grid.nc",
+        fn: str = DEFAULT_FN,
         mask_and_scale: bool = False,
         **kwargs,
     ) -> None:
@@ -199,14 +206,14 @@ class GridComponent(ModelComponent):
         res: Optional[float] = None,
         crs: Optional[int] = None,
         rotated: bool = False,
-        hydrography_fn: Optional[str] = None,
-        basin_index_fn: Optional[str] = None,
+        hydrography_fn: str = DEFAULT_HYDROGRAPHY_FN,
+        basin_index_fn: str = DEFAULT_BASIN_INDEX_FN,
         add_mask: bool = True,
         align: bool = True,
         dec_origin: int = 0,
         dec_rotation: int = 3,
     ) -> None:
-        """HYDROMT CORE METHOD: Create a 2D regular grid or reads an existing grid.
+        """HYDROMT CORE METHOD: Create a 2D regular grid.
 
         A 2D regular grid will be created from a geometry (geom_fn) or bbox. If an
         existing grid is given, then no new grid will be generated.
@@ -218,12 +225,7 @@ class GridComponent(ModelComponent):
         ----------
         region : dict
             Dictionary describing region of interest, e.g.:
-            * {'bbox': [xmin, ymin, xmax, ymax]}
-            * {'geom': 'path/to/polygon_geometry'}
-            * {'grid': 'path/to/grid_file'}
-            * {'basin': [x, y]}
-
-            Region must be of kind [grid, bbox, geom, basin, subbasin, interbasin].
+            See :func:`ModelRegionComponent.create` for details.
         res: float
             Resolution used to generate 2D grid [unit of the CRS], required if region
             is not based on 'grid'.

--- a/hydromt/components/region.py
+++ b/hydromt/components/region.py
@@ -26,6 +26,7 @@ from hydromt.workflows.basin_mask import get_basin_geometry
 if TYPE_CHECKING:
     from hydromt.models import Model
 
+__all__ = ["RegionComponent"]
 
 logger = getLogger(__name__)
 

--- a/hydromt/components/region.py
+++ b/hydromt/components/region.py
@@ -34,7 +34,7 @@ DEFAULT_HYDROGRAPHY_FN = "merit_hydro"
 DEFAULT_BASIN_INDEX_FN = "merit_hydro_index"
 
 
-class ModelRegionComponent(ModelComponent):
+class RegionComponent(ModelComponent):
     """Define the model region."""
 
     def __init__(
@@ -281,7 +281,7 @@ class ModelRegionComponent(ModelComponent):
             gdf.to_file(write_path, **write_kwargs)
 
     def __eq__(self, __value: object) -> bool:
-        if not isinstance(__value, ModelRegionComponent):
+        if not isinstance(__value, RegionComponent):
             return False
         else:
             try:

--- a/hydromt/components/region.py
+++ b/hydromt/components/region.py
@@ -41,7 +41,6 @@ class ModelRegionComponent(ModelComponent):
     ) -> None:
         super().__init__(model)
         self._data: Optional[GeoDataFrame] = None
-        self._initialized = False
 
     @hydromt_step
     def create(
@@ -197,8 +196,6 @@ class ModelRegionComponent(ModelComponent):
             self._data = data
         else:
             raise ValueError("Only GeoSeries or GeoDataFrame can be used as region.")
-
-        self._initialized = True
 
     @property
     def bounds(self):

--- a/hydromt/components/region.py
+++ b/hydromt/components/region.py
@@ -45,8 +45,8 @@ class ModelRegionComponent(ModelComponent):
     @hydromt_step
     def create(
         self,
-        *,
         region: dict,
+        *,
         crs: Optional[int] = None,
         hydrography_fn: str = "merit_hydro",
         basin_index_fn: str = "merit_hydro_index",

--- a/hydromt/components/region.py
+++ b/hydromt/components/region.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 DEFAULT_REGION_FILE_PATH = "region.geojson"
+DEFAULT_HYDROGRAPHY_FN = "merit_hydro"
+DEFAULT_BASIN_INDEX_FN = "merit_hydro_index"
 
 
 class ModelRegionComponent(ModelComponent):
@@ -48,8 +50,8 @@ class ModelRegionComponent(ModelComponent):
         region: dict,
         *,
         crs: Optional[int] = None,
-        hydrography_fn: str = "merit_hydro",
-        basin_index_fn: str = "merit_hydro_index",
+        hydrography_fn: str = DEFAULT_HYDROGRAPHY_FN,
+        basin_index_fn: str = DEFAULT_BASIN_INDEX_FN,
     ) -> None:
         """Check and return parsed region arguments.
 
@@ -131,17 +133,8 @@ class ModelRegionComponent(ModelComponent):
             * {'interbasin': [xmin, ymin, xmax, ymax], 'xy': [x, y]}
 
             * {'interbasin': /path/to/polygon_geometry, 'outlets': true}
-        logger:
-            The logger to use.
         crs: int, optional
             EPSG code of the model or "utm" to let hydromt find the closest projected
-
-        Returns
-        -------
-        kind : {'basin', 'subbasin', 'interbasin', 'geom', 'bbox', 'grid'}
-            region kind
-        kwargs : dict
-            parsed region json
         """
         if self.data is not None:
             self._logger.warn("Model region already initialized. Skipping creation.")

--- a/hydromt/models/model.py
+++ b/hydromt/models/model.py
@@ -33,6 +33,7 @@ from pyproj import CRS
 from hydromt import hydromt_step
 from hydromt._typing import DeferedFileClose, StrPath, XArrayDict
 from hydromt._utils import _classproperty
+from hydromt._utils.constants import DEFAULT_REGION_COMPONENT
 from hydromt._utils.rgetattr import rgetattr
 from hydromt._utils.steps_validator import validate_steps
 from hydromt.components import ModelRegionComponent
@@ -112,7 +113,8 @@ class Model(object, metaclass=ABCMeta):
         # Recursively update the options with any defaults that are missing in the configuration.
         components = components or {}
         components = deep_merge(
-            {"region": {"type": "ModelRegionComponent"}}, components
+            {DEFAULT_REGION_COMPONENT: {"type": ModelRegionComponent.__name__}},
+            components,
         )
 
         data_libs = data_libs or []
@@ -179,7 +181,7 @@ class Model(object, metaclass=ABCMeta):
     @property
     def region(self) -> ModelRegionComponent:
         """Return the model region component."""
-        return self.get_component("region", ModelRegionComponent)
+        return self.get_component(DEFAULT_REGION_COMPONENT, ModelRegionComponent)
 
     @_classproperty
     def api(cls) -> Dict:

--- a/hydromt/models/model.py
+++ b/hydromt/models/model.py
@@ -138,7 +138,7 @@ class Model(object, metaclass=ABCMeta):
         # file system
         self.root: ModelRoot = ModelRoot(root or ".", mode=mode)
 
-        self._components: Dict[str, ModelComponent] = {}
+        self._components: dict[str, ModelComponent] = {}
         self._add_components(components)
 
         self._defered_file_closes = []
@@ -187,7 +187,7 @@ class Model(object, metaclass=ABCMeta):
         _api = cls._API.copy()
 
         # reversed is so that child attributes take priority
-        # this does mean that it becomes imporant in which order you
+        # this does mean that it becomes important in which order you
         # inherit from your base classes.
         for base_cls in reversed(cls.__mro__):
             if hasattr(base_cls, "_API"):
@@ -197,9 +197,8 @@ class Model(object, metaclass=ABCMeta):
     def build(
         self,
         *,
-        region: dict[str, Any],
         write: Optional[bool] = True,
-        steps: Optional[list[dict[str, dict[str, Any]]]] = None,
+        steps: list[dict[str, dict[str, Any]]],
     ):
         r"""Single method to build a model from scratch based on settings in `steps`.
 
@@ -215,9 +214,6 @@ class Model(object, metaclass=ABCMeta):
 
         Parameters
         ----------
-        region: dict
-            Description of model region. See :py:meth:`~hydromt.workflows.parse_region`
-            for all options.
         write: bool, optional
             Write complete model after executing all methods in opt, by default True.
         steps: Optional[list[dict[str, dict[str, Any]]]]
@@ -239,10 +235,7 @@ class Model(object, metaclass=ABCMeta):
                 ]
 
         """
-        steps = steps or []
         validate_steps(self, steps)
-        self._update_region_from_arguments(steps, region)
-        self._move_region_create_to_front(steps)
 
         for step_dict in steps:
             step, kwargs = next(iter(step_dict.items()))
@@ -315,9 +308,6 @@ class Model(object, metaclass=ABCMeta):
         steps = steps or []
         validate_steps(self, steps)
 
-        # check if region.create is in the steps, and remove it.
-        self._remove_region_create(steps)
-
         # read current model
         if not self.root.is_writing_mode():
             if model_out is None:
@@ -389,39 +379,6 @@ class Model(object, metaclass=ABCMeta):
         return any(
             next(iter(step_dict)).split(".")[-1] == "write" for step_dict in steps
         )
-
-    @staticmethod
-    def _update_region_from_arguments(
-        steps: list[dict[str, dict[str, Any]]], region: dict[str, Any]
-    ) -> None:
-        try:
-            region_step = next(
-                step_dict
-                for step_dict in enumerate(steps)
-                if next(iter(step_dict)) == "region.create"
-            )
-            region_step[1]["region"] = region
-        except StopIteration:
-            steps.insert(0, {"region.create": {"region": region}})
-
-    @staticmethod
-    def _move_region_create_to_front(steps: list[dict[str, dict[str, Any]]]) -> None:
-        region_create = next(
-            step_dict for step_dict in steps if "region.create" in step_dict
-        )
-        steps.remove(region_create)
-        steps.insert(0, region_create)
-
-    def _remove_region_create(self, steps: list[dict[str, dict[str, Any]]]) -> None:
-        try:
-            steps.remove(
-                next(step_dict for step_dict in steps if "region.create" in step_dict)
-            )
-            self.logger.warning(
-                "region.create can only be called when building a model."
-            )
-        except StopIteration:
-            pass
 
     @hydromt_step
     def write_data_catalog(

--- a/hydromt/models/model.py
+++ b/hydromt/models/model.py
@@ -36,7 +36,7 @@ from hydromt._utils import _classproperty
 from hydromt._utils.constants import DEFAULT_REGION_COMPONENT
 from hydromt._utils.rgetattr import rgetattr
 from hydromt._utils.steps_validator import validate_steps
-from hydromt.components import ModelRegionComponent
+from hydromt.components import RegionComponent
 from hydromt.components.base import ModelComponent
 from hydromt.data_catalog import DataCatalog
 from hydromt.gis.raster import GEO_MAP_COORD
@@ -77,7 +77,7 @@ class Model(object, metaclass=ABCMeta):
         "tables": Dict[str, pd.DataFrame],
         "maps": XArrayDict,
         "forcing": XArrayDict,
-        "region": ModelRegionComponent,
+        "region": RegionComponent,
         "results": XArrayDict,
         "states": XArrayDict,
     }
@@ -113,7 +113,7 @@ class Model(object, metaclass=ABCMeta):
         # Recursively update the options with any defaults that are missing in the configuration.
         components = components or {}
         components = deep_merge(
-            {DEFAULT_REGION_COMPONENT: {"type": ModelRegionComponent.__name__}},
+            {DEFAULT_REGION_COMPONENT: {"type": RegionComponent.__name__}},
             components,
         )
 
@@ -143,7 +143,7 @@ class Model(object, metaclass=ABCMeta):
         self._components: dict[str, ModelComponent] = {}
         self._add_components(components)
 
-        self._defered_file_closes = []
+        self._defered_file_closes: list[DeferedFileClose] = []
 
         # model paths
         self._config_fn = self._CONF if config_fn is None else config_fn
@@ -179,9 +179,9 @@ class Model(object, metaclass=ABCMeta):
         return self._components[name]
 
     @property
-    def region(self) -> ModelRegionComponent:
+    def region(self) -> RegionComponent:
         """Return the model region component."""
-        return self.get_component(DEFAULT_REGION_COMPONENT, ModelRegionComponent)
+        return self.get_component(DEFAULT_REGION_COMPONENT, RegionComponent)
 
     @_classproperty
     def api(cls) -> Dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,3 +151,6 @@ filterwarnings = [
   # "ignore:rasterio.errors.NotGeoreferencedWarning",                        # upstream issue with rasterio, see https://github.com/rasterio/rasterio/issues/2497
   "ignore:Detected a customized `__new__` method in subclass:DeprecationWarning", #upstream error in universal_pathlib see https://github.com/fsspec/universal_pathlib?tab=readme-ov-file#migrating-to-v020
 ]
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/tests/_validators/test_model_config.py
+++ b/tests/_validators/test_model_config.py
@@ -105,8 +105,8 @@ def test_validate_step_signature_bind():
 def test_validate_global_config_components():
     globals = HydromtGlobalConfig(
         components={
-            "grid": {"type": "GridComponent"},
-            "subgrid": {"type": "GridComponent"},
+            "grid": {"type": GridComponent.__name__},
+            "subgrid": {"type": GridComponent.__name__},
         },  # type: ignore
     )
     assert globals.components[0].name == "grid"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from hydromt import __version__
 from hydromt._typing import NoDataException
 from hydromt.cli.main import main as hydromt_cli
+from hydromt.components.region import RegionComponent
 
 DATADIR = join(dirname(abspath(__file__)), "..", "data")
 
@@ -29,7 +30,7 @@ def test_cli_components():
     r = CliRunner().invoke(hydromt_cli, "--components")
     assert r.exit_code == 0
     assert "Component plugins" in r.output
-    assert "ModelRegionComponent" in r.output
+    assert RegionComponent.__name__ in r.output
 
 
 def test_cli_help():

--- a/tests/components/test_grid_component.py
+++ b/tests/components/test_grid_component.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 from pytest_mock import MockerFixture
 
+from hydromt._utils.constants import DEFAULT_REGION_COMPONENT
 from hydromt.components import ModelRegionComponent
 from hydromt.components.grid import GridComponent
 from hydromt.data_catalog import DataCatalog
@@ -27,7 +28,7 @@ def mock_model(tmpdir, mocker: MockerFixture):
     model.get_component = mocker.Mock()
     model.get_component.return_value = None
     model.get_component.side_effect = (
-        lambda name, _: model.region if name == "region" else None
+        lambda name, _: model.region if name == DEFAULT_REGION_COMPONENT else None
     )
     model.logger = logger
     return model

--- a/tests/components/test_grid_component.py
+++ b/tests/components/test_grid_component.py
@@ -9,7 +9,7 @@ import xarray as xr
 from pytest_mock import MockerFixture
 
 from hydromt._utils.constants import DEFAULT_REGION_COMPONENT
-from hydromt.components import ModelRegionComponent
+from hydromt.components import RegionComponent
 from hydromt.components.grid import GridComponent
 from hydromt.data_catalog import DataCatalog
 from hydromt.models.model import Model
@@ -24,7 +24,7 @@ def mock_model(tmpdir, mocker: MockerFixture):
     model = mocker.create_autospec(Model)
     model.root = ModelRoot(path=tmpdir)
     model.data_catalog = DataCatalog()
-    model.region = ModelRegionComponent(model)
+    model.region = RegionComponent(model)
     model.get_component = mocker.Mock()
     model.get_component.return_value = None
     model.get_component.side_effect = (

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -222,7 +222,7 @@ def test_model_does_not_overwrite_in_write_mode(tmpdir):
     bbox = [12.05, 45.30, 12.85, 45.65]
     root = join(tmpdir, "tmp")
     model = Model(root=root, mode="w")
-    model.region.create(region={"bbox": bbox})
+    model.region.create({"bbox": bbox})
     model.region.write()
     assert exists(join(root, "region.geojson"))
     with pytest.raises(
@@ -348,7 +348,7 @@ def test_model_set_geoms(tmpdir):
     geom = gpd.GeoDataFrame(geometry=[bbox], crs=4326)
     geom_28992 = geom.to_crs(epsg=28992)
     model = Model(root=str(tmpdir), mode="w")
-    model.region.create(region={"geom": geom_28992})  # set model crs based on epsg28992
+    model.region.create({"geom": geom_28992})  # set model crs based on epsg28992
     model.set_geoms(geom, "geom_wgs84")  # this should convert the geom crs to epsg28992
     assert model._geoms["geom_wgs84"].crs.to_epsg() == model.crs.to_epsg()
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -19,7 +19,7 @@ from shapely.geometry import box
 from hydromt._utils.constants import DEFAULT_REGION_COMPONENT
 from hydromt.components.base import ModelComponent
 from hydromt.components.grid import GridComponent
-from hydromt.components.region import ModelRegionComponent
+from hydromt.components.region import RegionComponent
 from hydromt.data_catalog import DataCatalog
 from hydromt.models import Model
 from hydromt.models.model import _check_data
@@ -800,13 +800,13 @@ def test_meshmodel_setup(griduda, world):
 
 def test_initialize_model():
     m = Model()
-    assert isinstance(m.region, ModelRegionComponent)
+    assert isinstance(m.region, RegionComponent)
 
 
 def test_initialize_model_with_grid_component():
-    m = Model(components={"grid": {"type": "GridComponent"}})
+    m = Model(components={"grid": {"type": GridComponent.__name__}})
     assert isinstance(m.grid, GridComponent)
-    assert isinstance(m.region, ModelRegionComponent)
+    assert isinstance(m.region, RegionComponent)
 
 
 def test_write_multiple_components(mocker: MockerFixture, tmpdir: Path):
@@ -855,7 +855,7 @@ def test_read_in_write_mode():
 
 
 def test_build_empty_model_builds_region(mocker: MockerFixture, tmpdir: Path):
-    region = _patch_plugin_components(mocker, ModelRegionComponent)[0]
+    region = _patch_plugin_components(mocker, RegionComponent)[0]
     region.create.__ishydromtstep__ = True
     m = Model(root=str(tmpdir))
     assert m.region is region
@@ -866,7 +866,7 @@ def test_build_empty_model_builds_region(mocker: MockerFixture, tmpdir: Path):
 
 
 def test_build_two_components_writes_one(mocker: MockerFixture, tmpdir: Path):
-    region, foo = _patch_plugin_components(mocker, ModelRegionComponent, ModelComponent)
+    region, foo = _patch_plugin_components(mocker, RegionComponent, ModelComponent)
     foo.write.__ishydromtstep__ = True
     m = Model(root=str(tmpdir))
     m.add_component("foo", foo)
@@ -880,7 +880,7 @@ def test_build_two_components_writes_one(mocker: MockerFixture, tmpdir: Path):
 
 
 def test_build_write_disabled_does_not_write(mocker: MockerFixture, tmpdir: Path):
-    region = _patch_plugin_components(mocker, ModelRegionComponent)[0]
+    region = _patch_plugin_components(mocker, RegionComponent)[0]
     m = Model(root=str(tmpdir))
     assert m.region is region
 
@@ -890,7 +890,7 @@ def test_build_write_disabled_does_not_write(mocker: MockerFixture, tmpdir: Path
 
 
 def test_build_non_existing_step(mocker: MockerFixture, tmpdir: Path):
-    region = _patch_plugin_components(mocker, ModelRegionComponent)[0]
+    region = _patch_plugin_components(mocker, RegionComponent)[0]
     m = Model(root=str(tmpdir))
     assert m.region is region
 
@@ -928,7 +928,7 @@ def test_update_in_read_mode_without_out_folder_throws(tmpdir: Path):
 def test_update_in_read_mode_with_out_folder_sets_to_write_mode(
     tmpdir: Path, mocker: MockerFixture
 ):
-    region = _patch_plugin_components(mocker, ModelRegionComponent)[0]
+    region = _patch_plugin_components(mocker, RegionComponent)[0]
     m = Model(root=str(tmpdir), mode="r")
     assert region is m.region
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -398,31 +398,28 @@ def test_maps_setup(tmpdir):
     mod.write(components=["config", "geoms", "maps"])
 
 
-@pytest.mark.skip(reason="Needs implementation of new Model class with GridComponent.")
-def test_gridmodel(grid_model, tmpdir, demda):
-    assert "grid" in grid_model.api
-    non_compliant = grid_model._test_model_api()
-    assert len(non_compliant) == 0, non_compliant
+@pytest.mark.skip(reason="Needs implementation of RasterDataSet.")
+def test_gridmodel(model, tmpdir, demda):
+    model.add_component("grid", GridComponent(model))
     # grid specific attributes
-    assert np.all(grid_model.res == grid_model.grid.raster.res)
-    assert np.all(grid_model.bounds == grid_model.grid.raster.bounds)
-    assert np.all(grid_model.transform == grid_model.grid.raster.transform)
+    assert np.all(model.grid.res == model.grid.data.raster.res)
+    assert np.all(model.grid.bounds == model.grid.data.raster.bounds)
+    assert np.all(model.grid.transform == model.grid.data.raster.transform)
     # write model
-    grid_model.root.set(str(tmpdir), mode="w")
-    grid_model.write()
+    model.root.set(str(tmpdir), mode="w")
+    model.write()
     # read model
-    GridModel: Any = ...  # bypass ruff
-    model1 = GridModel(str(tmpdir), mode="r")
+    model1 = Model(str(tmpdir), mode="r")
     model1.read()
     # check if equal
-    equal, errors = grid_model._test_equal(model1)
+    equal, errors = model._test_equal(model1)
     assert equal, errors
 
     # try update
-    grid_model.root.set(str(join(tmpdir, "update")), mode="w")
-    grid_model.write()
+    model.root.set(str(join(tmpdir, "update")), mode="w")
+    model.write()
 
-    model1 = GridModel(str(join(tmpdir, "update")), mode="r+")
+    model1 = Model(str(join(tmpdir, "update")), mode="r+")
     model1.update(
         opt={
             "set_grid": {"data": demda, "name": "testdata"},
@@ -798,9 +795,6 @@ def test_meshmodel_setup(griduda, world):
     )
     assert "roughness_manning" in mod1.mesh.data_vars
     assert np.all(mod1.mesh["landuse"].values == mod1.mesh["vito"].values)
-
-
-# NEW TESTS FOR REFACTOR MODEL COMPONENTS
 
 
 def test_initialize_model():

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -163,7 +163,7 @@ def test_model_tables(model, df, tmpdir):
         model.set_tables(d, name=i)
         assert df.equals(model.tables[i])
 
-    # now do the same but interating over the stables instead
+    # now do the same but iterating over the stables instead
     for i, d in model.tables.items():
         model.set_tables(d, name=i)
         assert df.equals(model.tables[i])
@@ -861,11 +861,12 @@ def test_read_in_write_mode():
 
 def test_build_empty_model_builds_region(mocker: MockerFixture, tmpdir: Path):
     region = _patch_plugin_components(mocker, ModelRegionComponent)[0]
+    region.create.__ishydromtstep__ = True
     m = Model(root=str(tmpdir))
     assert m.region is region
     region_dict = {"bbox": [12.05, 45.30, 12.85, 45.65]}
-    m.build(region=region_dict)
-    region.create.assert_called_once_with(region=region_dict)
+    m.build(steps=[{"region.create": {"region": region_dict}}])
+    region.create.assert_called_once()
     region.write.assert_called_once()
 
 
@@ -874,14 +875,11 @@ def test_build_two_components_writes_one(mocker: MockerFixture, tmpdir: Path):
     foo.write.__ishydromtstep__ = True
     m = Model(root=str(tmpdir))
     m.add_component("foo", foo)
-    region_dict = {"bbox": [12.05, 45.30, 12.85, 45.65]}
     assert m.region is region
     assert m.foo is foo
 
-    # Specify to only write foo
-    m.build(region=region_dict, steps=[{"foo.write": {}}])
+    m.build(steps=[{"foo.write": {}}])
 
-    region.create.assert_called_once_with(region=region_dict)
     region.write.assert_not_called()  # Only foo will be written, so no total write
     foo.write.assert_called_once()  # foo was written, because it was specified in steps
 
@@ -891,10 +889,8 @@ def test_build_write_disabled_does_not_write(mocker: MockerFixture, tmpdir: Path
     m = Model(root=str(tmpdir))
     assert m.region is region
 
-    region_dict = {"bbox": [12.05, 45.30, 12.85, 45.65]}
-    m.build(write=False, region=region_dict)
+    m.build(write=False, steps=[])
 
-    region.create.assert_called_once()
     region.write.assert_not_called()
 
 
@@ -903,10 +899,8 @@ def test_build_non_existing_step(mocker: MockerFixture, tmpdir: Path):
     m = Model(root=str(tmpdir))
     assert m.region is region
 
-    region_dict = {"bbox": [12.05, 45.30, 12.85, 45.65]}
-
-    with pytest.raises(KeyError):
-        m.build(region=region_dict, steps=[{"foo": {}}])
+    with pytest.raises(KeyError, match="foo"):
+        m.build(steps=[{"foo": {}}])
 
 
 def test_add_component_duplicate_throws(mocker: MockerFixture):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -16,6 +16,7 @@ import xarray as xr
 from pytest_mock import MockerFixture
 from shapely.geometry import box
 
+from hydromt._utils.constants import DEFAULT_REGION_COMPONENT
 from hydromt.components.base import ModelComponent
 from hydromt.components.grid import GridComponent
 from hydromt.components.region import ModelRegionComponent
@@ -244,7 +245,7 @@ def test_model_build_update(tmpdir, demda, obsda):
             "region.write": {"components": {"geoms", "config"}},
         },
     )
-    assert hasattr(model, "region")
+    assert hasattr(model, DEFAULT_REGION_COMPONENT)
     assert isfile(join(model.root.path, "model.yml"))
     assert isfile(join(model.root.path, "hydromt.log"))
     assert isfile(join(model.root.path, "region.geojson")), listdir(model.root.path)

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -221,7 +221,7 @@ def test_model_does_not_overwrite_in_write_mode(tmpdir):
     bbox = [12.05, 45.30, 12.85, 45.65]
     root = join(tmpdir, "tmp")
     model = Model(root=root, mode="w")
-    model.region.create({"bbox": bbox})
+    model.region.create(region={"bbox": bbox})
     model.region.write()
     assert exists(join(root, "region.geojson"))
     with pytest.raises(
@@ -347,7 +347,7 @@ def test_model_set_geoms(tmpdir):
     geom = gpd.GeoDataFrame(geometry=[bbox], crs=4326)
     geom_28992 = geom.to_crs(epsg=28992)
     model = Model(root=str(tmpdir), mode="w")
-    model.region.create({"geom": geom_28992})  # set model crs based on epsg28992
+    model.region.create(region={"geom": geom_28992})  # set model crs based on epsg28992
     model.set_geoms(geom, "geom_wgs84")  # this should convert the geom crs to epsg28992
     assert model._geoms["geom_wgs84"].crs.to_epsg() == model.crs.to_epsg()
 

--- a/tests/models/test_model_region.py
+++ b/tests/models/test_model_region.py
@@ -20,6 +20,6 @@ def test_model_writes_region(test_model, geodf):
     test_model.root.mode = ModelMode.WRITE
     region_file_path = join(test_dir, "region.geojson")
     assert not exists(region_file_path)
-    test_model.region.create(region={"bbox": geodf.total_bounds})
+    test_model.region.create({"bbox": geodf.total_bounds})
     test_model.region.write()
     assert exists(region_file_path)

--- a/tests/models/test_model_region.py
+++ b/tests/models/test_model_region.py
@@ -20,6 +20,6 @@ def test_model_writes_region(test_model, geodf):
     test_model.root.mode = ModelMode.WRITE
     region_file_path = join(test_dir, "region.geojson")
     assert not exists(region_file_path)
-    test_model.region.create({"bbox": geodf.total_bounds})
+    test_model.region.create(region={"bbox": geodf.total_bounds})
     test_model.region.write()
     assert exists(region_file_path)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 
 from hydromt.components.base import ModelComponent
 from hydromt.components.grid import GridComponent
-from hydromt.components.region import ModelRegionComponent
+from hydromt.components.region import RegionComponent
 from hydromt.models.model import Model
 from hydromt.plugins import PLUGINS
 
@@ -14,9 +14,9 @@ from hydromt.plugins import PLUGINS
 def test_core_component_plugins():
     components = PLUGINS.component_plugins
     assert components == {
-        "ModelRegionComponent": ModelRegionComponent,
-        "GridComponent": GridComponent,
-        "ModelComponent": ModelComponent,
+        RegionComponent.__name__: RegionComponent,
+        GridComponent.__name__: GridComponent,
+        ModelComponent.__name__: ModelComponent,
     }
 
 
@@ -30,10 +30,10 @@ def test_summary():
     model_summary = PLUGINS.model_summary()
     assert "Component plugins:" in component_summary
     assert "Model plugins:" in model_summary
-    assert "ModelRegionComponent" in component_summary
-    assert "GridComponent" in component_summary
-    assert "ModelComponent" in component_summary
-    assert "Model" in model_summary
+    assert RegionComponent.__name__ in component_summary
+    assert GridComponent.__name__ in component_summary
+    assert ModelComponent.__name__ in component_summary
+    assert Model.__name__ in model_summary
 
 
 def _patch_plugin_entry_point(mocker: MockerFixture, component_names: List[str]):


### PR DESCRIPTION
## Issue addressed
Fixes #847 

## Explanation
Move region code parsing from GridComponent to ModelRegionComponent.
Attaches the region to the grid via the name id of the region component in the constructor of grid.
Removes region from the command line arguments.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed
- [ ] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
