### PR TITLE
Update pixi to 0.21.1

### DIFF
--- a/.github/workflows/check-data-catalogs.yml
+++ b/.github/workflows/check-data-catalogs.yml
@@ -29,9 +29,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: prefix-dev/setup-pixi@v0.5.1
+      - uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: "v0.15.2"
+          pixi-version: "v0.21.1"
           environments: min-py311
       - name: Prepare pixi
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,9 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v3
-      - uses: prefix-dev/setup-pixi@v0.5.1
+      - uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: "v0.15.2"
+          pixi-version: "v0.21.1"
           environments: full-py311
       - name: Prepare pixi
         run: |

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: prefix-dev/setup-pixi@v0.5.1
+      - uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: "v0.15.2"
+          pixi-version: "v0.21.1"
           cache: false
       - name: Update pixi lock file
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,9 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.5.1
+      - uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: "v0.15.2"
+          pixi-version: "v0.21.1"
           environments: full-py${{ matrix.python-version }}
       - name: Prepare pixi
         run: |


### PR DESCRIPTION
## Explanation
Update pixi to the latest version so people with multiple Deltares repositories on their PC don't have to switch pixi versions.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
- [x] For predefined catalogs: update the catalog version in the file itself, the references in data/predefined_catalogs.yml, and the changelog in data/changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
