### PR TITLE
Parametrize source tests

### DIFF
--- a/hydromt/data_catalog/adapters/dataset.py
+++ b/hydromt/data_catalog/adapters/dataset.py
@@ -17,7 +17,12 @@ from hydromt._typing import (
     Variables,
     exec_nodata_strat,
 )
-from hydromt._utils import _has_no_data, _set_metadata, _shift_dataset_time
+from hydromt._utils import (
+    _has_no_data,
+    _set_metadata,
+    _shift_dataset_time,
+    _single_var_as_array,
+)
 from hydromt.data_catalog.adapters.data_adapter_base import DataAdapterBase
 
 logger = getLogger(__name__)
@@ -36,6 +41,7 @@ class DatasetAdapter(DataAdapterBase):
         variables: Optional[Variables] = None,
         time_range: Optional[TimeRange] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
+        single_var_as_array: bool = True,
         logger: Logger = logger,
     ) -> Optional[xr.Dataset]:
         """Return a clipped, sliced and unified Dataset.
@@ -58,6 +64,7 @@ class DatasetAdapter(DataAdapterBase):
             ds = self._apply_unit_conversion(ds, logger=logger)
             ds = _set_metadata(ds, metadata)
             # return array if single var and single_var_as_array
+            ds = _single_var_as_array(ds, single_var_as_array, variable_name=variables)
             return ds
         except NoDataException:
             exec_nodata_strat(

--- a/hydromt/data_catalog/adapters/rasterdataset.py
+++ b/hydromt/data_catalog/adapters/rasterdataset.py
@@ -156,7 +156,7 @@ class RasterDatasetAdapter(DataAdapterBase):
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         single_var_as_array: bool = True,
         logger: Logger = logger,
-    ) -> Optional[xr.Dataset]:
+    ) -> Union[xr.Dataset, xr.DataArray, None]:
         """Filter and harmonize the input RasterDataset.
 
         Parameters
@@ -266,7 +266,7 @@ class RasterDatasetAdapter(DataAdapterBase):
         variables: Optional[List] = None,
         mask: Optional[Geom] = None,
         align: Optional[float] = None,
-        time_tuple: Optional[TimeRange] = None,
+        time_range: Optional[TimeRange] = None,
         logger: Logger = logger,
     ) -> Optional[xr.Dataset]:
         """Filter the RasterDataset.
@@ -311,10 +311,10 @@ class RasterDatasetAdapter(DataAdapterBase):
                 if any(mvars):
                     raise NoDataException(f"RasterDataset: variables not found {mvars}")
                 ds = ds[variables]
-        if time_tuple is not None:
+        if time_range is not None:
             ds = _slice_temporal_dimension(
                 ds,
-                time_tuple,
+                time_range,
                 logger=logger,
             )
         if mask is not None:

--- a/hydromt/data_catalog/sources/dataset.py
+++ b/hydromt/data_catalog/sources/dataset.py
@@ -44,8 +44,9 @@ class DatasetSource(DataSource):
         variables: Optional[List[str]] = None,
         time_range: Optional[TimeRange] = None,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
+        single_var_as_array: bool = True,
         logger: Logger = logger,
-    ) -> Optional[xr.Dataset]:
+    ) -> Union[xr.Dataset, xr.DataArray]:
         """
         Read data from this source.
 
@@ -70,6 +71,7 @@ class DatasetSource(DataSource):
             self.metadata,
             variables=variables,
             time_range=time_range,
+            single_var_as_array=single_var_as_array,
             logger=logger,
         )
 

--- a/hydromt/data_catalog/sources/rasterdataset.py
+++ b/hydromt/data_catalog/sources/rasterdataset.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from logging import Logger, getLogger
 from os.path import basename, splitext
-from typing import Any, ClassVar, Dict, List, Literal, Optional, cast
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union, cast
 
 import pandas as pd
 import xarray as xr
@@ -53,9 +53,10 @@ class RasterDatasetSource(DataSource):
         variables: Optional[List[str]] = None,
         time_range: Optional[TimeRange] = None,
         zoom_level: Optional[ZoomLevel] = None,
+        single_var_as_array: bool = True,
         handle_nodata: NoDataStrategy = NoDataStrategy.RAISE,
         logger: Logger = logger,
