### PR TITLE
Replace unsafe `pyyaml` loader with `SafeLoader` 

### DIFF
--- a/hydromt/cli/cli_utils.py
+++ b/hydromt/cli/cli_utils.py
@@ -122,7 +122,7 @@ def parse_config(
 def parse_export_config_yaml(ctx, param, value) -> Dict:
     if value:
         with open(value, "r") as stream:
-            yml = yaml.load(stream, Loader=yaml.FullLoader)
+            yml = yaml.load(stream, Loader=yaml.SafeLoader)
         return yml
     else:
         return {}

--- a/hydromt/data_catalog.py
+++ b/hydromt/data_catalog.py
@@ -1767,10 +1767,10 @@ def _yml_from_uri_or_path(uri_or_path: Union[Path, str]) -> Dict:
     if _uri_validator(str(uri_or_path)):
         with requests.get(uri_or_path, stream=True) as r:
             r.raise_for_status()
-            yml = yaml.load(r.text, Loader=yaml.FullLoader)
+            yml = yaml.load(r.text, Loader=yaml.SafeLoader)
     else:
         with open(uri_or_path, "r") as stream:
-            yml = yaml.load(stream, Loader=yaml.FullLoader)
+            yml = yaml.load(stream, Loader=yaml.SafeLoader)
     return yml
 
 


### PR DESCRIPTION
## Explanation
The default loaders in PyYAML are not safe to use with untrusted data. They potentially make your application vulnerable to arbitrary code execution attacks. If you open a YAML file from an untrusted source, and the file is loaded with the default loader, an attacker could execute arbitrary code on your machine.

This codemod hardens all [`yaml.load()`](https://pyyaml.org/wiki/PyYAMLDocumentation) calls against such attacks by replacing the default loader with `yaml.SafeLoader`. This is the recommended loader for loading untrusted data. For most use cases it functions as a drop-in replacement for the default loader.

Calling `yaml.load()` without an explicit loader argument is equivalent to calling it with `Loader=yaml.Loader`, which is unsafe. This usage [has been deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input\)-Deprecation) since PyYAML 5.1. This codemod will add an explicit `SafeLoader` argument to all `yaml.load()` calls that don't use an explicit loader.

The changes from this codemod look like the following:
```diff
  import yaml
  data = b'!!python/object/apply:subprocess.Popen \\n- ls'
- deserialized_data = yaml.load(data, yaml.Loader)
+ deserialized_data = yaml.load(data, Loader=yaml.SafeLoader)
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data](https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data)
  * [https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:python/harden-pyyaml](https://docs.pixee.ai/codemods/python/pixee_python_harden-pyyaml) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fdeltares_hydromt%7C09975fbf7561fc6fe5ea5b957e20c7e3d9e0c5f1)


<!--{"type":"DRIP","codemod":"pixee:python/harden-pyyaml"}-->

## General Checklist
- [X] Updated tests or added new tests - **NA**
- [X] Branch is up to date with `main`
- [X] Tests & pre-commit hooks pass 
- [X] Updated documentation - **NA**
- [X] Updated changelog.rst - **NA**

## Data/Catalog checklist
- [X] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [X] None of the old `data_catalog.yml` files have been chagned
- [X] `data/chagnelog.rst` has been updated - **NA**
- [X] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [X] New file has been tested locally
- [X] Tests have been added using the new file in the test suite - **NA**

## Additional Notes (optional)
This change was autogenerated from a GitHub app - called [Pixeebot](https://github.com/marketplace/pixeebot-automated-code-fixes). Feel free to check it our for more details for how you can install it onto your project's repo for continued code hardening and code security recommendations. 👍