### PR TITLE
Add URI resolver for raster_tindex files

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -184,6 +184,14 @@ ConventionResolver
    metadata_resolver.convention_resolver.ConventionResolver
    metadata_resolver.convention_resolver.ConventionResolver.resolve
 
+RasterTindexResolver
+--------------------
+.. autosummary::
+   :toctree: _generated
+
+   metadata_resolver.raster_tindex_resolver.RasterTindexResolver
+      metadata_resolver.raster_tindex_resolver.RasterTindexResolver.resolve
+
 Driver
 ======
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -190,7 +190,7 @@ RasterTindexResolver
    :toctree: _generated
 
    metadata_resolver.raster_tindex_resolver.RasterTindexResolver
-      metadata_resolver.raster_tindex_resolver.RasterTindexResolver.resolve
+   metadata_resolver.raster_tindex_resolver.RasterTindexResolver.resolve
 
 Driver
 ======

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Added
 - Added a `DatasetsComponent` to manage multidimensional data of a model. (#894)
 - Added a `GeoDatasetDriver` to read vector data from tabular formats. (#912)
 - Added a `GeoDatasetSource` to handle vector data from tabular formats. (#912)
+- Added `RasterTindexResolver` to handle URIs in raster tindex files. (#928)
 
 Changed
 -------

--- a/hydromt/drivers/raster/rasterdataset_driver.py
+++ b/hydromt/drivers/raster/rasterdataset_driver.py
@@ -55,6 +55,7 @@ class RasterDatasetDriver(BaseDriver, ABC):
             variables=variables,
             zoom_level=zoom_level,
             handle_nodata=handle_nodata,
+            options=self.options,
         )
         return self.read_data(
             uris,

--- a/hydromt/drivers/raster/rasterio_driver.py
+++ b/hydromt/drivers/raster/rasterio_driver.py
@@ -1,4 +1,5 @@
 """Driver using rasterio for RasterDataset."""
+
 from glob import glob
 from io import IOBase
 from logging import Logger, getLogger
@@ -91,6 +92,9 @@ class RasterioDriver(RasterDatasetDriver):
         #     if isinstance(zoom_level, int) and zoom_level > 0:
         #         # NOTE: overview levels start at zoom_level 1, see _get_zoom_levels_and_crs
         #         kwargs.update(overview_level=zoom_level - 1)
+
+        if mask:
+            kwargs.update({"mask": mask})
         ds = open_mfraster(uris, logger=logger, **kwargs)
         # rename ds with single band if single variable is requested
         if variables is not None and len(variables) == 1 and len(ds.data_vars) == 1:

--- a/hydromt/metadata_resolver/convention_resolver.py
+++ b/hydromt/metadata_resolver/convention_resolver.py
@@ -93,6 +93,7 @@ class ConventionResolver(MetaDataResolver):
         variables: Optional[List[str]] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         logger: Logger = logger,
+        options: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """Resolve the placeholders in the URI."""
         warn_on_unused_kwargs(

--- a/hydromt/metadata_resolver/metadata_resolver.py
+++ b/hydromt/metadata_resolver/metadata_resolver.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from logging import Logger, getLogger
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fsspec import AbstractFileSystem
 from pydantic import BaseModel, ConfigDict
@@ -29,6 +29,7 @@ class MetaDataResolver(BaseModel, ABC):
         zoom_level: Optional[ZoomLevel] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         logger: Optional[Logger] = logger,
+        options: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """Resolve metadata of data behind a single URI."""
         ...

--- a/hydromt/metadata_resolver/raster_tindex_resolver.py
+++ b/hydromt/metadata_resolver/raster_tindex_resolver.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Union
 import geopandas as gpd
 from fsspec import AbstractFileSystem
 
-from hydromt._typing import Geom, NoDataStrategy, TimeRange, ZoomLevel
+from hydromt._typing import NoDataStrategy, TimeRange, ZoomLevel
 from hydromt.metadata_resolver.metadata_resolver import MetaDataResolver
 
 logger: Logger = getLogger(__name__)
@@ -21,9 +21,9 @@ class RasterTindexResolver(MetaDataResolver):
         self,
         uri: str,
         fs: AbstractFileSystem,
+        mask: Optional[gpd.GeoDataFrame] = None,
         *,
         time_range: Optional[TimeRange] = None,
-        mask: Optional[Geom] = None,
         zoom_level: Optional[ZoomLevel] = None,
         variables: Union[int, tuple[float, str], None] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,

--- a/hydromt/metadata_resolver/raster_tindex_resolver.py
+++ b/hydromt/metadata_resolver/raster_tindex_resolver.py
@@ -35,7 +35,9 @@ class RasterTindexResolver(MetaDataResolver):
         gdf = gdf.iloc[gdf.sindex.query(mask.to_crs(gdf.crs).unary_union)]
         tileindex: Optional[str] = options.get("tileindex")
         if tileindex is None:
-            raise ValueError(f"{self.__class__.__name__} needs options specifying 'tileindex'}")
+            raise ValueError(
+                f"{self.__class__.__name__} needs options specifying 'tileindex'"
+            )
         if gdf.index.size == 0:
             raise IOError("No intersecting tiles found.")
         elif tileindex not in gdf.columns:

--- a/hydromt/metadata_resolver/raster_tindex_resolver.py
+++ b/hydromt/metadata_resolver/raster_tindex_resolver.py
@@ -33,7 +33,9 @@ class RasterTindexResolver(MetaDataResolver):
         """Resolve URIs of a raster tindex file."""
         gdf = gpd.read_file(uri)
         gdf = gdf.iloc[gdf.sindex.query(mask.to_crs(gdf.crs).unary_union)]
-        tileindex = options.get("tileindex")
+        tileindex: Optional[str] = options.get("tileindex")
+        if tileindex is None:
+            raise ValueError(f"{self.__class__.__name__} needs options specifying 'tileindex'}")
         if gdf.index.size == 0:
             raise IOError("No intersecting tiles found.")
         elif tileindex not in gdf.columns:

--- a/hydromt/metadata_resolver/raster_tindex_resolver.py
+++ b/hydromt/metadata_resolver/raster_tindex_resolver.py
@@ -1,0 +1,50 @@
+"""MetaDataResolver for raster tindex files."""
+
+from logging import Logger, getLogger
+from os.path import abspath, dirname, join
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import geopandas as gpd
+from fsspec import AbstractFileSystem
+
+from hydromt._typing import Geom, NoDataStrategy, TimeRange, ZoomLevel
+from hydromt.metadata_resolver.metadata_resolver import MetaDataResolver
+
+logger: Logger = getLogger(__name__)
+
+
+class RasterTindexResolver(MetaDataResolver):
+    """Implementation of the MetaDataResolver for raster tindex files."""
+
+    def resolve(
+        self,
+        uri: str,
+        fs: AbstractFileSystem,
+        *,
+        time_range: Optional[TimeRange] = None,
+        mask: Optional[Geom] = None,
+        zoom_level: Optional[ZoomLevel] = None,
+        variables: Union[int, tuple[float, str], None] = None,
+        handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
+        logger: Optional[Logger] = logger,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> List[str]:
+        """Resolve URIs of a raster tindex file."""
+        gdf = gpd.read_file(uri)
+        gdf = gdf.iloc[gdf.sindex.query(mask.to_crs(gdf.crs).unary_union)]
+        tileindex = options.get("tileindex")
+        if gdf.index.size == 0:
+            raise IOError("No intersecting tiles found.")
+        elif tileindex not in gdf.columns:
+            raise IOError(
+                f'Tile index "{tileindex}" column missing in tile index file.'
+            )
+        else:
+            root = dirname(uri)
+            paths = []
+            for fn in gdf[tileindex]:
+                path = str(Path(str(fn)))
+                if not path.is_absolute():
+                    paths.append(str(Path(abspath(join(root, fn)))))
+        return paths

--- a/hydromt/metadata_resolver/raster_tindex_resolver.py
+++ b/hydromt/metadata_resolver/raster_tindex_resolver.py
@@ -44,7 +44,7 @@ class RasterTindexResolver(MetaDataResolver):
             root = dirname(uri)
             paths = []
             for fn in gdf[tileindex]:
-                path = str(Path(str(fn)))
+                path = Path(str(fn))
                 if not path.is_absolute():
                     paths.append(str(Path(abspath(join(root, fn)))))
         return paths

--- a/tests/metadata_resolvers/test_raster_tindex_resolver.py
+++ b/tests/metadata_resolvers/test_raster_tindex_resolver.py
@@ -1,0 +1,95 @@
+import os
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from fsspec import AbstractFileSystem
+from shapely.geometry import box
+
+from hydromt.metadata_resolver.raster_tindex_resolver import RasterTindexResolver
+
+
+@pytest.fixture()
+def raster_tindex():
+    raster_tindex_dict = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "id": "1",
+                "type": "Feature",
+                "properties": {
+                    "location": "GRWL_mask_V01.01//NA18.tif",
+                    "EPSG": "EPSG:32618",
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-78.0081091502138, 4.000817142717678],
+                            [-71.99333022015983, 4.000822441345486],
+                            [-72.00061525372493, 0.0005420901698317547],
+                            [-78.00082064189185, 0.0005420894530163727],
+                            [-78.0081091502138, 4.000817142717678],
+                        ]
+                    ],
+                },
+            },
+            {
+                "id": "2",
+                "type": "Feature",
+                "properties": {
+                    "location": "GRWL_mask_V01.01//NA19.tif",
+                    "EPSG": "EPSG:32619",
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-72.0081091502138, 4.000817142717678],
+                            [-65.99333022015983, 4.000822441345486],
+                            [-66.00061525372493, 0.0005420901698317547],
+                            [-72.00082064189183, 0.0005420894530163727],
+                            [-72.0081091502138, 4.000817142717678],
+                        ]
+                    ],
+                },
+            },
+        ],
+    }
+    gdf = gpd.GeoDataFrame.from_features(raster_tindex_dict)
+    gdf.set_crs(crs=4326, inplace=True)
+    return gdf
+
+
+def test_raster_tindex_resolver(raster_tindex, tmpdir):
+    geom = raster_tindex.iloc[[0]]
+    fp = os.path.join(tmpdir, "raster_tindex.gpkg")
+    raster_tindex.to_file(fp)
+    options = {"tileindex": "location"}
+    resolver = RasterTindexResolver()
+    paths = resolver.resolve(
+        uri=fp, fs=AbstractFileSystem(), mask=geom, options=options
+    )
+    for file in raster_tindex["location"]:
+        path = str(Path(os.path.join(tmpdir, file)))
+        assert path in paths
+
+    geom = gpd.GeoDataFrame(geometry=[box(-66, 1, 65, 3)], crs=4326)
+    paths = resolver.resolve(
+        uri=fp, fs=AbstractFileSystem(), mask=geom, options=options
+    )
+    assert len(paths) == 1
+    path = str(Path(os.path.join(tmpdir, "GRWL_mask_V01.01\\NA19.tif")))
+    assert path in paths
+
+    options = {"tileindex": "file"}
+    with pytest.raises(
+        IOError,
+        match='Tile index "file" column missing in tile index file.',
+    ):
+        resolver.resolve(uri=fp, fs=AbstractFileSystem(), mask=geom, options=options)
+
+    geom = gpd.GeoDataFrame(geometry=[box(4, 52, 5, 53)], crs=4326)
+
+    with pytest.raises(IOError, match="No intersecting tiles found."):
+        resolver.resolve(uri=fp, fs=AbstractFileSystem(), mask=geom, options=options)

