### PR TITLE
Release/v0.10.0

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -29,7 +29,14 @@ jobs:
           pip install tomli flit twine
 
       - name: Build artifacts
-        run: make pypi
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install flit wheel twine
+            git clean -xdf
+            git restore -SW .
+            flit build
+            python -m twine check dist/*
+
 
       - uses: actions/upload-artifact@v3
         with:

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -50,6 +50,11 @@
     "url": "https://deltares.github.io/hydromt/v0.9.4/"
   },
   {
+    "name": "v0.10.0",
+    "version": "0.10.0",
+    "url": "https://deltares.github.io/hydromt/v0.10.0/"
+  },
+  {
     "name": "latest",
     "version": "latest",
     "url": "https://deltares.github.io/hydromt/latest/"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this page.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
-Unreleased
-==========
+v0.10.0 (2024-06-14)
+====================
 
 New
 ---

--- a/hydromt/__init__.py
+++ b/hydromt/__init__.py
@@ -1,7 +1,7 @@
 """HydroMT: Automated and reproducible model building and analysis."""
 
 # version number without 'v' at start
-__version__ = "0.9.5.dev0"
+__version__ = "0.10.0"
 
 # pkg_resource deprication warnings originate from dependencies
 # so silence them for now


### PR DESCRIPTION

New
---
- New `PredefinedCatalog` class to handle predefined catalog version based on pooch registry files. (#849)


Changed
-------
- Development environment is now set up via pixi instead of mamba / conda. See the documentation for more information on how to install.
- Use the native data CRS when determining zoom levels over the data catalog crs. (#851)
- Improved `flw.d8_from_dem` method with different options to use river vector data to aid the flow direction derivation. (#305)
- DataCatalog.predefined_catalogs retrieves predefined_catalogs specified in predefined_catalogs.py. There is no need for setting the predefined_catalogs anymore. (#844)


Fixed
-----
- Bug in `raster.transform` with lazy coordinates. (#801)
- Bug in `workflows.mesh.mesh2d_from_rasterdataset` with multi-dimensional coordinates. (#843)
- Bug in `MeshModel.get_mesh` after xugrid update to 0.9.0. (#848)
- Bug in `raster.clip_bbox` when bbox doesn't overlap with raster. (#860)
- Allow for string format in zoom_level path, e.g. `{zoom_level:02d}` (#851)
- Fixed incorrect renaming of single variable raster datasets (#883)
- Provide better error message for 0D geometry arrays in GeoDataset (#885)
- Fixed index error when the number of peaks varies between stations in get_hydrographs method (#933)

Deprecated
----------
- The `DataCatalog.from_archive` method is deprecated. Use `DataCatalog.from_yml` with the root pointing to the archive instead. (#849)

