### PR TITLE
Implement default file path pattern for tables component

### DIFF
--- a/hydromt/components/tables.py
+++ b/hydromt/components/tables.py
@@ -36,6 +36,11 @@ class TablesComponent(ModelComponent):
         ----------
         model: Model
             HydroMT model instance
+        default_filename: str
+            The default place that should be used for reading and writing unless the user
+            overrides it. If a relative is given it will be used as being relative to the
+            model root. By default `tables/{name}.csv` for this component, and can be either
+            relative or absolute.
         """
         self._data: Optional[Dict[str, Union[pd.DataFrame, pd.Series]]] = None
         self._filename = default_filename
@@ -59,7 +64,7 @@ class TablesComponent(ModelComponent):
 
     @hydromt_step
     def write(self, filename: Optional[str] = None, **kwargs) -> None:
-        """Write tables at <root>/tables."""
+        """Write tables at provided or default filepath if none is provided."""
         self._root._assert_write_mode()
         fn = filename or self._filename
         if len(self.data) > 0:
@@ -75,7 +80,7 @@ class TablesComponent(ModelComponent):
 
     @hydromt_step
     def read(self, filename: Optional[str] = None, **kwargs) -> None:
-        """Read table files at <root>/tables and parse to dict of dataframes."""
+        """Read tables at provided or default filepath if none is provided."""
         self._root._assert_read_mode()
         self._initialize_tables(skip_read=True)
         self._model.logger.info("Reading model table files.")

--- a/hydromt/components/tables.py
+++ b/hydromt/components/tables.py
@@ -29,7 +29,7 @@ class TablesComponent(ModelComponent):
     It is well suited to represent non-geospatial tabular model data.
     """
 
-    def __init__(self, model: "Model", default_filename: str = _DEFAULT_TABLE_FILENAME):
+    def __init__(self, model: "Model", filename: str = _DEFAULT_TABLE_FILENAME):
         """Initialize a TablesComponent.
 
         Parameters
@@ -43,7 +43,7 @@ class TablesComponent(ModelComponent):
             relative or absolute.
         """
         self._data: Optional[Dict[str, Union[pd.DataFrame, pd.Series]]] = None
-        self._filename = default_filename
+        self._filename = filename
         super().__init__(model=model)
 
     @property

--- a/hydromt/utils/__init__.py
+++ b/hydromt/utils/__init__.py
@@ -1,6 +1,5 @@
 """Public helper functions that (pulgin) developers can use."""
 
-from hydromt.utils.constants import DEFAULT_TABLE_FILENAME
 from hydromt.utils.deep_merge import deep_merge
 
-__all__ = ["deep_merge", "DEFAULT_TABLE_FILENAME"]
+__all__ = ["deep_merge"]

--- a/hydromt/utils/constants.py
+++ b/hydromt/utils/constants.py
@@ -1,3 +1,0 @@
-"""Publically available constants for hydromt."""
-
-DEFAULT_TABLE_FILENAME = "tables/{name}.csv"

--- a/tests/components/test_tables_component.py
+++ b/tests/components/test_tables_component.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from hydromt.components.tables import TablesComponent
+from hydromt.models import Model
+
+
+def test_model_tables_key_error(df, tmpdir: Path):
+    m = Model(root=str(tmpdir), mode="r+")
+    m.add_component("test_table", TablesComponent(m))
+    component = m.get_component("test_table", TablesComponent)
+
+    with pytest.raises(KeyError):
+        component.data["1"]
+
+
+def test_model_tables_merges_correctly(df, tmpdir: Path):
+    m = Model(root=str(tmpdir), mode="r+")
+    m.add_component("test_table", TablesComponent(m))
+    component = m.get_component("test_table", TablesComponent)
+
+    # make a couple copies of the dfs for testing
+    dfs = {str(i): df.copy() * i for i in range(5)}
+
+    component.set(tables=dfs)
+
+    computed = component.get_tables_merged()
+    expected = pd.concat([df.assign(table_origin=name) for name, df in dfs.items()])
+    assert computed.equals(expected)
+
+
+def test_model_tables_sets_correctly(df, tmpdir: Path):
+    m = Model(root=str(tmpdir), mode="r+")
+    m.add_component("test_table", TablesComponent(m))
+    component = m.get_component("test_table", TablesComponent)
+
+    # make a couple copies of the dfs for testing
+    dfs = {str(i): df.copy() for i in range(5)}
+
+    for i, d in dfs.items():
+        component.set(tables=d, name=i)
+        assert df.equals(component.data[i])
+
+    assert list(component.data.keys()) == list(map(str, range(5)))
+
+
+@pytest.mark.skip(reason="Needs raster dataset implementation")
+def test_model_tables_reads_and_writes_correctly(df, tmpdir: Path):
+    model = Model(root=str(tmpdir), mode="r+")
+    model.add_component("test_table", TablesComponent(model))
+    component = model.get_component("test_table", TablesComponent)
+
+    component.set(tables=df, name="table")
+
+    model.write()
+    clean_model = Model(root=str(tmpdir), mode="r")
+    clean_model.add_component("test_table", TablesComponent(model))
+    clean_model.read()
+
+    clean_component = clean_model.get_component("test_table", TablesComponent)
+
+    assert component.data["table"].equals(clean_component.data["table"])

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -18,7 +18,6 @@ from shapely.geometry import box
 from hydromt.components.base import ModelComponent
 from hydromt.components.grid import GridComponent
 from hydromt.components.region import ModelRegionComponent