--- a/tests/metadata_resolvers/test_raster_tindex_resolver.py
+++ b/tests/metadata_resolvers/test_raster_tindex_resolver.py
@@ -72,11 +72,11 @@ class TestRasterTindexResolver:
         )
         assert len(paths) == 2
         assert (
-            str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01\\NA19.tif")))
+            str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01/NA19.tif")))
             in paths
         )
         assert (
-            str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01\\NA18.tif")))
+            str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01/NA18.tif")))
             in paths
         )
 
@@ -85,7 +85,7 @@ class TestRasterTindexResolver:
             uri=raster_tindex, fs=AbstractFileSystem(), mask=geom, options=options
         )
         assert len(paths) == 1
-        path = str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01\\NA19.tif")))
+        path = str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01/NA19.tif")))
         assert path in paths
 
     def test_raises_no_tileindex(self, raster_tindex):

--- a/tests/metadata_resolvers/test_raster_tindex_resolver.py
+++ b/tests/metadata_resolvers/test_raster_tindex_resolver.py
@@ -1,4 +1,4 @@
-import os
+from os.path import dirname, join
 from pathlib import Path
 
 import geopandas as gpd
@@ -9,87 +9,102 @@ from shapely.geometry import box
 from hydromt.metadata_resolver.raster_tindex_resolver import RasterTindexResolver
 
 
