### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/test_error_free.yml
+++ b/.github/workflows/test_error_free.yml
@@ -1,0 +1,61 @@
+name: Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - v1
+    paths:
+      - tests/**/*
+      - hydromt/**/*
+      - data/**/*
+      - pyproject.toml
+      - pixi.lock
+      - pixi.toml
+      - .github/workflows/tests.yml
+  pull_request:
+    branches:
+      - main
+      - v1
+    paths:
+      - tests/**/*
+      - hydromt/**/*
+      - data/**/*
+      - pyproject.toml
+      - pixi.lock
+      - pixi.toml
+      - .github/workflows/tests.yml
+
+
+jobs:
+  build:
+    defaults:
+      run:
+        shell: bash -e -l {0}
+    name: test for warnings
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-warning-free-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.6.0
+        with:
+          pixi-version: "v0.21.1"
+          environments: full-py${{ matrix.python-version }}
+      - name: Prepare pixi
+        run: |
+          pixi run --locked -e full-py${{ matrix.python-version }} install-hydromt
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
+      - name: Test
+        run: |
+          export NUMBA_DISABLE_JIT=1
+          pixi run --locked -e full-py312 test-err-warn

--- a/.github/workflows/test_error_free.yml
+++ b/.github/workflows/test_error_free.yml
@@ -48,7 +48,7 @@ jobs:
           environments: full-py311
       - name: Prepare pixi
         run: |
-          pixi run --locked -e full-311 install-hydromt
+          pixi run --locked -e full-py311 install-hydromt
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
@@ -58,4 +58,4 @@ jobs:
       - name: Test
         run: |
           export NUMBA_DISABLE_JIT=1
-          pixi run --locked -e full-311 test-err-warn
+          pixi run --locked -e full-py311 test-err-warn

--- a/.github/workflows/test_error_free.yml
+++ b/.github/workflows/test_error_free.yml
@@ -45,10 +45,10 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.6.0
         with:
           pixi-version: "v0.21.1"
-          environments: full-py312
+          environments: full-py311
       - name: Prepare pixi
         run: |
-          pixi run --locked -e full-py312 install-hydromt
+          pixi run --locked -e full-311 install-hydromt
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
@@ -58,4 +58,4 @@ jobs:
       - name: Test
         run: |
           export NUMBA_DISABLE_JIT=1
-          pixi run --locked -e full-py312 test-err-warn
+          pixi run --locked -e full-311 test-err-warn

--- a/.github/workflows/test_error_free.yml
+++ b/.github/workflows/test_error_free.yml
@@ -45,10 +45,10 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.6.0
         with:
           pixi-version: "v0.21.1"
-          environments: full-py${{ matrix.python-version }}
+          environments: full-py312
       - name: Prepare pixi
         run: |
-          pixi run --locked -e full-py${{ matrix.python-version }} install-hydromt
+          pixi run --locked -e full-py312 install-hydromt
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/.github/workflows/test_error_free.yml
+++ b/.github/workflows/test_error_free.yml
@@ -45,10 +45,10 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.6.0
         with:
           pixi-version: "v0.21.1"
-          environments: full-py311
+          environments: full-py39
       - name: Prepare pixi
         run: |
-          pixi run --locked -e full-py311 install-hydromt
+          pixi run --locked -e full-py39 install-hydromt
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
@@ -58,4 +58,4 @@ jobs:
       - name: Test
         run: |
           export NUMBA_DISABLE_JIT=1
-          pixi run --locked -e full-py311 test-err-warn
+          pixi run --locked -e full-py39 test-err-warn

--- a/hydromt/drivers/base_driver.py
+++ b/hydromt/drivers/base_driver.py
@@ -28,7 +28,6 @@ class BaseDriver(BaseModel, ABC):
     name: ClassVar[str]
     metadata_resolver: MetaDataResolver = Field(default_factory=RESOLVERS["convention"])
     filesystem: FS = Field(default=LocalFileSystem())
-    supports_writing: ClassVar[bool] = False
     options: Dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("metadata_resolver", mode="before")

--- a/hydromt/drivers/base_driver.py
+++ b/hydromt/drivers/base_driver.py
@@ -26,6 +26,7 @@ class BaseDriver(BaseModel, ABC):
     """
 
     name: ClassVar[str]
+    supports_writing: ClassVar[bool] = False
     metadata_resolver: MetaDataResolver = Field(default_factory=RESOLVERS["convention"])
     filesystem: FS = Field(default=LocalFileSystem())
     options: Dict[str, Any] = Field(default_factory=dict)

--- a/hydromt/drivers/dataframe/pandas_driver.py
+++ b/hydromt/drivers/dataframe/pandas_driver.py
@@ -2,7 +2,7 @@
 
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import ClassVar, List, Optional
+from typing import List, Optional
 
 import pandas as pd
 
@@ -23,7 +23,7 @@ class PandasDriver(DataFrameDriver):
     """Driver for DataFrames using the pandas library."""
 
     name = "pandas"
-    supports_writing: ClassVar[bool] = True
+    supports_writing = True
 
     def read_data(
         self,

--- a/hydromt/drivers/geodataframe/pyogrio_driver.py
+++ b/hydromt/drivers/geodataframe/pyogrio_driver.py
@@ -1,7 +1,7 @@
 """Driver to read geodataframes using Pyogrio."""
 
 from logging import Logger, getLogger
-from typing import ClassVar, List, Optional
+from typing import List, Optional
 
 import geopandas as gpd
 from pyogrio import read_dataframe, read_info, write_dataframe
@@ -19,7 +19,7 @@ class PyogrioDriver(GeoDataFrameDriver):
     """Driver to read GeoDataFrames using the `pyogrio` package."""
 
     name = "pyogrio"
-    supports_writing: ClassVar[bool] = True
+    supports_writing = True
 
     def read_data(
         self,

--- a/hydromt/drivers/geodataset/xarray_driver.py
+++ b/hydromt/drivers/geodataset/xarray_driver.py
@@ -4,7 +4,7 @@ from copy import copy
 from functools import partial
 from logging import Logger, getLogger
 from os.path import splitext
-from typing import Callable, ClassVar, List, Optional
+from typing import Callable, List, Optional
 
 import xarray as xr
 
@@ -27,7 +27,7 @@ class GeoDatasetXarrayDriver(GeoDatasetDriver):
     """GeoDatasetXarrayDriver."""
 
     name = "geodataset_xarray"
-    supports_writing: ClassVar[bool] = True
+    supports_writing = True
 
     def read_data(
         self,

--- a/hydromt/drivers/raster/raster_xarray_driver.py
+++ b/hydromt/drivers/raster/raster_xarray_driver.py
@@ -4,7 +4,7 @@ from copy import copy
 from functools import partial
 from logging import Logger, getLogger
 from os.path import splitext
-from typing import Callable, ClassVar, List, Optional
+from typing import Callable, List, Optional
 
 import xarray as xr
 
@@ -28,7 +28,7 @@ class RasterDatasetXarrayDriver(RasterDatasetDriver):
     """RasterDatasetXarrayDriver."""
 
     name = "raster_xarray"
-    supports_writing: ClassVar[bool] = True
+    supports_writing = True
 
     def read_data(
         self,

--- a/pixi.toml
+++ b/pixi.toml
@@ -124,6 +124,7 @@ clean-docs-exmaples = { cmd = ["rm", "-rf", "docs/examples"] }
 
 test = { cmd = ["pytest"] }
 test-lf = { cmd = ["pytest", "--lf", "--tb=short"] }
+test-err-warn = { cmd = ["pytest", "--tb=short", "-W", "error"] }
 test-cov = { cmd = [
   "pytest",
   "--verbose",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from os import sep
 from os.path import abspath, dirname, join
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Generator, Optional, cast
+from typing import Any, ClassVar, Dict, Generator, Optional, cast
 
 import geopandas as gpd
 import numpy as np
@@ -523,7 +523,7 @@ def mock_raster_ds_driver(
 ) -> RasterDatasetDriver:
     class MockRasterDatasetDriver(RasterDatasetDriver):
         name = "mock_raster_ds_driver"
-        supports_writing: bool = True
+        supports_writing: ClassVar[bool] = True
 
         def read_data(self, *args, **kwargs) -> xr.Dataset:
             return raster_ds
@@ -537,7 +537,7 @@ def mock_geo_ds_driver(
 ) -> GeoDatasetDriver:
     class MockGeoDatasetDriver(GeoDatasetDriver):
         name = "mock_geo_ds_driver"
-        supports_writing: bool = True
+        supports_writing: ClassVar[bool] = True
 
         def read_data(self, *args, **kwargs) -> xr.Dataset:
             return geoda.to_dataset()

--- a/tests/data_sources/test_geo_dataframe_source.py
+++ b/tests/data_sources/test_geo_dataframe_source.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from os.path import basename
 from pathlib import Path
-from typing import List, Type, cast
+from typing import ClassVar, List, Type, cast
 from uuid import uuid4
 
 import geopandas as gpd
@@ -200,7 +200,7 @@ class TestGeoDataFrameSource:
     def MockWriteableDriver(self, geodf: gpd.GeoDataFrame):
         class MockWritableGeoDataFrameDriver(GeoDataFrameDriver):
             name = "mock_geodf_to_file"
-            supports_writing: bool = True
+            supports_writing: ClassVar[bool] = True
 
             def write(self, path: StrPath, gdf: gpd.GeoDataFrame, **kwargs) -> None:
                 pass

--- a/tests/data_sources/test_geo_dataset_source.py
+++ b/tests/data_sources/test_geo_dataset_source.py
@@ -100,6 +100,7 @@ class TestGeoDatasetSource:
     def MockDriver(self, geoda: xr.Dataset):
         class MockGeoDatasetDriver(GeoDatasetDriver):
             name = "mock_geods_to_file"
+            supports_writing: bool = False
 
             def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
                 pass

--- a/tests/data_sources/test_geo_dataset_source.py
+++ b/tests/data_sources/test_geo_dataset_source.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Type
+from typing import ClassVar, List, Type
 
 import pytest
 import xarray as xr
@@ -100,10 +100,6 @@ class TestGeoDatasetSource:
     def MockDriver(self, geoda: xr.Dataset):
         class MockGeoDatasetDriver(GeoDatasetDriver):
             name = "mock_geods_to_file"
-            supports_writing: bool = False
-
-            def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
-                pass
 
             def read(self, uri: str, **kwargs) -> xr.Dataset:
                 kinda_ds = self.read_data([uri], **kwargs)
@@ -121,7 +117,7 @@ class TestGeoDatasetSource:
     def MockWritableDriver(self, geoda: xr.Dataset):
         class MockWriteableGeoDatasetDriver(GeoDatasetDriver):
             name = "mock_geods_to_file"
-            supports_writing: bool = True
+            supports_writing: ClassVar[bool] = True
 
             def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
                 pass

--- a/tests/data_sources/test_raster_dataset_source.py
+++ b/tests/data_sources/test_raster_dataset_source.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Type
+from typing import ClassVar, List, Type
 
 import pytest
 import xarray as xr
@@ -117,7 +117,7 @@ class TestRasterDatasetSource:
     def MockWritableDriver(self, raster_ds: xr.Dataset):
         class MockWritableRasterDatasetDriver(RasterDatasetDriver):
             name = "mock_rasterds_to_file"
-            supports_writing: bool = True
+            supports_writing: ClassVar[bool] = True
 
             def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
                 pass


### PR DESCRIPTION
## Explanation
Apparently pydantic doesn't like you overriding the class vars of parents. As I think it is important to stay warning free, I added a pixi test job and a (non-required) ci job to make sure that the test suite remains warning free.  We can also always allow/ignore warnings that we think are acceptable in the `pyproject.toml` 

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
