### PR TITLE
bugfix in clip_bbox for clipping on a bbox outside of rasterdataset

### DIFF
--- a/hydromt/raster.py
+++ b/hydromt/raster.py
@@ -1249,8 +1249,9 @@ class XRasterBase(XGeoBase):
         # use round to get integer slices
         c0 = max(int(np.round(cs.min() - buffer)), 0)
         r0 = max(int(np.round(rs.min() - buffer)), 0)
-        c1 = int(np.round(cs.max() + buffer))
-        r1 = int(np.round(rs.max() + buffer))
+        # max to avoid negative slices (which start to count from the end of the array)
+        c1 = max(int(np.round(cs.max() + buffer)), 0)
+        r1 = max(int(np.round(rs.max() + buffer)), 0)
         return self.clip(slice(c0, c1), slice(r0, r1))
 
     def clip_mask(self, da_mask: xr.DataArray, mask: bool = False):


### PR DESCRIPTION
## Issue addressed
Fixes #859

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed
- [ ] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