-    ) -> Optional[xr.Dataset]:
+    ) -> Union[xr.Dataset, xr.DataArray]:
         """
         Read data from this source.
 
@@ -86,6 +87,7 @@ class RasterDatasetSource(DataSource):
             variables=variables,
             time_range=time_range,
             zoom_level=zoom_level,
+            single_var_as_array=single_var_as_array,
             logger=logger,
         )
 

--- a/hydromt/model/processes/region.py
+++ b/hydromt/model/processes/region.py
@@ -15,6 +15,7 @@ from shapely import box
 from hydromt._typing import NoDataStrategy
 from hydromt._typing.type_def import StrPath
 from hydromt.data_catalog import DataCatalog
+from hydromt.data_catalog.sources import RasterDatasetSource
 from hydromt.gis import gis_utils
 from hydromt.model.processes.basin_mask import get_basin_geometry
 from hydromt.plugins import PLUGINS
@@ -278,7 +279,7 @@ def parse_region_grid(
         value0,
         handle_nodata=NoDataStrategy.RAISE,
         single_var_as_array=True,
-        driver_kwargs=kwargs,
+        driver={"name": RasterDatasetSource._fallback_driver_read, "options": kwargs},
     )
 
     return da

--- a/tests/data_catalog/adapters/test_data_adapter.py
+++ b/tests/data_catalog/adapters/test_data_adapter.py
@@ -27,7 +27,7 @@ def test_gcs_cmip6():
     ds = data_catalog.get_rasterdataset(
         "cmip6_NOAA-GFDL/GFDL-ESM4_historical_r1i1p1f1_Amon",
         variables=["precip", "temp"],
-        time_tuple=(("1990-01-01", "1990-03-01")),
+        time_range=(("1990-01-01", "1990-03-01")),
     )
     # Check reading and some preprocess
     assert "precip" in ds

--- a/tests/data_catalog/sources/conftest.py
+++ b/tests/data_catalog/sources/conftest.py
@@ -1,5 +1,6 @@
 from typing import List, Type
 
+import geopandas as gpd
 import pandas as pd
 import pytest
 import xarray as xr
@@ -11,7 +12,11 @@ from hydromt.data_catalog.adapters import (
     GeoDatasetAdapter,
     RasterDatasetAdapter,
 )
-from hydromt.data_catalog.drivers import DataFrameDriver, DatasetDriver
+from hydromt.data_catalog.drivers import (
+    DataFrameDriver,
+    DatasetDriver,
+    GeoDataFrameDriver,
+)
 
 # DataFrame
 
@@ -71,6 +76,25 @@ def MockDatasetDriver(timeseries_ds: xr.Dataset) -> Type[DatasetDriver]:
             return timeseries_ds
 
     return MockDatasetDriver
+
+
+# GeoDataFrame
+@pytest.fixture()
+def MockGeoDataFrameDriver(geodf: gpd.GeoDataFrame) -> Type[GeoDataFrameDriver]:
+    class MockGeoDataFrameDriver(GeoDataFrameDriver):
+        name = "mock_geodf_driver"
+        supports_writing = True
+
+        def write(self, path: StrPath, gdf: gpd.GeoDataFrame, **kwargs) -> None:
+            pass
+
+        def read(self, uri: str, **kwargs) -> gpd.GeoDataFrame:
+            return self.read_data([uri], **kwargs)
+
+        def read_data(self, *args, **kwargs) -> gpd.GeoDataFrame:
+            return geodf
+
+    return MockGeoDataFrameDriver
 
 
 # GeoDataset

--- a/tests/data_catalog/sources/conftest.py
+++ b/tests/data_catalog/sources/conftest.py
@@ -16,6 +16,8 @@ from hydromt.data_catalog.drivers import (
     DataFrameDriver,
     DatasetDriver,
     GeoDataFrameDriver,
+    GeoDatasetDriver,
+    RasterDatasetDriver,
 )
 
 # DataFrame
@@ -101,6 +103,24 @@ def MockGeoDataFrameDriver(geodf: gpd.GeoDataFrame) -> Type[GeoDataFrameDriver]:
 
 
 @pytest.fixture()
+def MockGeoDatasetDriver(geoda: xr.Dataset):
+    class MockGeoDatasetDriver(GeoDatasetDriver):
+        name = "mock_geods_driver"
+
+        def read(self, uri: str, **kwargs) -> xr.Dataset:
+            kinda_ds = self.read_data([uri], **kwargs)
+            if isinstance(kinda_ds, xr.DataArray):
+                return kinda_ds.to_dataset()
+            else:
+                return kinda_ds
+
+        def read_data(self, uris: List[str], **kwargs) -> xr.Dataset:
+            return geoda
+
+    return MockGeoDatasetDriver
+
+
+@pytest.fixture()
 def mock_geo_ds_adapter():
     class MockGeoDataSetAdapter(GeoDatasetAdapter):
         def transform(self, ds: xr.Dataset, metadata: SourceMetadata, **kwargs):
@@ -110,6 +130,23 @@ def mock_geo_ds_adapter():
 
 
 # RasterDataset
+
+
+@pytest.fixture()
+def MockRasterDatasetDriver(raster_ds: xr.Dataset):
+    class MockRasterDatasetDriver(RasterDatasetDriver):
+        name = "mock_rasterds_driver"
+
+        def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
+            pass
+
+        def read(self, uri: str, **kwargs) -> xr.Dataset:
+            return self.read_data([uri], **kwargs)
+
+        def read_data(self, uris: List[str], **kwargs) -> xr.Dataset:
+            return raster_ds
+
+    return MockRasterDatasetDriver
 
 
 @pytest.fixture()

--- a/tests/data_catalog/sources/conftest.py
+++ b/tests/data_catalog/sources/conftest.py
@@ -1,4 +1,4 @@
-from typing import List, Type
+from typing import List, Type, Union
 
 import geopandas as gpd
 import pandas as pd
@@ -32,7 +32,7 @@ def mock_df_adapter():
     return MockDataFrameAdapter()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture()
 def MockDataFrameDriver(df: pd.DataFrame) -> Type[DataFrameDriver]:
     class MockDataFrameDriver(DataFrameDriver):
         name = "mock_df_driver"
@@ -48,6 +48,15 @@ def MockDataFrameDriver(df: pd.DataFrame) -> Type[DataFrameDriver]:
             return df
 
     return MockDataFrameDriver
+
+
+@pytest.fixture()
+def MockDataFrameReadOnlyDriver(MockDataFrameDriver) -> Type[DataFrameDriver]:
+    class MockDataFrameReadOnlyDriver(MockDataFrameDriver):
+        name = "mock_df_readonly_driver"
+        supports_writing = False
+
+    return MockDataFrameReadOnlyDriver
 
 
 # Dataset
@@ -80,7 +89,18 @@ def MockDatasetDriver(timeseries_ds: xr.Dataset) -> Type[DatasetDriver]:
     return MockDatasetDriver
 
 
+@pytest.fixture()
+def MockDatasetReadOnlyDriver(MockDatasetDriver) -> Type[DatasetDriver]:
+    class MockDatasetReadOnlyDriver(MockDatasetDriver):
+        name = "mock_ds_readonly_driver"
+        supports_writing = False
+
+    return MockDatasetReadOnlyDriver
+
+
 # GeoDataFrame
+
+
 @pytest.fixture()
 def MockGeoDataFrameDriver(geodf: gpd.GeoDataFrame) -> Type[GeoDataFrameDriver]:
     class MockGeoDataFrameDriver(GeoDataFrameDriver):
@@ -99,13 +119,28 @@ def MockGeoDataFrameDriver(geodf: gpd.GeoDataFrame) -> Type[GeoDataFrameDriver]:
     return MockGeoDataFrameDriver
 
 
+@pytest.fixture()
+def MockGeoDataFrameReadOnlyDriver(MockGeoDataFrameDriver) -> Type[GeoDataFrameDriver]:
+    class MockGeoDataFrameReadOnlyDriver(MockGeoDataFrameDriver):
+        name = "mock_geodf_readonly_driver"
+        supports_writing = False
+
+    return MockGeoDataFrameReadOnlyDriver
+
+
 # GeoDataset
 
 
 @pytest.fixture()
-def MockGeoDatasetDriver(geoda: xr.Dataset):
+def MockGeoDatasetDriver(geoda: xr.Dataset) -> Type[GeoDatasetDriver]:
     class MockGeoDatasetDriver(GeoDatasetDriver):
         name = "mock_geods_driver"
+        supports_writing = True
+
+        def write(
+            self, uri: str, ds: Union[xr.DataArray, xr.Dataset], **kwargs
+        ) -> None:
+            pass
 
         def read(self, uri: str, **kwargs) -> xr.Dataset:
             kinda_ds = self.read_data([uri], **kwargs)
@@ -121,6 +156,15 @@ def MockGeoDatasetDriver(geoda: xr.Dataset):
 
 
 @pytest.fixture()
+def MockGeoDatasetReadOnlyDriver(MockGeoDatasetDriver) -> Type[GeoDatasetDriver]:
+    class MockGeoDatasetReadOnlyDriver(MockGeoDatasetDriver):
+        name = "mock_geods_readonly_driver"
+        supports_writing = False
+
+    return MockGeoDatasetReadOnlyDriver
+
+
+@pytest.fixture()
 def mock_geo_ds_adapter():
     class MockGeoDataSetAdapter(GeoDatasetAdapter):
         def transform(self, ds: xr.Dataset, metadata: SourceMetadata, **kwargs):
@@ -133,11 +177,14 @@ def mock_geo_ds_adapter():
 
 
 @pytest.fixture()
-def MockRasterDatasetDriver(raster_ds: xr.Dataset):
+def MockRasterDatasetDriver(raster_ds: xr.Dataset) -> Type[RasterDatasetDriver]:
     class MockRasterDatasetDriver(RasterDatasetDriver):
-        name = "mock_rasterds_driver"
+        name = "mock_raster_ds_driver"
+        supports_writing = True
 
-        def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
+        def write(
+            self, path: StrPath, ds: Union[xr.DataArray, xr.Dataset], **kwargs
+        ) -> None:
             pass
 
         def read(self, uri: str, **kwargs) -> xr.Dataset:
@@ -147,6 +194,17 @@ def MockRasterDatasetDriver(raster_ds: xr.Dataset):
             return raster_ds
 
     return MockRasterDatasetDriver
+
+
+@pytest.fixture()
+def MockRasterDatasetReadOnlyDriver(
+    MockRasterDatasetDriver,
+) -> Type[RasterDatasetDriver]:
+    class MockRasterDatasetReadOnlyDriver(MockRasterDatasetDriver):
+        name = "raster_ds_readonly_driver"
+        supports_writing = False
+
+    return MockRasterDatasetReadOnlyDriver
 
 
 @pytest.fixture()

--- a/tests/data_catalog/sources/conftest.py
+++ b/tests/data_catalog/sources/conftest.py
@@ -1,0 +1,97 @@
+from typing import List, Type
+
+import pandas as pd
+import pytest
+import xarray as xr
+
+from hydromt._typing import SourceMetadata, StrPath
+from hydromt.data_catalog.adapters import (
+    DataFrameAdapter,
+    DatasetAdapter,
+    GeoDatasetAdapter,
+    RasterDatasetAdapter,
+)
+from hydromt.data_catalog.drivers import DataFrameDriver, DatasetDriver
+
+# DataFrame
+
+
+@pytest.fixture(scope="session")
+def mock_df_adapter():
+    class MockDataFrameAdapter(DataFrameAdapter):
+        def transform(self, df: pd.DataFrame, metadata: SourceMetadata, **kwargs):
+            return df
+
+    return MockDataFrameAdapter()
+
+
+@pytest.fixture(scope="class")
+def MockDataFrameDriver(df: pd.DataFrame) -> Type[DataFrameDriver]:
+    class MockDataFrameDriver(DataFrameDriver):
+        name = "mock_df_driver"
+        supports_writing = True
+
+        def write(self, path: StrPath, df: pd.DataFrame, **kwargs) -> None:
+            pass
+
+        def read(self, uri: str, **kwargs) -> pd.DataFrame:
+            return self.read_data([uri], **kwargs)
+
+        def read_data(self, uris: List[str], **kwargs) -> pd.DataFrame:
+            return df
+
+    return MockDataFrameDriver
+
+
+# Dataset
+
+
+@pytest.fixture(scope="session")
+def mock_ds_adapter():
+    class MockDatasetAdapter(DatasetAdapter):
+        def transform(self, ds: xr.Dataset, metadata: SourceMetadata, **kwargs):
+            return ds
+
+    return MockDatasetAdapter()
+
+
+@pytest.fixture()
+def MockDatasetDriver(timeseries_ds: xr.Dataset) -> Type[DatasetDriver]:
+    class MockDatasetDriver(DatasetDriver):
+        name = "mock_ds_driver"
+        supports_writing = True
+
+        def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
+            pass
+
+        def read(self, uri: str, **kwargs) -> xr.Dataset:
+            return self.read_data([uri], **kwargs)
+
+        def read_data(self, uris: List[str], **kwargs) -> xr.Dataset:
+            return timeseries_ds
+
+    return MockDatasetDriver
+
+
+# GeoDataset
+
+
+@pytest.fixture()
+def mock_geo_ds_adapter():
+    class MockGeoDataSetAdapter(GeoDatasetAdapter):
+        def transform(self, ds: xr.Dataset, metadata: SourceMetadata, **kwargs):
+            return ds
+
+    return MockGeoDataSetAdapter()
+
+
+# RasterDataset
+
+
+@pytest.fixture()
+def mock_raster_ds_adapter():
+    class MockRasterDataSetAdapter(RasterDatasetAdapter):
+        def transform(self, ds: xr.Dataset, metadata: SourceMetadata, **kwargs):
+            return ds
+
+    return MockRasterDataSetAdapter()

--- a/tests/data_catalog/sources/test_common_functionality.py
+++ b/tests/data_catalog/sources/test_common_functionality.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 from typing import Type
 
 import pytest
 from pydantic import ValidationError
 
+from hydromt._typing import SourceMetadata
 from hydromt.data_catalog.adapters.data_adapter_base import DataAdapterBase
 from hydromt.data_catalog.drivers import BaseDriver
 from hydromt.data_catalog.sources import (
@@ -13,11 +15,12 @@ from hydromt.data_catalog.sources import (
     GeoDatasetSource,
     RasterDatasetSource,
 )
+from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestValidators:
     @pytest.mark.parametrize(
-        "source_cls,_adapter",  # noqa: PT006
+        ("source_cls", "_adapter"),
         [
             (DataFrameSource, "mock_df_adapter"),
             (DatasetSource, "mock_ds_adapter"),
@@ -48,7 +51,7 @@ class TestValidators:
         assert error_driver["type"] == "value_error"
 
     @pytest.mark.parametrize(
-        "source_cls,_driver_cls,_adapter",  # noqa: PT006
+        ("source_cls", "_driver_cls", "_adapter"),
         [
             (DataFrameSource, "MockDataFrameDriver", "mock_df_adapter"),
             (DatasetSource, "MockDatasetDriver", "mock_ds_adapter"),
@@ -127,3 +130,170 @@ class TestValidators:
             uri="points.csv",
             driver=driver_name,
         )
+
+    @pytest.mark.parametrize(
+        ("source_cls", "_driver_cls", "path"),
+        [
+            (DataFrameSource, "MockDataFrameDriver", "test.csv"),
+            (DatasetSource, "MockDatasetDriver", "test.nc"),
+            (GeoDataFrameSource, "MockGeoDataFrameDriver", "test.gpkg"),
+            (GeoDatasetSource, "MockGeoDatasetDriver", "test.nc"),
+            (RasterDatasetSource, "MockRasterDatasetDriver", "test.zarr"),
+        ],
+    )
+    def test_to_file(
+        self,
+        source_cls: Type[DataSource],
+        _driver_cls: str,  # noqa: PT019
+        path: str,
+        tmp_path: Path,
+        request: pytest.FixtureRequest,
+    ):
+        driver_cls: Type[BaseDriver] = request.getfixturevalue(_driver_cls)
+        driver = driver_cls()
+        uri: str = str(tmp_path / path)
+        source = source_cls(
+            name="test",
+            uri=uri,
+            driver=driver,
+            metadata=SourceMetadata(crs=4326),
+        )
+        new_source: DataSource = source.to_file(uri)
+        assert "local" in new_source.driver.filesystem.protocol
+        # make sure we are not changing the state
+        assert id(new_source) != id(source)
+        assert id(driver) != id(new_source.driver)
+
+    @pytest.mark.parametrize(
+        ("source_cls", "_driver_cls", "_adapter", "path"),
+        [
+            (DataFrameSource, "MockDataFrameDriver", "mock_df_adapter", "test.csv"),
+            (DatasetSource, "MockDatasetDriver", "mock_ds_adapter", "test.nc"),
+            (
+                GeoDataFrameSource,
+                "MockGeoDataFrameDriver",
+                "mock_geodataframe_adapter",
+                "test.gpkg",
+            ),
+            (
+                GeoDatasetSource,
+                "MockGeoDatasetDriver",
+                "mock_geo_ds_adapter",
+                "test.nc",
+            ),
+            (
+                RasterDatasetSource,
+                "MockRasterDatasetDriver",
+                "mock_raster_ds_adapter",
+                "test.zarr",
+            ),
+        ],
+    )
+    def test_to_file_override(
+        self,
+        source_cls: Type[DataSource],
+        _driver_cls: str,  # noqa: PT019
+        _adapter: str,  # noqa: PT019
+        path: str,
+        tmp_path: Path,
+        request: pytest.FixtureRequest,
+    ):
+        driver_cls: Type[BaseDriver] = request.getfixturevalue(_driver_cls)
+        adapter: Type[DataAdapterBase] = request.getfixturevalue(_adapter)
+        driver1 = driver_cls()
+
+        uri: str = str(tmp_path / path)
+        source: DataSource = source_cls(
+            name="test", uri=uri, driver=driver1, data_adapter=adapter
+        )
+        driver2 = driver_cls(filesystem="memory")
+        new_source = source.to_file("test", driver_override=driver2)
+        assert new_source.driver.filesystem.protocol == "memory"
+        # make sure we are not changing the state
+        assert id(new_source) != id(source)
+        assert id(driver2) == id(new_source.driver)
+
+    @pytest.mark.parametrize(
+        ("source_cls", "_driver_cls", "_adapter", "path"),
+        [
+            (
+                DataFrameSource,
+                "MockDataFrameReadOnlyDriver",
+                "mock_df_adapter",
+                "test.csv",
+            ),
+            (DatasetSource, "MockDatasetReadOnlyDriver", "mock_ds_adapter", "test.nc"),
+            (
+                GeoDataFrameSource,
+                "MockGeoDataFrameReadOnlyDriver",
+                "mock_geodataframe_adapter",
+                "test.gpkg",
+            ),
+            (
+                GeoDatasetSource,
+                "MockGeoDatasetReadOnlyDriver",
+                "mock_geo_ds_adapter",
+                "test.nc",
+            ),
+            (
+                RasterDatasetSource,
+                "MockRasterDatasetReadOnlyDriver",
+                "mock_raster_ds_adapter",
+                "test.zarr",
+            ),
+        ],
+    )
+    def test_to_file_defaults(
+        self,
+        source_cls: Type[DataSource],
+        _driver_cls: str,  # noqa: PT019
+        _adapter: str,  # noqa: PT019
+        path: str,
+        tmp_path: Path,
+        mock_resolver: MetaDataResolver,
+        request: pytest.FixtureRequest,
+    ):
+        driver_cls: Type[BaseDriver] = request.getfixturevalue(_driver_cls)
+        adapter: Type[DataAdapterBase] = request.getfixturevalue(_adapter)
+
+        old_path: Path = tmp_path / path
+        new_path: Path = tmp_path / path.replace("test", "temp")
+
+        new_source: DataSource = source_cls(
+            name="test",
+            uri=str(old_path),
+            data_adapter=adapter,
+            driver=driver_cls(metadata_resolver=mock_resolver),
+        ).to_file(new_path)
+        # assert new_path.is_file()
+        assert new_source.root is None
+        assert new_source.driver.filesystem.protocol == ("file", "local")
+
+    @pytest.mark.parametrize(
+        ("source_cls", "_driver_cls"),
+        [
+            (DataFrameSource, "MockDataFrameReadOnlyDriver"),
+            (DatasetSource, "MockDatasetReadOnlyDriver"),
+            (GeoDataFrameSource, "MockGeoDataFrameReadOnlyDriver"),
+            (GeoDatasetSource, "MockGeoDatasetReadOnlyDriver"),
+            (RasterDatasetSource, "MockRasterDatasetReadOnlyDriver"),
+        ],
+    )
+    def test_raises_on_write_with_incapable_driver(
+        self,
+        source_cls: Type[DataSource],
+        _driver_cls: str,  # noqa: PT019
+        request: pytest.FixtureRequest,
+    ):
+        driver_cls: Type[BaseDriver] = request.getfixturevalue(_driver_cls)
+        mock_driver = driver_cls()
+        source = source_cls(
+            name="test",
+            uri="test",
+            driver=mock_driver,
+        )
+        with pytest.raises(
+            RuntimeError,
+            match=f"driver: '{mock_driver.name}' does not support writing data",
+        ):
+            source.to_file("/non/existant/test", driver_override=mock_driver)

--- a/tests/data_catalog/sources/test_common_functionality.py
+++ b/tests/data_catalog/sources/test_common_functionality.py
@@ -53,6 +53,8 @@ class TestValidators:
             (DataFrameSource, "MockDataFrameDriver", "mock_df_adapter"),
             (DatasetSource, "MockDatasetDriver", "mock_ds_adapter"),
             (GeoDataFrameSource, "MockGeoDataFrameDriver", "mock_geodataframe_adapter"),
+            (GeoDatasetSource, "MockGeoDatasetDriver", "mock_geo_ds_adapter"),
+            (RasterDatasetSource, "MockRasterDatasetDriver", "mock_raster_ds_adapter"),
         ],
     )
     def test_model_validates_correctly(

--- a/tests/data_catalog/sources/test_common_functionality.py
+++ b/tests/data_catalog/sources/test_common_functionality.py
@@ -1,12 +1,13 @@
-from typing import Any, Dict, Tuple, Type
+from typing import Type
 
 import pytest
 from pydantic import ValidationError
 
-from hydromt.data_catalog.adapters import DataFrameAdapter, DatasetAdapter
+from hydromt.data_catalog.adapters.data_adapter_base import DataAdapterBase
 from hydromt.data_catalog.sources import (
     DataFrameSource,
     DatasetSource,
+    DataSource,
     GeoDataFrameSource,
     GeoDatasetSource,
     RasterDatasetSource,
@@ -14,92 +15,30 @@ from hydromt.data_catalog.sources import (
 
 
 class TestValidators:
-    @pytest.fixture()
-    def dataframe_source_args(
-        self, mock_df_adapter: DataFrameAdapter
-    ) -> Tuple[Type[DataFrameSource], Dict[str, Any]]:
-        return (
-            DataFrameSource,
-            dict(
-                name="name",
-                uri="uri",
-                data_adapter=mock_df_adapter,
-                driver="does not exist",
-            ),
-        )
-
-    @pytest.fixture()
-    def dataset_source_args(
-        self, mock_ds_adapter: DatasetAdapter
-    ) -> Tuple[Type[DatasetSource], Dict[str, Any]]:
-        return (
-            DatasetSource,
-            dict(
-                name="name",
-                uri="uri",
-                data_adapter=mock_ds_adapter,
-                driver="does not exist",
-            ),
-        )
-
-    @pytest.fixture()
-    def geodataframe_source_args(
-        self, mock_geodataframe_adapter
-    ) -> Tuple[Type[GeoDataFrameSource], Dict[str, Any]]:
-        return (
-            GeoDataFrameSource,
-            dict(
-                name="name",
-                uri="uri",
-                data_adapter=mock_geodataframe_adapter,
-                driver="does not exist",
-            ),
-        )
-
-    @pytest.fixture()
-    def geodataset_source_args(
-        self, mock_geo_ds_adapter
-    ) -> Tuple[Type[GeoDatasetSource], Dict[str, Any]]:
-        return (
-            GeoDatasetSource,
-            dict(
-                name="name",
-                uri="uri",
-                data_adapter=mock_geo_ds_adapter,
-                driver="does not exist",
-            ),
-        )
-
-    @pytest.fixture()
-    def rasterdataset_source_args(
-        self, mock_raster_ds_adapter
-    ) -> Tuple[Type[RasterDatasetSource], Dict[str, Any]]:
-        return (
-            RasterDatasetSource,
-            dict(
-                name="name",
-                uri="uri",
-                data_adapter=mock_raster_ds_adapter,
-                driver="does not exist",
-            ),
-        )
-
-    fixture_sources = pytest.mark.parametrize(
-        "source",
+    @pytest.mark.parametrize(
+        "source_cls,_adapter",  # noqa: PT006
         [
-            "dataframe_source_args",
-            "dataset_source_args",
-            "geodataframe_source_args",
-            "geodataset_source_args",
-            "rasterdataset_source_args",
+            (DataFrameSource, "mock_df_adapter"),
+            (DatasetSource, "mock_ds_adapter"),
+            (GeoDataFrameSource, "mock_geodataframe_adapter"),
+            (GeoDatasetSource, "mock_geo_ds_adapter"),
+            (RasterDatasetSource, "mock_raster_ds_adapter"),
         ],
     )
-
-    @fixture_sources
-    def test_validators(self, source: str, request: pytest.FixtureRequest):
-        source_cls, source_vals = request.getfixturevalue(source)
+    def test_validators(
+        self,
+        source_cls: Type[DataSource],
+        _adapter: str,  # noqa: PT019
+        request: pytest.FixtureRequest,
+    ):
+        adapter: DataAdapterBase = request.getfixturevalue(_adapter)
         with pytest.raises(ValidationError) as e_info:
-            source_cls(**source_vals)
+            source_cls(
+                name="name",
+                uri="uri",
+                data_adapter=adapter,
+                driver="does_not_exist",
+            )
 
         assert e_info.value.error_count() == 1
         error_driver = next(

--- a/tests/data_catalog/sources/test_common_functionality.py
+++ b/tests/data_catalog/sources/test_common_functionality.py
@@ -85,3 +85,26 @@ class TestValidators:
                     "uri": "test_uri",
                 }
             )
+
+    @pytest.mark.parametrize(
+        "source_cls,driver_name",  # noqa: PT006
+        [
+            (DataFrameSource, "pandas"),
+            (DatasetSource, "dataset_xarray"),
+            (GeoDataFrameSource, "pyogrio"),
+            (GeoDatasetSource, "geodataset_xarray"),
+            (RasterDatasetSource, "raster_xarray"),
+        ],
+    )
+    def test_instantiate_directly(
+        self,
+        source_cls: Type[DataSource],
+        driver_name: str,
+    ):
+        datasource = source_cls(
+            name="test",
+            uri="data.format",
+            driver={"name": driver_name, "metadata_resolver": "convention"},
+            data_adapter={"unit_add": {"geoattr": 1.0}},
+        )
+        assert isinstance(datasource, source_cls)

--- a/tests/data_catalog/sources/test_common_functionality.py
+++ b/tests/data_catalog/sources/test_common_functionality.py
@@ -1,0 +1,108 @@
+from typing import Any, Dict, Tuple, Type
+
+import pytest
+from pydantic import ValidationError
+
+from hydromt.data_catalog.adapters import DataFrameAdapter, DatasetAdapter
+from hydromt.data_catalog.sources import (
+    DataFrameSource,
+    DatasetSource,
+    GeoDataFrameSource,
+    GeoDatasetSource,
+    RasterDatasetSource,
+)
+
+
+class TestValidators:
+    @pytest.fixture()
+    def dataframe_source_args(
+        self, mock_df_adapter: DataFrameAdapter
+    ) -> Tuple[Type[DataFrameSource], Dict[str, Any]]:
+        return (
+            DataFrameSource,
+            dict(
+                name="name",
+                uri="uri",
+                data_adapter=mock_df_adapter,
+                driver="does not exist",
+            ),
+        )
+
+    @pytest.fixture()
+    def dataset_source_args(
+        self, mock_ds_adapter: DatasetAdapter
+    ) -> Tuple[Type[DatasetSource], Dict[str, Any]]:
+        return (
+            DatasetSource,
+            dict(
+                name="name",
+                uri="uri",
+                data_adapter=mock_ds_adapter,
+                driver="does not exist",
+            ),
+        )
+
+    @pytest.fixture()
+    def geodataframe_source_args(
+        self, mock_geodataframe_adapter
+    ) -> Tuple[Type[GeoDataFrameSource], Dict[str, Any]]:
+        return (
+            GeoDataFrameSource,
+            dict(
+                name="name",
+                uri="uri",
+                data_adapter=mock_geodataframe_adapter,
+                driver="does not exist",
+            ),
+        )
+
+    @pytest.fixture()
+    def geodataset_source_args(
+        self, mock_geo_ds_adapter
+    ) -> Tuple[Type[GeoDatasetSource], Dict[str, Any]]:
+        return (
+            GeoDatasetSource,
+            dict(
+                name="name",
+                uri="uri",
+                data_adapter=mock_geo_ds_adapter,
+                driver="does not exist",
+            ),
+        )
+
+    @pytest.fixture()
+    def rasterdataset_source_args(
+        self, mock_raster_ds_adapter
+    ) -> Tuple[Type[RasterDatasetSource], Dict[str, Any]]:
+        return (
+            RasterDatasetSource,
+            dict(
+                name="name",
+                uri="uri",
+                data_adapter=mock_raster_ds_adapter,
+                driver="does not exist",
+            ),
+        )
+
+    fixture_sources = pytest.mark.parametrize(
+        "source",
+        [
+            "dataframe_source_args",
+            "dataset_source_args",
+            "geodataframe_source_args",
+            "geodataset_source_args",
+            "rasterdataset_source_args",
+        ],
+    )
+
+    @fixture_sources
+    def test_validators(self, source: str, request: pytest.FixtureRequest):
+        source_cls, source_vals = request.getfixturevalue(source)
+        with pytest.raises(ValidationError) as e_info:
+            source_cls(**source_vals)
+
+        assert e_info.value.error_count() == 1
+        error_driver = next(
+            filter(lambda e: e["loc"] == ("driver",), e_info.value.errors())
+        )
+        assert error_driver["type"] == "value_error"

--- a/tests/data_catalog/sources/test_common_functionality.py
+++ b/tests/data_catalog/sources/test_common_functionality.py
@@ -108,3 +108,22 @@ class TestValidators:
             data_adapter={"unit_add": {"geoattr": 1.0}},
         )
         assert isinstance(datasource, source_cls)
+
+    @pytest.mark.parametrize(
+        "source_cls,driver_name",  # noqa: PT006
+        [
+            (DataFrameSource, "pandas"),
+            (DatasetSource, "dataset_xarray"),
+            (GeoDataFrameSource, "pyogrio"),
+            (GeoDatasetSource, "geodataset_xarray"),
+            (RasterDatasetSource, "raster_xarray"),
+        ],
+    )
+    def test_instantiate_directly_minimal_kwargs(
+        self, source_cls: Type[DataSource], driver_name: str
+    ):
+        source_cls(
+            name="test",
+            uri="points.csv",
+            driver=driver_name,
+        )

--- a/tests/data_catalog/sources/test_dataframe_source.py
+++ b/tests/data_catalog/sources/test_dataframe_source.py
@@ -11,17 +11,6 @@ from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestDataFrameSource:
-    def test_instantiate_directly(
-        self,
-    ):
-        datasource = DataFrameSource(
-            name="test",
-            uri="points.csv",
-            driver={"name": "pandas", "metadata_resolver": "convention"},
-            data_adapter={"unit_add": {"geoattr": 1.0}},
-        )
-        assert isinstance(datasource, DataFrameSource)
-
     def test_instantiate_directly_minimal_kwargs(self):
         DataFrameSource(
             name="test",

--- a/tests/data_catalog/sources/test_dataframe_source.py
+++ b/tests/data_catalog/sources/test_dataframe_source.py
@@ -1,13 +1,11 @@
 from pathlib import Path
-from typing import ClassVar, Type
+from typing import Type
 
 import pandas as pd
 
-from hydromt._typing import SourceMetadata
 from hydromt.data_catalog.adapters import DataFrameAdapter
 from hydromt.data_catalog.drivers import DataFrameDriver
 from hydromt.data_catalog.sources import DataFrameSource
-from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestDataFrameSource:
@@ -27,53 +25,3 @@ class TestDataFrameSource:
             uri=str(tmp_dir / "test.xls"),
         )
         pd.testing.assert_frame_equal(df, source.read_data())
-
-    def test_to_file(self, MockDataFrameDriver: Type[DataFrameDriver]):
-        mock_df_driver = MockDataFrameDriver()
-        source = DataFrameSource(
-            name="test",
-            uri="source.csv",
-            driver=mock_df_driver,
-            metadata=SourceMetadata(crs=4326),
-        )
-        new_source = source.to_file("test.csv")
-        assert "local" in new_source.driver.filesystem.protocol
-        # make sure we are not changing the state
-        assert id(new_source) != id(source)
-        assert id(mock_df_driver) != id(new_source.driver)
-
-    def test_to_file_override(self, MockDataFrameDriver: Type[DataFrameDriver]):
-        driver1 = MockDataFrameDriver()
-        source = DataFrameSource(
-            name="test",
-            uri="df.xlsx",
-            driver=driver1,
-            metadata=SourceMetadata(category="test"),
-        )
-        driver2 = MockDataFrameDriver(filesystem="memory")
-        new_source = source.to_file("test", driver_override=driver2)
-        assert new_source.driver.filesystem.protocol == "memory"
-        # make sure we are not changing the state
-        assert id(new_source) != id(source)
-        assert id(driver2) == id(new_source.driver)
-
-    def test_to_file_defaults(
-        self, tmp_dir: Path, df: pd.DataFrame, mock_resolver: MetaDataResolver
-    ):
-        class NotWritableDriver(DataFrameDriver):
-            name: ClassVar[str] = "test_to_file_defaults"
-
-            def read_data(self, uri: str, **kwargs) -> pd.DataFrame:
-                return df
-
-        old_path: Path = tmp_dir / "test.csv"
-        new_path: Path = tmp_dir / "temp.csv"
-
-        new_source: DataFrameSource = DataFrameSource(
-            name="test",
-            uri=str(old_path),
-            driver=NotWritableDriver(metadata_resolver=mock_resolver),
-        ).to_file(new_path)
-        assert new_path.is_file()
-        assert new_source.root is None
-        assert new_source.driver.filesystem.protocol == ("file", "local")

--- a/tests/data_catalog/sources/test_dataframe_source.py
+++ b/tests/data_catalog/sources/test_dataframe_source.py
@@ -11,13 +11,6 @@ from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestDataFrameSource:
-    def test_instantiate_directly_minimal_kwargs(self):
-        DataFrameSource(
-            name="test",
-            uri="points.csv",
-            driver={"name": "pandas"},
-        )
-
     def test_read_data(
         self,
         MockDataFrameDriver: Type[DataFrameDriver],

--- a/tests/data_catalog/sources/test_dataframe_source.py
+++ b/tests/data_catalog/sources/test_dataframe_source.py
@@ -2,8 +2,6 @@ from pathlib import Path
 from typing import ClassVar, Type
 
 import pandas as pd
-import pytest
-from pydantic import ValidationError
 
 from hydromt._typing import SourceMetadata
 from hydromt.data_catalog.adapters import DataFrameAdapter
@@ -13,30 +11,6 @@ from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestDataFrameSource:
-    def test_model_validate(
-        self,
-        MockDataFrameDriver: Type[DataFrameDriver],
-        mock_df_adapter: DataFrameAdapter,
-    ):
-        DataFrameSource.model_validate(
-            {
-                "name": "example_file",
-                "driver": MockDataFrameDriver(),
-                "data_adapter": mock_df_adapter,
-                "uri": "test_uri",
-            }
-        )
-        with pytest.raises(ValidationError, match="'data_type' must be 'DataFrame'."):
-            DataFrameSource.model_validate(
-                {
-                    "name": "geojsonfile",
-                    "data_type": "DifferentDataType",
-                    "driver": MockDataFrameDriver(),
-                    "data_adapter": mock_df_adapter,
-                    "uri": "test_uri",
-                }
-            )
-
     def test_instantiate_directly(
         self,
     ):

--- a/tests/data_catalog/sources/test_dataset_source.py
+++ b/tests/data_catalog/sources/test_dataset_source.py
@@ -3,7 +3,6 @@ from typing import ClassVar, Optional, Type
 
 import pytest
 import xarray as xr
-from pydantic import ValidationError
 from pystac import Catalog as StacCatalog
 
 from hydromt._typing import ErrorHandleMethod, SourceMetadata
@@ -14,30 +13,6 @@ from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestDatasetSource:
-    def test_model_validate(
-        self,
-        MockDatasetDriver: Type[DatasetDriver],
-        mock_ds_adapter: DatasetAdapter,
-    ):
-        DatasetSource.model_validate(
-            {
-                "name": "example_file",
-                "driver": MockDatasetDriver(),
-                "data_adapter": mock_ds_adapter,
-                "uri": "test_uri",
-            }
-        )
-        with pytest.raises(ValidationError, match="'data_type' must be 'Dataset'."):
-            DatasetSource.model_validate(
-                {
-                    "name": "geojsonfile",
-                    "data_type": "DifferentDataType",
-                    "driver": MockDatasetDriver(),
-                    "data_adapter": mock_ds_adapter,
-                    "uri": "test_uri",
-                }
-            )
-
     def test_instantiate_directly(
         self,
     ):

--- a/tests/data_catalog/sources/test_dataset_source.py
+++ b/tests/data_catalog/sources/test_dataset_source.py
@@ -13,13 +13,6 @@ from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestDatasetSource:
-    def test_instantiate_directly_minimal_kwargs(self):
-        DatasetSource(
-            name="test",
-            uri="points.nc",
-            driver={"name": "dataset_xarray"},
-        )
-
     def test_read_data(
         self,
         MockDatasetDriver: Type[DatasetDriver],

--- a/tests/data_catalog/sources/test_dataset_source.py
+++ b/tests/data_catalog/sources/test_dataset_source.py
@@ -13,17 +13,6 @@ from hydromt.data_catalog.uri_resolvers import MetaDataResolver
 
 
 class TestDatasetSource:
-    def test_instantiate_directly(
-        self,
-    ):
-        datasource = DatasetSource(
-            name="test",
-            uri="points.nc",
-            driver={"name": "dataset_xarray", "metadata_resolver": "convention"},
-            data_adapter={"unit_add": {"geoattr": 1.0}},
-        )
-        assert isinstance(datasource, DatasetSource)
-
     def test_instantiate_directly_minimal_kwargs(self):
         DatasetSource(
             name="test",

--- a/tests/data_catalog/sources/test_geo_dataframe_source.py
+++ b/tests/data_catalog/sources/test_geo_dataframe_source.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from os.path import basename
 from pathlib import Path
-from typing import ClassVar, List, Type, cast
+from typing import cast
 from uuid import uuid4
 
 import geopandas as gpd
@@ -12,13 +12,13 @@ from pystac import Asset as StacAsset
 from pystac import Catalog as StacCatalog
 from pystac import Item as StacItem
 
-from hydromt._typing import NoDataException, SourceMetadata, StrPath
+from hydromt._typing import NoDataException
 from hydromt._typing.error import ErrorHandleMethod
 from hydromt.data_catalog import DataCatalog
 from hydromt.data_catalog.adapters.geodataframe import GeoDataFrameAdapter
 from hydromt.data_catalog.drivers import GeoDataFrameDriver, PyogrioDriver
 from hydromt.data_catalog.sources.geodataframe import GeoDataFrameSource
-from hydromt.data_catalog.uri_resolvers import ConventionResolver, MetaDataResolver
+from hydromt.data_catalog.uri_resolvers import ConventionResolver
 
 
 class TestGeoDataFrameSource:
@@ -114,93 +114,6 @@ class TestGeoDataFrameSource:
             driver=PyogrioDriver(metadata_resolver={"name": "convention"}),
             data_adapter={"unit_add": {"geoattr": 1.0}},
         )
-
-    @pytest.fixture(scope="class")
-    def MockDriver(self, geodf: gpd.GeoDataFrame):
-        class MockGeoDataFrameDriver(GeoDataFrameDriver):
-            name = "mock_geodf_to_file"
-
-            def write(self, path: StrPath, gdf: gpd.GeoDataFrame, **kwargs) -> None:
-                pass
-
-            def read(
-                self, uri: str, metadata: SourceMetadata, **kwargs
-            ) -> gpd.GeoDataFrame:
-                return self.read_data([uri], metadata, **kwargs)
-
-            def read_data(
-                self, uris: List[str], metadata: SourceMetadata, **kwargs
-            ) -> gpd.GeoDataFrame:
-                return geodf
-
-        return MockGeoDataFrameDriver
-
-    @pytest.fixture(scope="class")
-    def MockWriteableDriver(self, geodf: gpd.GeoDataFrame):
-        class MockWritableGeoDataFrameDriver(GeoDataFrameDriver):
-            name = "mock_geodf_to_file"
-            supports_writing: ClassVar[bool] = True
-
-            def write(self, path: StrPath, gdf: gpd.GeoDataFrame, **kwargs) -> None:
-                pass
-
-            def read(
-                self, uri: str, metadata: SourceMetadata, **kwargs
-            ) -> gpd.GeoDataFrame:
-                return self.read_data([uri], metadata, **kwargs)
-
-            def read_data(
-                self, uris: List[str], metadata: SourceMetadata, **kwargs
-            ) -> gpd.GeoDataFrame:
-                return geodf
-
-        return MockWritableGeoDataFrameDriver
-
-    @pytest.fixture()
-    def writable_source(
-        self, MockWriteableDriver: Type[GeoDataFrameDriver]
-    ) -> GeoDataFrameSource:
-        return GeoDataFrameSource(
-            name="test", uri="points.geojson", driver=MockWriteableDriver()
-        )
-
-    def test_to_file(self, writable_source: GeoDataFrameSource):
-        new_source = writable_source.to_file("test")
-        assert "local" in new_source.driver.filesystem.protocol
-        # make sure we are not changing the state
-        assert id(new_source) != id(writable_source)
-        assert id(writable_source.driver) != id(new_source.driver)
-
-    def test_to_file_override(self, MockWriteableDriver: Type[GeoDataFrameDriver]):
-        driver1 = MockWriteableDriver()
-        source = GeoDataFrameSource(name="test", uri="points.geojson", driver=driver1)
-        driver2 = MockWriteableDriver(filesystem="memory")
-        new_source = source.to_file("test", driver_override=driver2)
-        assert new_source.driver.filesystem.protocol == "memory"
-        # make sure we are not changing the state
-        assert id(new_source) != id(source)
-        assert id(driver2) == id(new_source.driver)
-
-    def test_to_file_defaults(
-        self, tmp_dir: Path, geodf: gpd.GeoDataFrame, mock_resolver: MetaDataResolver
-    ):
-        class NotWritableDriver(GeoDataFrameDriver):
-            name: ClassVar[str] = "test_to_file_defaults"
-
-            def read_data(self, uri: str, **kwargs) -> gpd.GeoDataFrame:
-                return geodf
-
-        old_path: Path = tmp_dir / "test.geojson"
-        new_path: Path = tmp_dir / "temp.geojson"
-
-        new_source: GeoDataFrameSource = GeoDataFrameSource(
-            name="test",
-            uri=str(old_path),
-            driver=NotWritableDriver(metadata_resolver=mock_resolver),
-        ).to_file(new_path)
-        assert new_path.is_file()
-        assert new_source.root is None
-        assert new_source.driver.filesystem.protocol == ("file", "local")
 
     def test_geodataframe_unit_attrs(self, artifact_data: DataCatalog):
         source = artifact_data.get_source("gadm_level1")

--- a/tests/data_catalog/sources/test_geo_dataframe_source.py
+++ b/tests/data_catalog/sources/test_geo_dataframe_source.py
@@ -49,33 +49,6 @@ class TestGeoDataFrameSource:
                 foo="bar",
             )
 
-    def test_model_validate(
-        self,
-        mock_geodf_driver: GeoDataFrameDriver,
-        mock_geodataframe_adapter: GeoDataFrameAdapter,
-    ):
-        GeoDataFrameSource.model_validate(
-            {
-                "name": "geojsonfile",
-                "data_type": "GeoDataFrame",
-                "driver": mock_geodf_driver,
-                "data_adapter": mock_geodataframe_adapter,
-                "uri": "test_uri",
-            }
-        )
-        with pytest.raises(
-            ValidationError, match="'data_type' must be 'GeoDataFrame'."
-        ):
-            GeoDataFrameSource.model_validate(
-                {
-                    "name": "geojsonfile",
-                    "data_type": "DifferentDataType",
-                    "driver": mock_geodf_driver,
-                    "data_adapter": mock_geodataframe_adapter,
-                    "uri": "test_uri",
-                }
-            )
-
     def test_get_data_query_params(
         self,
         geodf: gpd.GeoDataFrame,
@@ -133,16 +106,6 @@ class TestGeoDataFrameSource:
         )
         with pytest.raises(NoDataException):
             source.read_data()
-
-    def test_instantiate_directly(
-        self,
-    ):
-        GeoDataFrameSource(
-            name="test",
-            uri="points.geojson",
-            driver={"name": "pyogrio", "metadata_resolver": "convention"},
-            data_adapter={"unit_add": {"geoattr": 1.0}},
-        )
 
     def test_instantiate_mixed_objects(self):
         GeoDataFrameSource(

--- a/tests/data_catalog/sources/test_geo_dataframe_source.py
+++ b/tests/data_catalog/sources/test_geo_dataframe_source.py
@@ -115,13 +115,6 @@ class TestGeoDataFrameSource:
             data_adapter={"unit_add": {"geoattr": 1.0}},
         )
 
-    def test_instantiate_directly_minimal_kwargs(self):
-        GeoDataFrameSource(
-            name="test",
-            uri="points.geojson",
-            driver={"name": "pyogrio"},
-        )
-
     @pytest.fixture(scope="class")
     def MockDriver(self, geodf: gpd.GeoDataFrame):
         class MockGeoDataFrameDriver(GeoDataFrameDriver):

--- a/tests/data_catalog/sources/test_geo_dataframe_source.py
+++ b/tests/data_catalog/sources/test_geo_dataframe_source.py
@@ -34,23 +34,6 @@ class TestGeoDataFrameSource:
         geodf.to_file(uri, driver="GeoJSON")
         return uri
 
-    def test_validators(self, mock_geodataframe_adapter: GeoDataFrameAdapter):
-        with pytest.raises(ValidationError) as e_info:
-            GeoDataFrameSource(
-                root=".",
-                name="name",
-                data_type="GeoDataFrame",
-                uri="uri",
-                data_adapter=mock_geodataframe_adapter,
-                driver="does not exist",
-            )
-
-        assert e_info.value.error_count() == 1
-        error_driver = next(
-            filter(lambda e: e["loc"] == ("driver",), e_info.value.errors())
-        )
-        assert error_driver["type"] == "value_error"
-
     def test_raises_on_invalid_fields(
         self,
         mock_geodataframe_adapter: GeoDataFrameAdapter,

--- a/tests/data_catalog/sources/test_geo_dataset_source.py
+++ b/tests/data_catalog/sources/test_geo_dataset_source.py
@@ -1,16 +1,15 @@
 from pathlib import Path
-from typing import ClassVar, List, Type
+from typing import Type
 
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
 
-from hydromt._typing import SourceMetadata, StrPath
+from hydromt._typing import SourceMetadata
 from hydromt.data_catalog.adapters import GeoDatasetAdapter
 from hydromt.data_catalog.drivers import GeoDatasetDriver, GeoDatasetXarrayDriver
 from hydromt.data_catalog.sources import GeoDatasetSource
-from hydromt.data_catalog.uri_resolvers.metadata_resolver import MetaDataResolver
 from hydromt.gis.gis_utils import to_geographic_bbox
 
 
@@ -34,103 +33,13 @@ class TestGeoDatasetSource:
         assert read_data.equals(geoda)
 
     @pytest.fixture()
-    def MockWritableDriver(self, geoda: xr.Dataset):
-        class MockWriteableGeoDatasetDriver(GeoDatasetDriver):
-            name = "mock_geods_to_file"
-            supports_writing: ClassVar[bool] = True
-
-            def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
-                pass
-
-            def read(self, uri: str, metadata: SourceMetadata, **kwargs) -> xr.Dataset:
-                kinda_ds = self.read_data([uri], metadata, **kwargs)
-                if isinstance(kinda_ds, xr.DataArray):
-                    return kinda_ds.to_dataset()
-                else:
-                    return kinda_ds
-
-            def read_data(
-                self, uris: List[str], metadata: SourceMetadata, **kwargs
-            ) -> xr.Dataset:
-                return geoda
-
-        return MockWriteableGeoDatasetDriver
-
-    def test_to_file(self, MockWritableDriver: Type[GeoDatasetDriver]):
-        mock_driver = MockWritableDriver()
-
-        source = GeoDatasetSource(
-            name="test",
-            uri="geoda.zarr",
-            driver=mock_driver,
-            metadata=SourceMetadata(crs=4326),
-        )
-        new_source = source.to_file("test")
-        assert "local" in new_source.driver.filesystem.protocol
-        # make sure we are not changing the state
-        assert id(new_source) != id(source)
-        assert id(mock_driver) != id(new_source.driver)
-
-    def test_to_file_override(self, MockWritableDriver: Type[GeoDatasetDriver]):
-        driver1 = MockWritableDriver()
-        source = GeoDatasetSource(
-            name="test",
-            uri="geoda.zarr",
-            driver=driver1,
-            metadata=SourceMetadata(crs=4326),
-        )
-        driver2 = MockWritableDriver(filesystem="memory")
-        new_source = source.to_file("test", driver_override=driver2)
-        assert new_source.driver.filesystem.protocol == "memory"
-        # make sure we are not changing the state
-        assert id(new_source) != id(source)
-        assert id(driver2) == id(new_source.driver)
-
-    def test_to_file_defaults(
-        self, tmp_dir: Path, geods: xr.Dataset, mock_resolver: MetaDataResolver
-    ):
-        class NotWritableDriver(GeoDatasetDriver):
-            name: ClassVar[str] = "test_to_file_defaults"
-
-            def read_data(self, uri: str, **kwargs) -> xr.Dataset:
-                return geods
-
-        old_path: Path = tmp_dir / "test.zarr"
-        new_path: Path = tmp_dir / "temp.zarr"
-
-        new_source: GeoDatasetSource = GeoDatasetSource(
-            name="test",
-            uri=str(old_path),
-            driver=NotWritableDriver(metadata_resolver=mock_resolver),
-        ).to_file(new_path)
-        assert new_path.is_dir()  # zarr
-        assert new_source.root is None
-        assert new_source.driver.filesystem.protocol == ("file", "local")
-
-    def test_raises_on_write_with_incapable_driver(
-        self, MockGeoDatasetDriver: Type[GeoDatasetDriver]
-    ):
-        mock_driver = MockGeoDatasetDriver()
-        source = GeoDatasetSource(
-            name="test",
-            uri="geoda.zarr",
-            driver=mock_driver,
-            metadata=SourceMetadata(crs=4326),
-        )
-        with pytest.raises(
-            RuntimeError,
-            match=f"driver: '{mock_driver.name}' does not support writing data",
-        ):
-            source.to_file("/non/existant/asdf.zarr", driver_override=mock_driver)
-
-    @pytest.fixture()
     def writable_source(
-        self, MockWritableDriver: Type[GeoDatasetDriver], geoda: xr.DataArray
+        self, MockGeoDatasetReadOnlyDriver: Type[GeoDatasetDriver], geoda: xr.DataArray
     ) -> GeoDatasetSource:
         return GeoDatasetSource(
             name="test",
             uri="geoda.zarr",
-            driver=MockWritableDriver(),
+            driver=MockGeoDatasetReadOnlyDriver(),
             metadata=SourceMetadata(crs=4326),
         )
 

--- a/tests/data_catalog/sources/test_geo_dataset_source.py
+++ b/tests/data_catalog/sources/test_geo_dataset_source.py
@@ -15,24 +15,6 @@ from hydromt.gis.gis_utils import to_geographic_bbox
 
 
 class TestGeoDatasetSource:
-    def test_instantiate_directly(
-        self,
-    ):
-        datasource = GeoDatasetSource(
-            name="test",
-            uri="points.zarr",
-            driver={"name": "geodataset_vector", "metadata_resolver": "convention"},
-            data_adapter={"unit_add": {"geoattr": 1.0}},
-        )
-        assert isinstance(datasource, GeoDatasetSource)
-
-    def test_instantiate_directly_minimal_kwargs(self):
-        GeoDatasetSource(
-            name="test",
-            uri="points.zarr",
-            driver={"name": "geodataset_vector"},
-        )
-
     def test_read_data(
         self,
         geoda: xr.DataArray,

--- a/tests/data_catalog/sources/test_geo_dataset_source.py
+++ b/tests/data_catalog/sources/test_geo_dataset_source.py
@@ -15,31 +15,7 @@ from hydromt.data_catalog.uri_resolvers.metadata_resolver import MetaDataResolve
 from hydromt.gis.gis_utils import to_geographic_bbox
 
 
-@pytest.fixture()
-def mock_geo_ds_adapter():
-    class MockGeoDataSetAdapter(GeoDatasetAdapter):
-        def transform(self, ds: xr.Dataset, metadata: SourceMetadata, **kwargs):
-            return ds
-
-    return MockGeoDataSetAdapter()
-
-
 class TestGeoDatasetSource:
-    def test_validators(self, mock_geo_ds_adapter: GeoDatasetAdapter):
-        with pytest.raises(ValidationError) as e_info:
-            GeoDatasetSource(
-                name="name",
-                uri="uri",
-                data_adapter=mock_geo_ds_adapter,
-                driver="does not exist",  # type: ignore
-            )
-
-        assert e_info.value.error_count() == 1
-        error_driver = next(
-            filter(lambda e: e["loc"] == ("driver",), e_info.value.errors())
-        )
-        assert error_driver["type"] == "value_error"
-
     def test_model_validate(
         self,
         mock_geo_ds_driver: GeoDatasetDriver,

--- a/tests/data_catalog/sources/test_raster_dataset_source.py
+++ b/tests/data_catalog/sources/test_raster_dataset_source.py
@@ -4,7 +4,6 @@ from typing import ClassVar, List, Type
 import numpy as np
 import pytest
 import xarray as xr
-from pydantic import ValidationError
 
 from hydromt._typing import SourceMetadata, StrPath
 from hydromt.data_catalog.adapters import RasterDatasetAdapter
@@ -15,32 +14,6 @@ from hydromt.gis.gis_utils import to_geographic_bbox
 
 
 class TestRasterDatasetSource:
-    def test_model_validate(
-        self,
-        mock_raster_ds_driver: RasterDatasetDriver,
-        mock_raster_ds_adapter: RasterDatasetAdapter,
-    ):
-        RasterDatasetSource.model_validate(
-            {
-                "name": "zarrfile",
-                "driver": mock_raster_ds_driver,
-                "data_adapter": mock_raster_ds_adapter,
-                "uri": "test_uri",
-            }
-        )
-        with pytest.raises(
-            ValidationError, match="'data_type' must be 'RasterDataset'."
-        ):
-            RasterDatasetSource.model_validate(
-                {
-                    "name": "geojsonfile",
-                    "data_type": "DifferentDataType",
-                    "driver": mock_raster_ds_driver,
-                    "data_adapter": mock_raster_ds_adapter,
-                    "uri": "test_uri",
-                }
-            )
-
     def test_instantiate_directly(
         self,
     ):
@@ -75,22 +48,6 @@ class TestRasterDatasetSource:
             uri=str(tmp_dir / "rasterds.zarr"),
         )
         assert raster_ds == source.read_data()
-
-    @pytest.fixture()
-    def MockDriver(self, raster_ds: xr.Dataset):
-        class MockRasterDatasetDriver(RasterDatasetDriver):
-            name = "mock_rasterds_to_file"
-
-            def write(self, path: StrPath, ds: xr.Dataset, **kwargs) -> None:
-                pass
-
-            def read(self, uri: str, **kwargs) -> xr.Dataset:
-                return self.read_data([uri], **kwargs)
-
-            def read_data(self, uris: List[str], **kwargs) -> xr.Dataset:
-                return raster_ds
-
-        return MockRasterDatasetDriver
 
     @pytest.fixture()
     def MockWritableDriver(self, raster_ds: xr.Dataset):

--- a/tests/data_catalog/sources/test_raster_dataset_source.py
+++ b/tests/data_catalog/sources/test_raster_dataset_source.py
@@ -14,13 +14,6 @@ from hydromt.gis.gis_utils import to_geographic_bbox
 
 
 class TestRasterDatasetSource:
-    def test_instantiate_directly_minimal_kwargs(self):
-        RasterDatasetSource(
-            name="test",
-            uri="points.zarr",
-            driver={"name": "raster_xarray"},
-        )
-
     def test_read_data(
         self,
         raster_ds: xr.Dataset,

--- a/tests/data_catalog/sources/test_raster_dataset_source.py
+++ b/tests/data_catalog/sources/test_raster_dataset_source.py
@@ -14,18 +14,6 @@ from hydromt.gis.gis_utils import to_geographic_bbox
 
 
 class TestRasterDatasetSource:
-    def test_instantiate_directly(
-        self,
-    ):
-        datasource = RasterDatasetSource(
-            name="test",
-            uri="points.zarr",
-            zoom_levels={1: 10},
-            driver={"name": "raster_xarray", "metadata_resolver": "convention"},
-            data_adapter={"unit_add": {"geoattr": 1.0}},
-        )
-        assert isinstance(datasource, RasterDatasetSource)
-
     def test_instantiate_directly_minimal_kwargs(self):
         RasterDatasetSource(
             name="test",

--- a/tests/data_catalog/sources/test_raster_dataset_source.py
+++ b/tests/data_catalog/sources/test_raster_dataset_source.py
@@ -14,31 +14,7 @@ from hydromt.data_catalog.uri_resolvers.metadata_resolver import MetaDataResolve
 from hydromt.gis.gis_utils import to_geographic_bbox
 
 
-@pytest.fixture()
-def mock_raster_ds_adapter():
-    class MockRasterDataSetAdapter(RasterDatasetAdapter):
-        def transform(self, ds: xr.Dataset, metadata: SourceMetadata, **kwargs):
-            return ds
-
-    return MockRasterDataSetAdapter()
-
-
 class TestRasterDatasetSource:
-    def test_validators(self, mock_raster_ds_adapter: RasterDatasetAdapter):
-        with pytest.raises(ValidationError) as e_info:
-            RasterDatasetSource(
-                name="name",
-                uri="uri",
-                data_adapter=mock_raster_ds_adapter,
-                driver="does not exist",
-            )
-
-        assert e_info.value.error_count() == 1
-        error_driver = next(
-            filter(lambda e: e["loc"] == ("driver",), e_info.value.errors())
-        )
-        assert error_driver["type"] == "value_error"
-
     def test_model_validate(
         self,
         mock_raster_ds_driver: RasterDatasetDriver,


### PR DESCRIPTION
## Issue addressed
Many repeating tests using boilerplate

## Explanation
Using `pytest.mark.parametrize` we can reduce the lines of code and test interfaces effectively.

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `v1`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst