### PR TITLE
remove remaining deprecation warnings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,12 @@ Removed
 - `staticmaps` and `staticgeoms` attributes on the `Model` object have been removed. (#845)
 - Code refering to the unimplemented Network Model type has been removed (#871)
 - Removed `_API`, `.api` property, `test_api` and other `Model` level conventions as they are now handled by the components. (#894)
+- support for using aliases in the DataCatalog has been removed. (#987)
+- support for `storage_options` in the DataCatalog and adapters has been removed. (#987)
+- The function `hydromt.gis.flw.guagemap` has been removed in favour of `hydromt.gis.flw.guage_map`. (#987)
+- The function `hydromt.gis.flw.basinmap` has been removed in favour of `hydromt.gis.flw.basin_map`. (#987)
+- Support for using the `within` predicate in the function `get_basin_geometry` has been removed. (#987)
+
 
 
 Unreleased

--- a/hydromt/_validators/data_catalog.py
+++ b/hydromt/_validators/data_catalog.py
@@ -181,7 +181,6 @@ class DataCatalogValidator(BaseModel):
 
     meta: Optional[DataCatalogMetaData] = None
     sources: Dict[str, DataCatalogItem] = Field(default_factory=dict)
-    aliases: Dict[str, str] = Field(default_factory=dict)
 
     model_config: ConfigDict = ConfigDict(
         str_strip_whitespace=True,
@@ -197,22 +196,12 @@ class DataCatalogValidator(BaseModel):
             meta = input_dict.pop("meta", None)
             catalog_meta = DataCatalogMetaData.from_dict(meta)
             catalog_entries = {}
-            catalog_aliases = {}
             for entry_name, entry_dict in input_dict.items():
-                if "alias" in entry_dict.keys():
-                    catalog_aliases[entry_name] = entry_dict["alias"]
-                else:
-                    catalog_entries[entry_name] = DataCatalogItem.from_dict(
-                        entry_dict, name=entry_name
-                    )
+                catalog_entries[entry_name] = DataCatalogItem.from_dict(
+                    entry_dict, name=entry_name
+                )
 
-            for src, dst in catalog_aliases.items():
-                assert (
-                    dst in catalog_entries.keys()
-                ), f"{src} references unfound entry {dst}"
-            return DataCatalogValidator(
-                meta=catalog_meta, sources=catalog_entries, aliases=catalog_aliases
-            )
+            return DataCatalogValidator(meta=catalog_meta, sources=catalog_entries)
 
     @staticmethod
     def from_yml(path: str):

--- a/hydromt/cli/_utils.py
+++ b/hydromt/cli/_utils.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional, Union
 
 import click
 
-from hydromt._typing.error import DeprecatedError
 from hydromt.io import configread
 
 logger = logging.getLogger(__name__)
@@ -67,10 +66,6 @@ def parse_json(ctx, param, value: str) -> Dict[str, Any]:
     if isfile(value):
         with open(value, "r") as f:
             kwargs = json.load(f)
-
-    # Catch old keyword for resulution "-r"
-    elif type(literal_eval(value)) in (float, int):
-        raise DeprecatedError("'-r' is used for region, resolution is deprecated")
     else:
         if value.strip("{").startswith("'"):
             value = value.replace("'", '"')

--- a/hydromt/data_catalog/adapters/data_adapter.py
+++ b/hydromt/data_catalog/adapters/data_adapter.py
@@ -125,14 +125,6 @@ class DataAdapter(object, metaclass=ABCMeta):
                 str(path).split(".")[-1].lower(), self._DEFAULT_DRIVER
             )
         self.driver = driver
-        if "storage_options" in driver_kwargs:
-            warnings.warn(
-                "storage_options should be provided as a separate argument, "
-                "not as part of driver_kwargs",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            storage_options.update(driver_kwargs.pop("storage_options"))
         self.driver_kwargs = driver_kwargs
         self.storage_options = storage_options
         # get filesystem

--- a/hydromt/data_catalog/data_catalog.py
+++ b/hydromt/data_catalog/data_catalog.py
@@ -104,8 +104,6 @@ class DataCatalog(object):
             Currently only implemented for tiled rasterdatasets, by default False.
         cache_dir: str, Path, optional
             Folder root path to cach data to, by default ~/.hydromt_data
-        artifact_keys:
-            Deprecated from version v0.5
         logger : logger object, optional
             The logger object used for logging messages. If not provided, the default
             logger will be used.
@@ -1774,7 +1772,7 @@ def _process_dict(d: Dict, logger=logger) -> Dict:
 def _denormalise_data_dict(data_dict) -> List[Tuple[str, Dict]]:
     """Return a flat list of with data name, dictionary of input data_dict.
 
-    Expand possible versions, aliases and variants in data_dict.
+    Expand possible versions and variants in data_dict.
     """
     data_list = []
     for name, source in data_dict.items():

--- a/hydromt/gis/flw.py
+++ b/hydromt/gis/flw.py
@@ -438,35 +438,6 @@ def reproject_hydrography_like(
 ### hydrography maps ###
 
 
-def gaugemap(
-    ds: xr.Dataset,
-    idxs: Optional[np.ndarray] = None,
-    xy: Optional[Tuple] = None,
-    ids: Optional[np.ndarray] = None,
-    mask: Optional[xr.DataArray] = None,
-    flwdir: Optional[pyflwdir.FlwdirRaster] = None,
-    logger=logger,
-) -> xr.DataArray:
-    """Return map with unique gauge IDs.
-
-    This method is deprecated. See :py:meth:`~hydromt.flw.gauge_map`.
-    """
-    warnings.warn(
-        'The "gaugemap" method is deprecated, use  "hydromt.flw.gauge_map" instead.',
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return gauge_map(
-        ds=ds,
-        idxs=idxs,
-        xy=xy,
-        ids=ids,
-        stream=mask,
-        flwdir=flwdir,
-        logger=logger,
-    )
-
-
 def gauge_map(
     ds: Union[xr.Dataset, xr.DataArray],
     idxs: Optional[np.ndarray] = None,
@@ -676,38 +647,6 @@ def basin_map(
     if idxs is not None:
         xy = flwdir.xy(idxs)
     return da_basins, xy
-
-
-def basin_shape(
-    ds: xr.Dataset,
-    flwdir: pyflwdir.FlwdirRaster,
-    basin_name: str = "basins",
-    mask: bool = True,
-    **kwargs,
-) -> gpd.GeoDataFrame:
-    """Generate basins from a given dataset and flow direction raster.
-
-    This method is be deprecated. Use :py:meth:`~hydromt.flw.basin_map` in combination
-    with :py:meth:`~hydromt.raster.RasterDataArray.vectorize` instead.
-    """
-    warnings.warn(
-        "basin_shape is deprecated, use a combination of hydromt.flw.basin_map"
-        " and hydromt.raster.RasterDataArray.vectorize instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if basin_name not in ds:
-        ds[basin_name] = basin_map(ds, flwdir, **kwargs)[0]
-    elif not np.all(flwdir.shape == ds.raster.shape):
-        raise ValueError("flwdir and ds dimensions do not match")
-    da_basins = ds[basin_name]
-    nodata = da_basins.raster.nodata
-    if mask and "mask" in da_basins.coords and nodata is not None:
-        da_basins = da_basins.where(da_basins.coords["mask"] != 0, nodata)
-        da_basins.raster.set_nodata(nodata)
-    gdf = da_basins.raster.vectorize().set_index("value").sort_index()
-    gdf.index.name = basin_name
-    return gdf
 
 
 def clip_basins(

--- a/hydromt/model/processes/basin_mask.py
+++ b/hydromt/model/processes/basin_mask.py
@@ -5,7 +5,6 @@ Based on pre-cooked basin index files, basin maps or flow direction maps.
 """
 
 import logging
-import warnings
 
 import geopandas as gpd
 import numpy as np
@@ -92,13 +91,6 @@ def get_basin_geometry(
     if kind not in kind_lst:
         msg = f"Unknown kind: {kind}, select from {kind_lst}."
         raise ValueError(msg)
-    if bool(stream_kwargs.pop("within", False)):
-        warnings.warn(
-            '"within" stream argument has been deprecated.',
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     # check variables
     dvars = [flwdir_name] + [v for v in stream_kwargs]
     for name in dvars:

--- a/tests/_validators/test_data_catalog_validation.py
+++ b/tests/_validators/test_data_catalog_validation.py
@@ -55,34 +55,6 @@ def test_geodataframe_entry_validation():
     assert entry.path == Path("hydrography/hydro_atlas/basin_atlas_v10.gpkg")
 
 
-def test_valid_catalog_with_alias():
-    d = {
-        "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
-        "chelsa": {"alias": "chelsa_v1.2"},
-        "chelsa_v1.2": {
-            "crs": 4326,
-            "data_type": "RasterDataset",
-            "driver": "raster",
-            "kwargs": {
-                "chunks": {
-                    "x": 3600,
-                    "y": 3600,
-                }
-            },
-            "meta": {
-                "category": "meteo",
-                "paper_doi": "10.1038/sdata.2017.122",
-                "paper_ref": "Karger et al. (2017)",
-                "source_license": "CC BY 4.0",
-                "source_url": "https://chelsa-climate.org/downloads/",
-                "source_version": "1.2",
-            },
-            "path": "meteo/chelsa_clim_v1.2/CHELSA_bio10_12.tif",
-        },
-    }
-    _ = DataCatalogValidator.from_dict(d)
-
-
 def test_valid_catalog_variants():
     d = {
         "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
@@ -122,16 +94,6 @@ def test_valid_catalog_variants():
     _ = DataCatalogValidator.from_dict(d)
 
 
-def test_dangling_alias_catalog_entry():
-    d = {
-        "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
-        "chelsa": {"alias": "chelsa_v1.2"},
-    }
-
-    with pytest.raises(AssertionError):
-        _ = DataCatalogValidator.from_dict(d)
-
-
 def test_no_hydrmt_version_loggs_warning(caplog):
     d = {
         "meta": {"roots": [""]},
@@ -139,22 +101,6 @@ def test_no_hydrmt_version_loggs_warning(caplog):
 
     _ = DataCatalogValidator.from_dict(d)
     assert "No hydromt version" in caplog.text
-
-
-def test_valid_alias_catalog_entry():
-    d = {
-        "meta": {"hydromt_version": ">=1.0a,<2", "roots": [""]},
-        "chelsa": {"alias": "chelsa_v1.2"},
-        "chelsa_v1.2": {
-            "crs": 4326,
-            "data_type": "RasterDataset",
-            "driver": "raster",
-            "path": ".",
-        },
-    }
-    entry = DataCatalogValidator.from_dict(d)
-
-    assert entry.aliases == {"chelsa": "chelsa_v1.2"}
 
 
 def test_catalog_metadata_validation():

--- a/tests/gis/test_flw.py
+++ b/tests/gis/test_flw.py
@@ -1,4 +1,5 @@
 """Test hydromt.flw submodule."""
+
 import geopandas as gpd
 import numpy as np
 import pytest
@@ -121,15 +122,6 @@ def test_clip_basins(hydds, flwdir):
     assert hydds_clipped.where(hydds_clipped["mask"]).max() == upa0
 
 
-def test_basin_shape(hydds, flwdir):
-    # simple test because deprecated
-    with pytest.warns(DeprecationWarning, match="basin_shape is deprecated"):
-        gdf = flw.basin_shape(hydds, flwdir)
-        assert isinstance(gdf, gpd.GeoDataFrame)
-        with pytest.raises(ValueError, match="flwdir and ds dimensions do not match"):
-            flw.basin_shape(hydds.isel(x=slice(1, -1)), flwdir)
-
-
 def test_gauge_map(hydds, flwdir):
     # test with idxs at outlet
     idx0 = np.argmax(hydds["uparea"].values.ravel())
@@ -150,9 +142,6 @@ def test_gauge_map(hydds, flwdir):
     # test warning
     with pytest.warns(UserWarning, match="Snapping distance"):
         flw.gauge_map(hydds, flwdir=flwdir, stream=stream, xy=xy, max_dist=0)
-    # deprecation warning old method
-    with pytest.warns(DeprecationWarning, match='The "gaugemap" method is deprecated'):
-        flw.gaugemap(hydds, idxs=[idx0])
 
 
 def test_outlet_map(hydds, flwdir):

--- a/tests/workflows/test_basin_mask.py
+++ b/tests/workflows/test_basin_mask.py
@@ -133,13 +133,6 @@ def test_basin(caplog):
     )
     assert gdf_bas.index.size == 13
 
-    msg = (
-        'kind="outlets" has been deprecated, use outlets=True in combination with'
-        + ' kind="basin" or kind="interbasin" instead.'
-    )
-    with pytest.warns(DeprecationWarning, match=msg):
-        gdf_bas, gdf_out = get_basin_geometry(ds, kind="outlet")
-
     with pytest.raises(ValueError, match="Unknown kind: watershed,"):
         gdf_bas, gdf_out = get_basin_geometry(ds, kind="watershed")
 


### PR DESCRIPTION
## Issue addressed
Fixes #561
Fixes #566
Fixes #562 
Fixes #559
Fixes #549

## Explanation
Just remove the code associated with the deprecation warnings. All functionalities were already in some other place, so just removing the code is enough I think. 

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `v1`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst
