### PR TITLE
small refactor driver

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -167,7 +167,7 @@ RasterDataset
 .. autosummary::
    :toctree: _generated
    drivers.rasterdataset_driver.RasterDatasetDriver
-   drivers.rasterdataset_driver.RasterDatasetDriver.read
+   drivers.rasterdataset_driver.RasterDatasetDriver.read_data
 
 ZarrDriver
 ^^^^^^^^^^
@@ -175,13 +175,13 @@ ZarrDriver
 .. autosummary::
    :toctree: _generated
    drivers.zarr_driver.ZarrDriver
-   drivers.zarr_driver.ZarrDriver.read
+   drivers.zarr_driver.ZarrDriver.read_data
 
 NetcdfDriver
 .. autosummary::
    :toctree: _generated
    drivers.netcdf_driver.NetcdfDriver
-   drivers.netcdf_driver.NetcdfDriver.read
+   drivers.netcdf_driver.NetcdfDriver.read_data
 
 GeoDataFrame
 ------------
@@ -189,7 +189,7 @@ GeoDataFrame
 .. autosummary::
    :toctree: _generated
    drivers.geodataframe_driver.GeoDataFrameDriver
-   drivers.geodataframe_driver.GeoDataFrameDriver.read
+   drivers.geodataframe_driver.GeoDataFrameDriver.read_data
 
 PyogrioDriver
 ^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ PyogrioDriver
 .. autosummary::
    :toctree: _generated
    drivers.pyogrio_driver.PyogrioDriver
-   drivers.pyogrio_driver.PyogrioDriver.read
+   drivers.pyogrio_driver.PyogrioDriver.read_data
 
 DataAdapter
 ===========

--- a/hydromt/_typing/__init__.py
+++ b/hydromt/_typing/__init__.py
@@ -30,6 +30,7 @@ from .type_def import (
     TotalBounds,
     Variables,
     XArrayDict,
+    ZoomLevel,
 )
 
 __all__ = [
@@ -60,4 +61,5 @@ __all__ = [
     "DataType",
     "GeomBuffer",
     "Predicate",
+    "ZoomLevel",
 ]

--- a/hydromt/_typing/type_def.py
+++ b/hydromt/_typing/type_def.py
@@ -63,6 +63,7 @@ TimeRange = Annotated[
     BeforeValidator(_time_tuple_from_str),
     AfterValidator(_time_range_validate),
 ]
+ZoomLevel = Union[int, Tuple[float, str]]  # level OR (scale, resolution)
 Number = Union[int, float]
 SourceSpecDict = TypedDict(
     "SourceSpecDict", {"source": str, "provider": str, "version": Union[str, int]}

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -1202,7 +1202,6 @@ class DataCatalog(object):
         zoom_level: Optional[Union[int, tuple]] = None,
         buffer: Union[float, int] = 0,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
-        align: Optional[bool] = None,
         variables: Optional[Union[List, str]] = None,
         time_tuple: Optional[Tuple] = None,
         single_var_as_array: Optional[bool] = True,
@@ -1213,7 +1212,7 @@ class DataCatalog(object):
         """Return a clipped, sliced and unified RasterDataset.
 
         To clip the data to the area of interest, provide a `bbox` or `geom`,
-        with optional additional `buffer` and `align` arguments.
+        with optional additional `buffer` argument.
         To slice the data to the time period of interest, provide the `time_tuple`
         argument. To return only the dataset variables of interest provide the
         `variables` argument.
@@ -1243,8 +1242,6 @@ class DataCatalog(object):
             Buffer around the `bbox` or `geom` area of interest in pixels. By default 0.
         handle_nodata: NoDataStrategy, optional
             What to do if no data can be found.
-        align : float, optional
-            Resolution to align the bounding box, by default None
         variables : str or list of str, optional.
             Names of RasterDataset variables to return. By default all dataset variables
             are returned.
@@ -1291,7 +1288,6 @@ class DataCatalog(object):
                 geom,
                 bbox,
                 buffer,
-                align,
                 time_tuple,
                 logger=self.logger,
             )
@@ -1313,7 +1309,6 @@ class DataCatalog(object):
             geom=geom,
             buffer=buffer,
             zoom_level=zoom_level,
-            align=align,
             variables=variables,
             time_tuple=time_tuple,
             single_var_as_array=single_var_as_array,
@@ -1339,7 +1334,7 @@ class DataCatalog(object):
         """Return a clipped and unified GeoDataFrame (vector).
 
         To clip the data to the area of interest, provide a `bbox` or `geom`,
-        with optional additional `buffer` and `align` arguments.
+        with optional additional `buffer` argument.
         To return only the dataframe columns of interest provide the
         `variables` argument.
 
@@ -1365,8 +1360,6 @@ class DataCatalog(object):
             the predicate function against each item. Requires bbox or mask.
             By default 'intersects' options are:
             {'intersects', 'within', 'contains', 'overlaps', 'crosses', 'touches'},
-        align : float, optional
-            Resolution to align the bounding box, by default None
         variables : str or list of str, optional.
             Names of GeoDataFrame columns to return. By default all columns are
             returned.
@@ -1449,7 +1442,7 @@ class DataCatalog(object):
         """Return a clipped, sliced and unified GeoDataset.
 
         To clip the data to the area of interest, provide a `bbox` or `geom`,
-        with optional additional `buffer` and `align` arguments.
+        with optional additional `buffer` argument.
         To slice the data to the time period of interest, provide the
         `time_tuple` argument. To return only the dataset variables
         of interest provide the `variables` argument.

--- a/hydromt/data_source/data_source.py
+++ b/hydromt/data_source/data_source.py
@@ -48,7 +48,8 @@ class DataSource(BaseModel, ABC):
     root: Optional[str] = Field(default=None)
     version: Optional[str] = Field(default=None)
     provider: Optional[str] = Field(default=None)
-    crs: Optional[int] = Field(default=None)
+    # TODO: move crs, extent and data_adapter.nodata to metadata class https://github.com/Deltares/hydromt/issues/901
+    crs: Optional[Union[int, str]] = Field(default=None)  # 4326 or 'EPSG:4326'
     extent: Dict[str, Any] = Field(default_factory=dict)
 
     def summary(self) -> Dict[str, Any]:

--- a/hydromt/data_source/geodataframe.py
+++ b/hydromt/data_source/geodataframe.py
@@ -25,6 +25,7 @@ from hydromt._typing import (
 )
 from hydromt.data_adapter.geodataframe import GeoDataFrameAdapter
 from hydromt.drivers.geodataframe_driver import GeoDataFrameDriver
+from hydromt.gis.utils import parse_geom_bbox_buffer
 
 from .data_source import DataSource
 
@@ -55,11 +56,11 @@ class GeoDataFrameSource(DataSource):
     ) -> gpd.GeoDataFrame:
         """Use the driver and data adapter to read and harmonize the data."""
         self._used = True
+        if bbox is not None or (mask is not None and buffer > 0):
+            mask = parse_geom_bbox_buffer(mask, bbox, buffer)
         gdf: gpd.GeoDataFrame = self.driver.read(
             self.uri,
-            bbox=bbox,
-            geom=mask,
-            buffer=buffer,
+            mask=mask,
             crs=self.crs,
             predicate=predicate,
             variables=variables,
@@ -68,9 +69,7 @@ class GeoDataFrameSource(DataSource):
         )
         return self.data_adapter.transform(
             gdf,
-            bbox=bbox,
             mask=mask,
-            buffer=buffer,
             crs=self.crs,
             predicate=predicate,
             variables=variables,

--- a/hydromt/drivers/base_driver.py
+++ b/hydromt/drivers/base_driver.py
@@ -20,8 +20,12 @@ class BaseDriver(BaseModel, ABC):
 
     name: ClassVar[str]
     metadata_resolver: MetaDataResolver = Field(default_factory=RESOLVERS["convention"])
-    model_config = ConfigDict(extra="allow")
     filesystem: FS = Field(default=LocalFileSystem())
+    # TODO use options and remove ConfigDict(extra="allow"), see https://github.com/Deltares/hydromt/issues/899
+    # options: Dict[str, Any] = Field(default_factory=dict)
+
+    # Allow extra fields in the BaseDriver
+    model_config = ConfigDict(extra="allow")
 
     @field_validator("metadata_resolver", mode="before")
     @classmethod

--- a/hydromt/drivers/netcdf_driver.py
+++ b/hydromt/drivers/netcdf_driver.py
@@ -4,9 +4,8 @@ from logging import Logger
 from typing import Callable, List, Optional
 
 import xarray as xr
-from pyproj import CRS
 
-from hydromt._typing import Bbox, Geom, StrPath, TimeRange
+from hydromt._typing import Geom, StrPath, TimeRange, ZoomLevel
 from hydromt._typing.error import NoDataStrategy
 from hydromt.drivers.preprocessing import PREPROCESSORS
 from hydromt.drivers.rasterdataset_driver import RasterDatasetDriver
@@ -17,18 +16,13 @@ class NetcdfDriver(RasterDatasetDriver):
 
     name = "netcdf"
 
-    def read(
+    def read_data(
         self,
-        uri: str,
+        uris: List[str],
         *,
-        bbox: Optional[Bbox] = None,
         mask: Optional[Geom] = None,
-        buffer: float = 0,
-        crs: Optional[CRS] = None,
-        variables: Optional[List[str]] = None,
         time_range: Optional[TimeRange] = None,
-        predicate: str = "intersects",
-        zoom_level: int = 0,
+        zoom_level: Optional[ZoomLevel] = None,
         logger: Optional[Logger] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         **kwargs,
@@ -40,23 +34,9 @@ class NetcdfDriver(RasterDatasetDriver):
             preprocessor = PREPROCESSORS.get(preprocessor_name)
             if not preprocessor:
                 raise ValueError(f"unknown preprocessor: '{preprocessor_name}'")
-            kwargs.update({"preprocess": preprocessor})
 
-        uris: List[str] = self.metadata_resolver.resolve(
-            uri,
-            self.filesystem,
-            bbox=bbox,
-            mask=mask,
-            buffer=buffer,
-            predicate=predicate,
-            variables=variables,
-            time_range=time_range,
-            zoom_level=zoom_level,
-            handle_nodata=handle_nodata,
-            **kwargs,
-        )
-
-        return xr.open_mfdataset(uris, decode_coords="all", **kwargs)
+        # TODO: add **self.options, see https://github.com/Deltares/hydromt/issues/899
+        return xr.open_mfdataset(uris, decode_coords="all", preprocess=preprocessor)
 
     def write(
         self,

--- a/hydromt/drivers/rasterdataset_driver.py
+++ b/hydromt/drivers/rasterdataset_driver.py
@@ -5,9 +5,8 @@ from logging import Logger
 from typing import List, Optional
 
 import xarray as xr
-from pyproj import CRS
 
-from hydromt._typing import Bbox, Geom, StrPath, TimeRange
+from hydromt._typing import Geom, StrPath, TimeRange, ZoomLevel
 from hydromt._typing.error import NoDataStrategy
 
 from .base_driver import BaseDriver
@@ -16,22 +15,50 @@ from .base_driver import BaseDriver
 class RasterDatasetDriver(BaseDriver, ABC):
     """Abstract Driver to read GeoDataFrames."""
 
-    @abstractmethod
     def read(
         self,
         uri: str,
         *,
-        bbox: Optional[Bbox] = None,
         mask: Optional[Geom] = None,
-        buffer: float = 0.0,
-        crs: Optional[CRS] = None,
         variables: Optional[List[str]] = None,
         time_range: Optional[TimeRange] = None,
-        predicate: str = "intersects",
-        zoom_level: int = 0,
+        zoom_level: Optional[ZoomLevel] = None,
         logger: Optional[Logger] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         # TODO: https://github.com/Deltares/hydromt/issues/802
+        **kwargs,
+    ) -> xr.Dataset:
+        """Read in any compatible data source to an xarray Dataset."""
+        uris = self.metadata_resolver.resolve(
+            uri,
+            self.filesystem,
+            mask=mask,
+            time_range=time_range,
+            variables=variables,
+            zoom_level=zoom_level,
+            handle_nodata=handle_nodata,
+            **kwargs,
+        )
+        return self.read_data(
+            uris,
+            mask=mask,
+            time_range=time_range,
+            zoom_level=zoom_level,
+            logger=logger,
+            handle_nodata=handle_nodata,
+            **kwargs,
+        )
+
+    @abstractmethod
+    def read_data(
+        self,
+        uris: List[str],
+        *,
+        mask: Optional[Geom] = None,
+        time_range: Optional[TimeRange] = None,
+        zoom_level: Optional[ZoomLevel] = None,
+        logger: Logger,
+        handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         **kwargs,
     ) -> xr.Dataset:
         """

--- a/hydromt/drivers/zarr_driver.py
+++ b/hydromt/drivers/zarr_driver.py
@@ -5,9 +5,8 @@ from logging import Logger
 from typing import Callable, List, Optional
 
 import xarray as xr
-from pyproj import CRS
 
-from hydromt._typing import Bbox, Geom, StrPath, TimeRange
+from hydromt._typing import Geom, StrPath, TimeRange, ZoomLevel
 from hydromt._typing.error import NoDataStrategy
 from hydromt.drivers.preprocessing import PREPROCESSORS
 from hydromt.drivers.rasterdataset_driver import RasterDatasetDriver
@@ -18,18 +17,13 @@ class ZarrDriver(RasterDatasetDriver):
 
     name = "zarr"
 
-    def read(
+    def read_data(
         self,
-        uri: str,
+        uris: List[str],
         *,
-        bbox: Optional[Bbox] = None,
         mask: Optional[Geom] = None,
-        buffer: float = 0,
-        crs: Optional[CRS] = None,
-        variables: Optional[List[str]] = None,
         time_range: Optional[TimeRange] = None,
-        predicate: str = "intersects",
-        zoom_level: int = 0,
+        zoom_level: Optional[ZoomLevel] = None,
         logger: Optional[Logger] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         # TODO: https://github.com/Deltares/hydromt/issues/802
@@ -40,19 +34,6 @@ class ZarrDriver(RasterDatasetDriver):
 
         Args:
         """
-        uris = self.metadata_resolver.resolve(
-            uri,
-            self.filesystem,
-            bbox=bbox,
-            mask=mask,
-            buffer=buffer,
-            predicate=predicate,
-            variables=variables,
-            time_range=time_range,
-            zoom_level=zoom_level,
-            handle_nodata=handle_nodata,
-            **kwargs,
-        )
         preprocessor: Optional[Callable] = None
         preprocessor_name: Optional[str] = kwargs.get("preprocess")
         if preprocessor_name:

--- a/hydromt/gis/utils.py
+++ b/hydromt/gis/utils.py
@@ -210,7 +210,7 @@ def parse_geom_bbox_buffer(
     bbox: Optional[Bbox] = None,
     buffer: float = 0.0,
     crs: Optional[CRS] = None,
-):
+) -> Geom:
     """Parse geom or bbox to a (buffered) geometry.
 
     Arguments

--- a/hydromt/metadata_resolver/convention_resolver.py
+++ b/hydromt/metadata_resolver/convention_resolver.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from fsspec import AbstractFileSystem
 
-from hydromt._typing import Bbox, Geom, NoDataStrategy, Predicate, TimeRange
+from hydromt._typing import Geom, NoDataStrategy, TimeRange
 
 from .metadata_resolver import MetaDataResolver
 
@@ -95,13 +95,8 @@ class ConventionResolver(MetaDataResolver):
         fs: AbstractFileSystem,
         *,
         time_range: Optional[TimeRange] = None,
-        bbox: Optional[Bbox] = None,
-        # TODO: align? https://github.com/Deltares/hydromt/issues/874
         mask: Optional[Geom] = None,
-        buffer: float = 0.0,
-        predicate: Predicate = "intersects",
         variables: Optional[List[str]] = None,
-        zoom_level: int = 0,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         logger: Logger = logger,
         **kwargs,

--- a/hydromt/metadata_resolver/metadata_resolver.py
+++ b/hydromt/metadata_resolver/metadata_resolver.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 from fsspec import AbstractFileSystem
 from pydantic import BaseModel, Field
 
-from hydromt._typing import Bbox, Geom, NoDataStrategy, Predicate, TimeRange
+from hydromt._typing import Geom, NoDataStrategy, TimeRange
 
 logger: Logger = getLogger(__name__)
 
@@ -26,12 +26,8 @@ class MetaDataResolver(BaseModel, ABC):
         fs: AbstractFileSystem,
         *,
         time_range: Optional[TimeRange] = None,
-        bbox: Optional[Bbox] = None,
         mask: Optional[Geom] = None,
-        buffer: float = 0.0,
-        predicate: Predicate = "intersects",
         variables: Optional[List[str]] = None,
-        zoom_level: int = 0,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         logger: Optional[Logger] = logger,
         **kwargs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,7 +420,7 @@ def mock_geodf_driver(
     class MockGeoDataFrameDriver(GeoDataFrameDriver):
         name = "mock_geodf_driver"
 
-        def read(self, *args, **kwargs) -> gpd.GeoDataFrame:
+        def read_data(self, *args, **kwargs) -> gpd.GeoDataFrame:
             return geodf
 
     return MockGeoDataFrameDriver(metadata_resolver=mock_resolver)
@@ -433,7 +433,7 @@ def mock_raster_ds_driver(
     class MockRasterDatasetDriver(RasterDatasetDriver):
         name = "mock_raster_ds_driver"
 
-        def read(self, *args, **kwargs) -> xr.Dataset:
+        def read_data(self, *args, **kwargs) -> xr.Dataset:
             return rasterds
 
     return MockRasterDatasetDriver(metadata_resolver=mock_resolver)

--- a/tests/data_sources/test_data_source.py
+++ b/tests/data_sources/test_data_source.py
@@ -44,7 +44,7 @@ class TestGetNestedVar:
         class FakeGeoDfDriver(GeoDataFrameDriver):
             name = "test_reads_nested"
 
-            def read(self, **kwargs):
+            def read_data(self, **kwargs):
                 pass
 
         mock_geodf_driver = FakeGeoDfDriver(metadata_resolver={"name": "convention"})

--- a/tests/data_sources/test_geo_data_frame_source.py
+++ b/tests/data_sources/test_geo_data_frame_source.py
@@ -187,7 +187,7 @@ class TestGeoDataFrameSource:
             def write(self, path: StrPath, gdf: gpd.GeoDataFrame, **kwargs) -> None:
                 pass
 
-            def read(self, uri: str, **kwargs) -> gpd.GeoDataFrame:
+            def read_data(self, uri: str, **kwargs) -> gpd.GeoDataFrame:
                 return geodf
 
         return MockGeoDataFrameDriver

--- a/tests/data_sources/test_geo_data_frame_source.py
+++ b/tests/data_sources/test_geo_data_frame_source.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from os.path import basename
 from pathlib import Path
-from typing import Type, cast
+from typing import List, Type, cast
 from uuid import uuid4
 
 import geopandas as gpd
@@ -187,7 +187,10 @@ class TestGeoDataFrameSource:
             def write(self, path: StrPath, gdf: gpd.GeoDataFrame, **kwargs) -> None:
                 pass
 
-            def read_data(self, uri: str, **kwargs) -> gpd.GeoDataFrame:
+            def read(self, uri: str, **kwargs) -> gpd.GeoDataFrame:
+                return self.read_data([uri], **kwargs)
+
+            def read_data(self, uris: List[str], **kwargs) -> gpd.GeoDataFrame:
                 return geodf
 
         return MockGeoDataFrameDriver

--- a/tests/data_sources/test_raster_dataset_source.py
+++ b/tests/data_sources/test_raster_dataset_source.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Type
+from typing import List, Type
 
 import pytest
 import xarray as xr
@@ -105,7 +105,10 @@ class TestRasterDatasetSource:
             def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
                 pass
 
-            def read_data(self, uri: str, **kwargs) -> xr.Dataset:
+            def read(self, uri: str, **kwargs) -> xr.Dataset:
+                return self.read_data([uri], **kwargs)
+
+            def read_data(self, uris: List[str], **kwargs) -> xr.Dataset:
                 return rasterds
 
         return MockRasterDatasetDriver

--- a/tests/data_sources/test_raster_dataset_source.py
+++ b/tests/data_sources/test_raster_dataset_source.py
@@ -105,7 +105,7 @@ class TestRasterDatasetSource:
             def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
                 pass
 
-            def read(self, uri: str, **kwargs) -> xr.Dataset:
+            def read_data(self, uri: str, **kwargs) -> xr.Dataset:
                 return rasterds
 
         return MockRasterDatasetDriver

--- a/tests/drivers/test_pyogrio_driver.py
+++ b/tests/drivers/test_pyogrio_driver.py
@@ -91,14 +91,9 @@ class TestPyogrioDriver:
     ):
         uri = request.getfixturevalue(uri)
         bbox: Bbox = (-60, -34.5600, -55, -30)
-        gdf: gpd.GeoDataFrame = driver.read(
-            uri, bbox=(-60, -34.5600, -55, -30), buffer=10000
-        )
+        mask = gpd.GeoSeries(box(*bbox), crs=4326).to_crs(3857).buffer(10000)
+        gdf = driver.read(uri, mask=mask)
         assert gdf.shape == (1, 4)
-        gdf = driver.read(uri, mask=gpd.GeoSeries(box(*bbox)), buffer=10000)
-        assert gdf.shape == (1, 4)
-        with pytest.raises(ValueError, match="Both 'bbox' and 'mask' are provided."):
-            driver.read(uri, bbox=bbox, mask=gpd.GeoSeries(box(*bbox)), buffer=10000)
 
     def test_write(self, geodf: gpd.GeoDataFrame, tmp_dir: Path):
         df_path = tmp_dir / "temp.gpkg"


### PR DESCRIPTION
## Issue addressed
Fixes #874 #902 

## Explanation
- transform (mask, bbox, buffer) to mask early on in Source to reduce arguments downstream
- remove unnecessary arguments 
- create `Driver.read_data` method to avoid duplication of identical code to resolve the uris in `Driver.read`
- remove align argument from DataCatalog.get_rasterdataset, fixes #874 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `v1`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed