### PR TITLE
fix renaming issue

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Fixed
 - Bug in `MeshModel.get_mesh` after xugrid update to 0.9.0. (#848)
 - Bug in `raster.clip_bbox` when bbox doesn't overlap with raster. (#860)
 - Allow for string format in zoom_level path, e.g. `{zoom_level:02d}` (#851)
+- Fixed incorrect renaming of single variable raster datasets (#883)
 
 v0.9.4 (2024-02-26)
 ===================

--- a/hydromt/data_adapter/rasterdataset.py
+++ b/hydromt/data_adapter/rasterdataset.py
@@ -353,7 +353,7 @@ class RasterDatasetAdapter(DataAdapter):
     def _resolve_paths(
         self,
         time_tuple: Optional[TimeRange] = None,
-        variables: Optional[list] = None,
+        variables: Optional[List] = None,
         zoom_level: Optional[int] = 0,
         geom: Optional[Geom] = None,
         bbox: Optional[Bbox] = None,
@@ -377,7 +377,7 @@ class RasterDatasetAdapter(DataAdapter):
         bbox: Optional[Bbox],
         cache_root: Optional[StrPath],
         zoom_level: Optional[int] = None,
-        variables: Optional[list] = None,
+        variables: Optional[List] = None,
         logger: Logger = logger,
     ):
         kwargs = self.driver_kwargs.copy()
@@ -477,7 +477,7 @@ class RasterDatasetAdapter(DataAdapter):
     @staticmethod
     def _slice_data(
         ds: Data,
-        variables: Optional[list] = None,
+        variables: Optional[List] = None,
         geom: Optional[Geom] = None,
         bbox: Optional[Bbox] = None,
         buffer: GeomBuffer = 0,

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -73,12 +73,21 @@ def test_rasterdataset(rioda, tmpdir):
     fn_tif = str(tmpdir.join("test.tif"))
     rioda_utm = rioda.raster.reproject(dst_crs="utm")
     rioda_utm.raster.to_raster(fn_tif)
+    fn_nc = str(tmpdir.join("test.nc"))
+    rioda_utm.to_netcdf(fn_nc)
     data_catalog = DataCatalog()
+
     da1 = data_catalog.get_rasterdataset(fn_tif, bbox=rioda.raster.bounds)
+    assert da1.name == "test"  # name is taken from file name
     assert np.all(da1 == rioda_utm)
-    geom = rioda.raster.box
-    da1 = data_catalog.get_rasterdataset("test.tif", geom=geom)
+    assert "test.tif" in data_catalog.sources
+
+    da1 = data_catalog.get_rasterdataset("test.tif", geom=rioda.raster.box)
     assert np.all(da1 == rioda_utm)
+
+    ds1 = data_catalog.get_rasterdataset(fn_tif, single_var_as_array=False)
+    assert isinstance(ds1, xr.Dataset)  # test single_var_as_array=False
+
     with pytest.raises(FileNotFoundError):
         data_catalog.get_rasterdataset("no_file.tif")
     with pytest.raises(NoDataException):
@@ -90,8 +99,12 @@ def test_rasterdataset(rioda, tmpdir):
         bbox=[12.5, 12.6, 12.7, 12.8],
         handle_nodata=NoDataStrategy.IGNORE,
     )
-
     assert da1 is None
+
+    da1 = data_catalog.get_rasterdataset(fn_tif, variables=["temp"])
+    assert da1.name == "temp"  # tif is renamed to variable name
+    with pytest.raises(NoDataException):  # nc variables are not renamed
+        da1 = data_catalog.get_rasterdataset(fn_nc, variables=["temp"])
 
 
 @pytest.mark.skipif(not compat.HAS_GCSFS, reason="GCSFS not installed.")


### PR DESCRIPTION
## Issue addressed
Fixes #881

## Explanation
Variables on datasets with only a single variable were not checked. The reason was that we want to automatically convert variable names from tif files (which get the file name as variable by default) if a variable is requested. This is important to make sure we can still read tif files based on the path if not set in the data catalog without getting errors on the variable name. I have moved this functionality to the raster driver and now make sure the check for variables always occurs.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [ ] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
@Jaapel this behaviour should also land in #857 