-@pytest.fixture()
-def raster_tindex():
-    raster_tindex_dict = {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "id": "1",
-                "type": "Feature",
-                "properties": {
-                    "location": "GRWL_mask_V01.01//NA18.tif",
-                    "EPSG": "EPSG:32618",
+class TestRasterTindexResolver:
+    @pytest.fixture()
+    def raster_tindex(self, tmpdir):
+        raster_tindex_dict = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "id": "1",
+                    "type": "Feature",
+                    "properties": {
+                        "location": "GRWL_mask_V01.01//NA18.tif",
+                        "EPSG": "EPSG:32618",
+                    },
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-78.0081091502138, 4.000817142717678],
+                                [-71.99333022015983, 4.000822441345486],
+                                [-72.00061525372493, 0.0005420901698317547],
+                                [-78.00082064189185, 0.0005420894530163727],
+                                [-78.0081091502138, 4.000817142717678],
+                            ]
+                        ],
+                    },
                 },
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": [
-                        [
-                            [-78.0081091502138, 4.000817142717678],
-                            [-71.99333022015983, 4.000822441345486],
-                            [-72.00061525372493, 0.0005420901698317547],
-                            [-78.00082064189185, 0.0005420894530163727],
-                            [-78.0081091502138, 4.000817142717678],
-                        ]
-                    ],
+                {
+                    "id": "2",
+                    "type": "Feature",
+                    "properties": {
+                        "location": "GRWL_mask_V01.01//NA19.tif",
+                        "EPSG": "EPSG:32619",
+                    },
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-72.0081091502138, 4.000817142717678],
+                                [-65.99333022015983, 4.000822441345486],
+                                [-66.00061525372493, 0.0005420901698317547],
+                                [-72.00082064189183, 0.0005420894530163727],
+                                [-72.0081091502138, 4.000817142717678],
+                            ]
+                        ],
+                    },
                 },
-            },
-            {
-                "id": "2",
-                "type": "Feature",
-                "properties": {
-                    "location": "GRWL_mask_V01.01//NA19.tif",
-                    "EPSG": "EPSG:32619",
-                },
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": [
-                        [
-                            [-72.0081091502138, 4.000817142717678],
-                            [-65.99333022015983, 4.000822441345486],
-                            [-66.00061525372493, 0.0005420901698317547],
-                            [-72.00082064189183, 0.0005420894530163727],
-                            [-72.0081091502138, 4.000817142717678],
-                        ]
-                    ],
-                },
-            },
-        ],
-    }
-    gdf = gpd.GeoDataFrame.from_features(raster_tindex_dict)
-    gdf.set_crs(crs=4326, inplace=True)
-    return gdf
+            ],
+        }
+        gdf = gpd.GeoDataFrame.from_features(raster_tindex_dict)
+        gdf.set_crs(crs=4326, inplace=True)
+        fp = join(tmpdir, "raster_tindex.gpkg")
+        gdf.to_file(fp)
+        return fp
 
+    def test_resolves_correctly(self, raster_tindex):
+        geom = gpd.GeoDataFrame(geometry=[box(-78, 0.0005, -65, 4)], crs=4326)
+        options = {"tileindex": "location"}
+        resolver = RasterTindexResolver()
+        paths = resolver.resolve(
+            uri=raster_tindex, fs=AbstractFileSystem(), mask=geom, options=options
+        )
+        assert len(paths) == 2
+        assert (
+            str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01\\NA19.tif")))
+            in paths
+        )
+        assert (
+            str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01\\NA18.tif")))
+            in paths
+        )
 
-def test_raster_tindex_resolver(raster_tindex, tmpdir):
-    geom = raster_tindex.iloc[[0]]
-    fp = os.path.join(tmpdir, "raster_tindex.gpkg")
-    raster_tindex.to_file(fp)
-    options = {"tileindex": "location"}
-    resolver = RasterTindexResolver()
-    paths = resolver.resolve(
-        uri=fp, fs=AbstractFileSystem(), mask=geom, options=options
-    )
-    for file in raster_tindex["location"]:
-        path = str(Path(os.path.join(tmpdir, file)))
+        geom = gpd.GeoDataFrame(geometry=[box(-66, 1, 65, 3)], crs=4326)
+        paths = resolver.resolve(
+            uri=raster_tindex, fs=AbstractFileSystem(), mask=geom, options=options
+        )
+        assert len(paths) == 1
+        path = str(Path(join(dirname(raster_tindex), "GRWL_mask_V01.01\\NA19.tif")))
         assert path in paths
 
-    geom = gpd.GeoDataFrame(geometry=[box(-66, 1, 65, 3)], crs=4326)
-    paths = resolver.resolve(
-        uri=fp, fs=AbstractFileSystem(), mask=geom, options=options
-    )
-    assert len(paths) == 1
-    path = str(Path(os.path.join(tmpdir, "GRWL_mask_V01.01\\NA19.tif")))
-    assert path in paths
+    def test_raises_no_tileindex(self, raster_tindex):
+        resolver = RasterTindexResolver()
+        options = {"tileindex": "file"}
+        geom = gpd.GeoDataFrame(geometry=[box(-78, 0.0005, -65, 4)], crs=4326)
+        with pytest.raises(
+            IOError,
+            match='Tile index "file" column missing in tile index file.',
+        ):
+            resolver.resolve(
+                uri=raster_tindex, fs=AbstractFileSystem(), mask=geom, options=options
+            )
 
-    options = {"tileindex": "file"}
-    with pytest.raises(
-        IOError,
-        match='Tile index "file" column missing in tile index file.',
-    ):
-        resolver.resolve(uri=fp, fs=AbstractFileSystem(), mask=geom, options=options)
-
-    geom = gpd.GeoDataFrame(geometry=[box(4, 52, 5, 53)], crs=4326)
-
-    with pytest.raises(IOError, match="No intersecting tiles found."):
-        resolver.resolve(uri=fp, fs=AbstractFileSystem(), mask=geom, options=options)
+    def test_raises_no_intersecting_files(self, raster_tindex):
+        resolver = RasterTindexResolver()
+        options = {"tileindex": "file"}
+        geom = gpd.GeoDataFrame(geometry=[box(4, 52, 5, 53)], crs=4326)
+        with pytest.raises(IOError, match="No intersecting tiles found."):
+            resolver.resolve(
+                uri=raster_tindex, fs=AbstractFileSystem(), mask=geom, options=options
+            )

--- a/tests/metadata_resolvers/test_raster_tindex_resolver.py
+++ b/tests/metadata_resolvers/test_raster_tindex_resolver.py
@@ -90,6 +90,17 @@ class TestRasterTindexResolver:
 
     def test_raises_no_tileindex(self, raster_tindex):
         resolver = RasterTindexResolver()
+        geom = gpd.GeoDataFrame(geometry=[box(-78, 0.0005, -65, 4)], crs=4326)
+        with pytest.raises(
+            ValueError,
+            match="RasterTindexResolver needs options specifying 'tileindex'",
+        ):
+            resolver.resolve(
+                uri=raster_tindex, fs=AbstractFileSystem(), mask=geom, options={}
+            )
+
+    def test_raises_missing_tileindex(self, raster_tindex):
+        resolver = RasterTindexResolver()
         options = {"tileindex": "file"}
         geom = gpd.GeoDataFrame(geometry=[box(-78, 0.0005, -65, 4)], crs=4326)
         with pytest.raises(


### PR DESCRIPTION
## Issue addressed
Fixes #856 

## Explanation


## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist
- [x] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [x] None of the old `data_catalog.yml` files have been chagned
- [ ] `data/chagnelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