-from hydromt.components.tables import TablesComponent
 from hydromt.data_catalog import DataCatalog
 from hydromt.models import Model
 from hydromt.models.model import _check_data
@@ -147,63 +146,6 @@ def test_model(model, tmpdir):
     with pytest.deprecated_call():
         equal, errors = model._test_equal(model1)
     assert equal, errors
-
-
-def test_model_tables_key_error(df, tmpdir: Path):
-    m = Model(root=str(tmpdir), mode="r+")
-    m.add_component("test_table", TablesComponent(m))
-    component = m.get_component("test_table", TablesComponent)
-
-    with pytest.raises(KeyError):
-        component.data["1"]
-
-
-def test_model_tables_merges_correctly(df, tmpdir: Path):
-    m = Model(root=str(tmpdir), mode="r+")
-    m.add_component("test_table", TablesComponent(m))
-    component = m.get_component("test_table", TablesComponent)
-
-    # make a couple copies of the dfs for testing
-    dfs = {str(i): df.copy() * i for i in range(5)}
-
-    component.set(tables=dfs)
-
-    computed = component.get_tables_merged()
-    expected = pd.concat([df.assign(table_origin=name) for name, df in dfs.items()])
-    assert computed.equals(expected)
-
-
-def test_model_tables_sets_correctly(df, tmpdir: Path):
-    m = Model(root=str(tmpdir), mode="r+")
-    m.add_component("test_table", TablesComponent(m))
-    component = m.get_component("test_table", TablesComponent)
-
-    # make a couple copies of the dfs for testing
-    dfs = {str(i): df.copy() for i in range(5)}
-
-    for i, d in dfs.items():
-        component.set(tables=d, name=i)
-        assert df.equals(component.data[i])
-
-    assert list(component.data.keys()) == list(map(str, range(5)))
-
-
-@pytest.mark.skip(reason="Needs raster dataset implementation")
-def test_model_tables_reads_and_writes_correctly(df, tmpdir: Path):
-    model = Model(root=str(tmpdir), mode="r+")
-    model.add_component("test_table", TablesComponent(model))
-    component = model.get_component("test_table", TablesComponent)
-
-    component.set(tables=df, name="table")
-
-    model.write()
-    clean_model = Model(root=str(tmpdir), mode="r")
-    clean_model.add_component("test_table", TablesComponent(model))
-    clean_model.read()
-
-    clean_component = clean_model.get_component("test_table", TablesComponent)
-
-    assert component.data["table"].equals(clean_component.data["table"])
 
 
 @pytest.mark.skip(reason="Needs implementation of new Model class with GridComponent.")


### PR DESCRIPTION
## Issue addressed
Fixes #864

## Explanation
In today's refinement we decided that components should take some variation of `default_filename` at init, and store that so it can be used for reading and writing unless the user overrides it by passing in an argument of their own.

In addition we did not explicitly discuss today, but it seems we have reached a consensus that:
- components that can contain multiple objects (e.g. they store a dictionary of something) should be names in plural form
- We do not want to expose constants for our default paths. 

This PR brings `TablesComponent` up to date with that convention. I don't think any of the changelogs or documentation has to be updated for this, but feel free to let me know if you disagree. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `v1`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [ ] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
