### PR TITLE
Update pyproject.toml: consistent double quotes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ target-version = "py39"
 # enable pydocstyle (E), pyflake (F) and isort (I), pytest-style (PT), bugbear (B)
 select = ["E", "F", "I", "PT", "D", "B"]
 ignore-init-module-imports = true
-ignore = ["D211", "D213", 'D206', 'E501', "E741", "D105", "E712", "B904"]
+ignore = ["D211", "D213", "D206", "E501", "E741", "D105", "E712", "B904"]
 exclude = ["docs"]
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
Looking for inspiration for ruff rules, found some inconsistency in the quotes here.