### PR TITLE
added .yml to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.yaml text eol=lf
+*.yml text eol=lf
 
 # GitHub syntax highlighting
 pixi.lock linguist-language=YAML


### PR DESCRIPTION
## Explanation
The widcard in the git attributes to enforce correct line endings was misscpecified. we specified it as `*.yaml` and we should have included `*.yml`. This PR fixes that. 

## General Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist
- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been chagned
- [ ] `data/chagnelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
