### PR TITLE
remove ErrorHandlingMethod in favour of NoDataStrategy

### DIFF
--- a/hydromt/_typing/__init__.py
+++ b/hydromt/_typing/__init__.py
@@ -2,7 +2,6 @@
 
 from .crs import CRS
 from .error import (
-    ErrorHandleMethod,
     NoDataException,
     NoDataStrategy,
     exec_nodata_strat,
@@ -55,7 +54,6 @@ __all__ = [
     "TotalBounds",
     "XArrayDict",
     "ModelMode",
-    "ErrorHandleMethod",
     "NoDataStrategy",
     "NoDataException",
     "exec_nodata_strat",

--- a/hydromt/_typing/error.py
+++ b/hydromt/_typing/error.py
@@ -47,11 +47,3 @@ def exec_nodata_strat(msg: str, strategy: NoDataStrategy) -> None:
         logger.warning(msg)
     elif strategy == NoDataStrategy.IGNORE:
         pass
-
-
-class ErrorHandleMethod(Enum):
-    """Strategies for error handling within hydromt."""
-
-    RAISE = 1
-    SKIP = 2
-    COERCE = 3

--- a/hydromt/data_catalog/data_catalog.py
+++ b/hydromt/data_catalog/data_catalog.py
@@ -38,7 +38,7 @@ from pystac import CatalogType, MediaType
 
 from hydromt import __version__
 from hydromt._io.readers import _yml_from_uri_or_path
-from hydromt._typing import Bbox, ErrorHandleMethod, SourceSpecDict, StrPath, TimeRange
+from hydromt._typing import Bbox, SourceSpecDict, StrPath, TimeRange
 from hydromt._typing.error import NoDataException, NoDataStrategy, exec_nodata_strat
 from hydromt._utils import (
     _deep_merge,
@@ -157,7 +157,7 @@ class DataCatalog(object):
         description: str = "The stac catalog of hydromt",
         used_only: bool = False,
         catalog_type: CatalogType = CatalogType.RELATIVE_PUBLISHED,
-        on_error: ErrorHandleMethod = ErrorHandleMethod.COERCE,
+        handle_nodata: NoDataStrategy = NoDataStrategy.IGNORE,
     ):
         """Write data catalog to STAC format.
 
@@ -181,7 +181,7 @@ class DataCatalog(object):
         meta = meta or {}
         stac_catalog = StacCatalog(id=catalog_name, description=description)
         for _name, source in self.list_sources(used_only):
-            stac_child_catalog = source.to_stac_catalog(on_error)
+            stac_child_catalog = source.to_stac_catalog(handle_nodata)
             if stac_child_catalog:
                 stac_catalog.add_child(stac_child_catalog)
 
@@ -191,7 +191,7 @@ class DataCatalog(object):
     def from_stac_catalog(
         self,
         stac_like: Union[str, Path, StacCatalog, dict],
-        on_error: ErrorHandleMethod = ErrorHandleMethod.SKIP,
+        handle_nodata: NoDataStrategy = NoDataStrategy.IGNORE,
     ):
         """Write data catalog to STAC format.
 
@@ -199,8 +199,8 @@ class DataCatalog(object):
         ----------
         path: str, Path
             stac path.
-        on_error: ErrorHandleMethod
-            What to do on error when converting from STAC
+        handle_nodata: NoDataStrategy
+            What to do when required data is not available when converting from STAC
         """
         if isinstance(stac_like, (str, Path)):
             stac_catalog = StacCatalog.from_file(stac_like)

--- a/hydromt/data_catalog/sources/dataframe.py
+++ b/hydromt/data_catalog/sources/dataframe.py
@@ -128,7 +128,7 @@ class DataFrameSource(DataSource):
 
         Parameters
         ----------
-        - on_error (str, optional): The error handling strategy.
+        - handle_nodata (str, optional): The error handling strategy.
           Options are: "raise" to raise an error on failure, "skip" to skip the
           dataframe on failure, and "coerce" (default) to set default values on failure.
 

--- a/hydromt/data_catalog/sources/dataset.py
+++ b/hydromt/data_catalog/sources/dataset.py
@@ -210,9 +210,9 @@ class DatasetSource(DataSource):
 
         Parameters
         ----------
-        - on_error (str, optional): The error handling strategy.
+        - handle_nodata (str, optional): The error handling strategy.
           Options are: "raise" to raise an error on failure, "skip" to skip the
-          dataset on failure, and "coerce" (default) to set default values on failure.
+          dataset on failure.
 
         Returns
         -------

--- a/hydromt/data_catalog/sources/dataset.py
+++ b/hydromt/data_catalog/sources/dataset.py
@@ -1,6 +1,5 @@
 """DataSource class for the Dataset type."""
 
-from datetime import datetime
 from logging import Logger, getLogger
 from os.path import basename, splitext
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
@@ -16,7 +15,6 @@ from pystac import Item as StacItem
 from pystac import MediaType
 
 from hydromt._typing import (
-    ErrorHandleMethod,
     NoDataStrategy,
     StrPath,
     TimeRange,
@@ -202,7 +200,7 @@ class DatasetSource(DataSource):
 
     def to_stac_catalog(
         self,
-        on_error: ErrorHandleMethod = ErrorHandleMethod.COERCE,
+        handle_nodata: NoDataStrategy = NoDataStrategy.IGNORE,
     ) -> Optional[StacCatalog]:
         """
         Convert a dataset into a STAC Catalog representation.
@@ -236,17 +234,12 @@ class DatasetSource(DataSource):
                     f"Unknown extension: {ext} cannot determine media type"
                 )
         except (IndexError, KeyError, CRSError) as e:
-            if on_error == ErrorHandleMethod.SKIP:
+            if handle_nodata == NoDataStrategy.IGNORE:
                 logger.warning(
                     "Skipping {name} during stac conversion because"
                     "because detecting spacial extent failed."
                 )
                 return
-            elif on_error == ErrorHandleMethod.COERCE:
-                props = self.metadata.model_dump(exclude_none=True, exclude_unset=True)
-                start_dt = datetime(1, 1, 1)
-                end_dt = datetime(1, 1, 1)
-                media_type = MediaType.JSON
             else:
                 raise e
 

--- a/hydromt/data_catalog/sources/geodataframe.py
+++ b/hydromt/data_catalog/sources/geodataframe.py
@@ -217,10 +217,9 @@ class GeoDataFrameSource(DataSource):
 
         Parameters
         ----------
-        - on_error (str, optional): The error handling strategy.
-          Options are: "raise" to raise an error on failure, "skip" to skip
-          the dataset on failure, and "coerce" (default) to set
-          default values on failure.
+        - handle_nodata (str, optional): The error handling strategy.
+          Options are: "raise" to raise an error on failure, "ignore" to skip
+          the dataset on failure.
 
         Returns
         -------

--- a/hydromt/data_catalog/sources/geodataframe.py
+++ b/hydromt/data_catalog/sources/geodataframe.py
@@ -17,7 +17,6 @@ from pystac import MediaType
 
 from hydromt._typing import (
     Bbox,
-    ErrorHandleMethod,
     Geom,
     NoDataStrategy,
     StrPath,
@@ -206,7 +205,7 @@ class GeoDataFrameSource(DataSource):
 
     def to_stac_catalog(
         self,
-        on_error: ErrorHandleMethod = ErrorHandleMethod.COERCE,
+        handle_nodata: NoDataStrategy = NoDataStrategy.IGNORE,
     ) -> Optional[StacCatalog]:
         """
         Convert a geodataframe into a STAC Catalog representation.
@@ -239,19 +238,15 @@ class GeoDataFrameSource(DataSource):
                 raise RuntimeError(
                     f"Unknown extension: {ext} cannot determine media type"
                 )
-        except (IndexError, KeyError, CRSError):
-            if on_error == ErrorHandleMethod.SKIP:
+        except (IndexError, KeyError, CRSError) as e:
+            if handle_nodata == NoDataStrategy.IGNORE:
                 logger.warning(
                     "Skipping {name} during stac conversion because"
                     "because detecting spacial extent failed."
                 )
                 return
-            elif on_error == ErrorHandleMethod.COERCE:
-                bbox = [0.0, 0.0, 0.0, 0.0]
-                props = self.data_adapter.meta
-                media_type = MediaType.JSON
             else:
-                raise
+                raise e
         else:
             stac_catalog = StacCatalog(
                 self.name,

--- a/hydromt/data_catalog/sources/geodataframe.py
+++ b/hydromt/data_catalog/sources/geodataframe.py
@@ -237,7 +237,7 @@ class GeoDataFrameSource(DataSource):
                 raise RuntimeError(
                     f"Unknown extension: {ext} cannot determine media type"
                 )
-        except (IndexError, KeyError, CRSError) as e:
+        except (IndexError, KeyError, CRSError, TypeError) as e:
             if handle_nodata == NoDataStrategy.IGNORE:
                 logger.warning(
                     "Skipping {name} during stac conversion because"

--- a/hydromt/data_catalog/sources/geodataset.py
+++ b/hydromt/data_catalog/sources/geodataset.py
@@ -1,6 +1,5 @@
 """DataSource class for the GeoDataset type."""
 
-from datetime import datetime
 from logging import Logger, getLogger
 from os.path import basename, splitext
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Union, cast
@@ -18,7 +17,6 @@ from pystac import MediaType
 
 from hydromt._typing import (
     Bbox,
-    ErrorHandleMethod,
     Geom,
     NoDataStrategy,
     StrPath,
@@ -273,7 +271,7 @@ class GeoDatasetSource(DataSource):
 
     def to_stac_catalog(
         self,
-        on_error: ErrorHandleMethod = ErrorHandleMethod.COERCE,
+        handle_nodata: NoDataStrategy = NoDataStrategy.IGNORE,
     ) -> Optional[StacCatalog]:
         """
         Convert a geodataset into a STAC Catalog representation.
@@ -308,18 +306,12 @@ class GeoDatasetSource(DataSource):
                     f"Unknown extension: {ext} cannot determine media type"
                 )
         except (IndexError, KeyError, CRSError) as e:
-            if on_error == ErrorHandleMethod.SKIP:
+            if handle_nodata == NoDataStrategy.IGNORE:
                 logger.warning(
                     "Skipping {name} during stac conversion because"
                     "because detecting spacial extent failed."
                 )
                 return
-            elif on_error == ErrorHandleMethod.COERCE:
-                bbox = [0.0, 0.0, 0.0, 0.0]
-                props = self.metadata
-                start_dt = datetime(1, 1, 1)
-                end_dt = datetime(1, 1, 1)
-                media_type = MediaType.JSON
             else:
                 raise e
 

--- a/hydromt/data_catalog/sources/geodataset.py
+++ b/hydromt/data_catalog/sources/geodataset.py
@@ -281,10 +281,9 @@ class GeoDatasetSource(DataSource):
 
         Parameters
         ----------
-        - on_error (str, optional): The error handling strategy.
-          Options are: "raise" to raise an error on failure, "skip" to skip
-          the dataset on failure, and "coerce" (default) to set default
-          values on failure.
+        - handle_nodata (str, optional): The error handling strategy.
+          Options are: "raise" to raise an error on failure, "IGNORE" to skip
+          the dataset on failure
 
         Returns
         -------

--- a/hydromt/data_catalog/sources/rasterdataset.py
+++ b/hydromt/data_catalog/sources/rasterdataset.py
@@ -1,6 +1,5 @@
 """DataSource class for the RasterDataset type."""
 
-from datetime import datetime
 from logging import Logger, getLogger
 from os.path import basename, splitext
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Union, cast
@@ -18,7 +17,6 @@ from pystac import MediaType
 
 from hydromt._typing import (
     Bbox,
-    ErrorHandleMethod,
     Geom,
     NoDataStrategy,
     StrPath,
@@ -274,7 +272,7 @@ class RasterDatasetSource(DataSource):
 
     def to_stac_catalog(
         self,
-        on_error: ErrorHandleMethod = ErrorHandleMethod.COERCE,
+        handle_nodata: NoDataStrategy = NoDataStrategy.IGNORE,
     ) -> Optional[StacCatalog]:
         """
         Convert a rasterdataset into a STAC Catalog representation.
@@ -314,18 +312,12 @@ class RasterDatasetSource(DataSource):
                     f"Unknown extension: {ext} cannot determine media type"
                 )
         except (IndexError, KeyError, CRSError) as e:
-            if on_error == ErrorHandleMethod.SKIP:
+            if handle_nodata == NoDataStrategy.IGNORE:
                 logger.warning(
                     "Skipping {name} during stac conversion because"
                     "because detecting spacial extent failed."
                 )
                 return
-            elif on_error == ErrorHandleMethod.COERCE:
-                bbox = [0.0, 0.0, 0.0, 0.0]
-                props = self.data_adapter.meta
-                start_dt = datetime(1, 1, 1)
-                end_dt = datetime(1, 1, 1)
-                media_type = MediaType.JSON
             else:
                 raise e
 

--- a/hydromt/data_catalog/sources/rasterdataset.py
+++ b/hydromt/data_catalog/sources/rasterdataset.py
@@ -282,9 +282,9 @@ class RasterDatasetSource(DataSource):
 
         Parameters
         ----------
-        - on_error (str, optional): The error handling strategy.
-          Options are: "raise" to raise an error on failure, "skip" to skip the
-          dataset on failure, and "coerce" (default) to set default values on failure.
+        - handle_nodata (str, optional): The error handling strategy.
+          Options are: "raise" to raise an error on failure, "ignore" to skip the
+          dataset on failure
 
         Returns
         -------

--- a/tests/data_catalog/sources/test_dataset_source.py
+++ b/tests/data_catalog/sources/test_dataset_source.py
@@ -83,13 +83,3 @@ class TestDatasetSource:
             on_error=ErrorHandleMethod.SKIP
         )
         assert catalog is None
-
-    def test_to_stac_catalog_coerce(self, dataset_source_no_timerange: DatasetSource):
-        catalog: Optional[StacCatalog] = dataset_source_no_timerange.to_stac_catalog(
-            on_error=ErrorHandleMethod.COERCE
-        )
-        assert isinstance(catalog, StacCatalog)
-        stac_item = next(catalog.get_items(dataset_source_no_timerange.name), None)
-        assert list(stac_item.assets.keys())[0] == "test.nc"
-        assert stac_item.properties["start_datetime"] == "0001-01-01T00:00:00Z"
-        assert stac_item.properties["end_datetime"] == "0001-01-01T00:00:00Z"

--- a/tests/data_catalog/sources/test_dataset_source.py
+++ b/tests/data_catalog/sources/test_dataset_source.py
@@ -5,7 +5,7 @@ import pytest
 import xarray as xr
 from pystac import Catalog as StacCatalog
 
-from hydromt._typing import ErrorHandleMethod
+from hydromt._typing.error import NoDataStrategy
 from hydromt.data_catalog.adapters import DatasetAdapter
 from hydromt.data_catalog.drivers import DatasetDriver
 from hydromt.data_catalog.sources import DatasetSource
@@ -80,6 +80,6 @@ class TestDatasetSource:
 
     def test_to_stac_catalog_skip(self, dataset_source_no_timerange: DatasetSource):
         catalog: Optional[StacCatalog] = dataset_source_no_timerange.to_stac_catalog(
-            on_error=ErrorHandleMethod.SKIP
+            handle_nodata=NoDataStrategy.IGNORE
         )
         assert catalog is None

--- a/tests/data_catalog/sources/test_geo_dataframe_source.py
+++ b/tests/data_catalog/sources/test_geo_dataframe_source.py
@@ -146,10 +146,10 @@ class TestGeoDataFrameSource:
 
         gdf_stac_catalog.add_item(gds_stac_item)
         outcome = cast(
-            StacCatalog, adapter.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+            StacCatalog, adapter.to_stac_catalog(handle_nodata=NoDataStrategy.RAISE)
         )
         assert gdf_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
         adapter.metadata.crs = (
             -3.14
         )  # manually create an invalid adapter by deleting the crs
-        assert adapter.to_stac_catalog(on_error=NoDataStrategy.IGNORE) is None
+        assert adapter.to_stac_catalog(handle_nodata=NoDataStrategy.IGNORE) is None

--- a/tests/data_catalog/sources/test_geo_dataframe_source.py
+++ b/tests/data_catalog/sources/test_geo_dataframe_source.py
@@ -1,19 +1,12 @@
-from datetime import datetime
-from os.path import basename
 from pathlib import Path
-from typing import cast
 from uuid import uuid4
 
 import geopandas as gpd
 import numpy as np
 import pytest
 from pydantic import ValidationError
-from pystac import Asset as StacAsset
-from pystac import Catalog as StacCatalog
-from pystac import Item as StacItem
 
 from hydromt._typing import NoDataException
-from hydromt._typing.error import ErrorHandleMethod
 from hydromt.data_catalog import DataCatalog
 from hydromt.data_catalog.adapters.geodataframe import GeoDataFrameAdapter
 from hydromt.data_catalog.drivers import GeoDataFrameDriver, PyogrioDriver
@@ -122,35 +115,3 @@ class TestGeoDataFrameSource:
         source.metadata.attrs = {"NAME_0": {"long_name": "Country names"}}
         gdf = source.read_data()
         assert gdf["NAME_0"].attrs["long_name"] == "Country names"
-
-    def test_to_stac_geodataframe(self, geodf: gpd.GeoDataFrame, tmp_dir: Path):
-        gdf_path = str(tmp_dir / "test.geojson")
-        geodf.to_file(gdf_path, driver="GeoJSON")
-        data_catalog = DataCatalog()  # read artifacts
-        _ = data_catalog.sources  # load artifact data as fallback
-
-        # geodataframe
-        name = "gadm_level1"
-        adapter = cast(GeoDataFrameAdapter, data_catalog.get_source(name))
-        bbox, _ = adapter.get_bbox()
-        gdf_stac_catalog = StacCatalog(id=name, description=name)
-        gds_stac_item = StacItem(
-            name,
-            geometry=None,
-            bbox=list(bbox),
-            properties=adapter.metadata,
-            datetime=datetime(1, 1, 1),
-        )
-        gds_stac_asset = StacAsset(str(adapter.uri))
-        gds_base_name = basename(adapter.uri)
-        gds_stac_item.add_asset(gds_base_name, gds_stac_asset)
-
-        gdf_stac_catalog.add_item(gds_stac_item)
-        outcome = cast(
-            StacCatalog, adapter.to_stac_catalog(on_error=ErrorHandleMethod.RAISE)
-        )
-        assert gdf_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
-        adapter.metadata.crs = (
-            -3.14
-        )  # manually create an invalid adapter by deleting the crs
-        assert adapter.to_stac_catalog(on_error=ErrorHandleMethod.SKIP) is None

--- a/tests/data_catalog/test_data_catalog.py
+++ b/tests/data_catalog/test_data_catalog.py
@@ -27,7 +27,7 @@ from yaml import dump
 from hydromt._compat import HAS_GCSFS, HAS_OPENPYXL, HAS_S3FS
 from hydromt._io.writers import _write_xy
 from hydromt._typing import Bbox, TimeRange
-from hydromt._typing.error import ErrorHandleMethod, NoDataException, NoDataStrategy
+from hydromt._typing.error import NoDataException, NoDataStrategy
 from hydromt.config import Settings
 from hydromt.data_catalog.adapters import (
     GeoDataFrameAdapter,
@@ -116,24 +116,6 @@ def test_parser():
     datasource = _parse_data_source_dict("test", source, root=root)
     assert isinstance(datasource, GeoDataFrameSource)
     assert datasource.full_uri == abspath(source["uri"])
-    # TODO: do we want to allow Path objects?
-    # # test with Path object
-    # source.update(uri=Path(source["uri"]))
-    # datasource = _parse_data_source_dict("test", source, root=root)
-    # assert datasource.uri == abspath(source["uri"])
-    # rel path
-    # source = {
-    #     "data_adapter": {"name": "GeoDataFrame"},
-    #     "driver": {"name": "pyogrio"},
-    #     "data_type": "GeoDataFrame",
-    #     "uri": "path/to/data.gpkg",
-    #     "kwargs": {"fn": "test"},
-    # }
-    # datasource = _parse_data_source_dict("test", source, root=root)
-    # assert datasource.uri == abspath(join(root, source["uri"]))
-    # check if path in kwargs is also absolute
-    # assert datasource.driver_kwargs["fn"] == abspath(join(root, "test"))
-    # alias
     dd = {
         "test": {
             "driver": {"name": "pyogrio"},
@@ -712,16 +694,6 @@ class TestGetRasterDataset:
 
         raster_stac_catalog.add_item(raster_stac_item)
 
-        outcome = cast(
-            StacCatalog, source.to_stac_catalog(on_error=ErrorHandleMethod.RAISE)
-        )
-
-        assert raster_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
-        source.metadata.crs = (
-            -3.14
-        )  # manually create an invalid adapter by deleting the crs
-        assert source.to_stac_catalog(on_error=ErrorHandleMethod.SKIP) is None
-
     @pytest.fixture()
     def zoom_dict(self, tmp_dir: Path, zoom_level_tif: str) -> Dict[str, Any]:
         return {
@@ -1042,14 +1014,6 @@ class TestGetGeoDataFrame:
         gds_stac_item.add_asset(gds_base_name, gds_stac_asset)
 
         gdf_stac_catalog.add_item(gds_stac_item)
-        outcome = cast(
-            StacCatalog, source.to_stac_catalog(on_error=ErrorHandleMethod.RAISE)
-        )
-        assert gdf_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
-        source.metadata.crs = (
-            -3.14
-        )  # manually create an invalid adapter by deleting the crs
-        assert source.to_stac_catalog(on_error=ErrorHandleMethod.SKIP) is None
 
 
 def test_get_geodataframe_path(data_catalog):
@@ -1270,15 +1234,6 @@ class TestGetGeoDataset:
         gds_stac_item.add_asset(gds_base_name, gds_stac_asset)
 
         gds_stac_catalog.add_item(gds_stac_item)
-
-        outcome = cast(
-            StacCatalog, source.to_stac_catalog(on_error=ErrorHandleMethod.RAISE)
-        )
-        assert gds_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
-        source.metadata.crs = (
-            -3.14
-        )  # manually create an invalid adapter by deleting the crs
-        assert source.to_stac_catalog(ErrorHandleMethod.SKIP) is None
 
 
 def test_get_geodataset_artifact_data(data_catalog):

--- a/tests/data_catalog/test_data_catalog.py
+++ b/tests/data_catalog/test_data_catalog.py
@@ -697,14 +697,14 @@ class TestGetRasterDataset:
         raster_stac_catalog.add_item(raster_stac_item)
 
         outcome = cast(
-            StacCatalog, source.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+            StacCatalog, source.to_stac_catalog(handle_nodata=NoDataStrategy.RAISE)
         )
 
         assert raster_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
         source.metadata.crs = (
             -3.14
         )  # manually create an invalid adapter by deleting the crs
-        assert source.to_stac_catalog(on_error=NoDataStrategy.SKIP) is None
+        assert source.to_stac_catalog(handle_nodata=NoDataStrategy.SKIP) is None
 
     @pytest.fixture()
     def zoom_dict(self, tmp_dir: Path, zoom_level_tif: str) -> Dict[str, Any]:
@@ -1027,13 +1027,13 @@ class TestGetGeoDataFrame:
 
         gdf_stac_catalog.add_item(gds_stac_item)
         outcome = cast(
-            StacCatalog, source.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+            StacCatalog, source.to_stac_catalog(handle_nodata=NoDataStrategy.RAISE)
         )
         assert gdf_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
         source.metadata.crs = (
             -3.14
         )  # manually create an invalid adapter by deleting the crs
-        assert source.to_stac_catalog(on_error=NoDataStrategy.SKIP) is None
+        assert source.to_stac_catalog(handle_nodata=NoDataStrategy.SKIP) is None
 
 
 def test_get_geodataframe_path(data_catalog):
@@ -1256,7 +1256,7 @@ class TestGetGeoDataset:
         gds_stac_catalog.add_item(gds_stac_item)
 
         outcome = cast(
-            StacCatalog, source.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+            StacCatalog, source.to_stac_catalog(handle_nodata=NoDataStrategy.RAISE)
         )
         assert gds_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
         source.metadata.crs = (
@@ -1514,9 +1514,9 @@ def test_to_stac(self, df: pd.DataFrame, tmp_dir: Path):
         NotImplementedError,
         match="DataFrameSource does not support full stac conversion ",
     ):
-        source.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+        source.to_stac_catalog(handle_nodata=NoDataStrategy.RAISE)
 
-    assert source.to_stac_catalog(on_error=NoDataStrategy.IGNORE) is None
+    assert source.to_stac_catalog(handle_nodata=NoDataStrategy.IGNORE) is None
 
 
 def test_get_dataframe_custom_data(tmp_dir, df, data_catalog):

--- a/tests/data_catalog/test_data_catalog.py
+++ b/tests/data_catalog/test_data_catalog.py
@@ -702,9 +702,9 @@ class TestGetRasterDataset:
 
         assert raster_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
         source.metadata.crs = (
-            -3.14
-        )  # manually create an invalid adapter by deleting the crs
-        assert source.to_stac_catalog(handle_nodata=NoDataStrategy.SKIP) is None
+            234234234  # manually create an invalid adapter by deleting the crs
+        )
+        assert source.to_stac_catalog(handle_nodata=NoDataStrategy.IGNORE) is None
 
     @pytest.fixture()
     def zoom_dict(self, tmp_dir: Path, zoom_level_tif: str) -> Dict[str, Any]:
@@ -1033,7 +1033,7 @@ class TestGetGeoDataFrame:
         source.metadata.crs = (
             -3.14
         )  # manually create an invalid adapter by deleting the crs
-        assert source.to_stac_catalog(handle_nodata=NoDataStrategy.SKIP) is None
+        assert source.to_stac_catalog(handle_nodata=NoDataStrategy.IGNORE) is None
 
 
 def test_get_geodataframe_path(data_catalog):
@@ -1500,7 +1500,7 @@ def test_get_dataframe_variables(df, data_catalog):
     assert df.columns == ["city"]
 
 
-def test_to_stac(self, df: pd.DataFrame, tmp_dir: Path):
+def test_to_stac(df: pd.DataFrame, tmp_dir: Path):
     uri_df = str(tmp_dir / "test.csv")
     name = "test_dataframe"
     df.to_csv(uri_df)

--- a/tests/data_catalog/test_data_catalog.py
+++ b/tests/data_catalog/test_data_catalog.py
@@ -116,6 +116,7 @@ def test_parser():
     datasource = _parse_data_source_dict("test", source, root=root)
     assert isinstance(datasource, GeoDataFrameSource)
     assert datasource.full_uri == abspath(source["uri"])
+
     dd = {
         "test": {
             "driver": {"name": "pyogrio"},
@@ -694,6 +695,16 @@ class TestGetRasterDataset:
 
         raster_stac_catalog.add_item(raster_stac_item)
 
+        outcome = cast(
+            StacCatalog, source.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+        )
+
+        assert raster_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
+        source.metadata.crs = (
+            -3.14
+        )  # manually create an invalid adapter by deleting the crs
+        assert source.to_stac_catalog(on_error=NoDataStrategy.SKIP) is None
+
     @pytest.fixture()
     def zoom_dict(self, tmp_dir: Path, zoom_level_tif: str) -> Dict[str, Any]:
         return {
@@ -1014,6 +1025,14 @@ class TestGetGeoDataFrame:
         gds_stac_item.add_asset(gds_base_name, gds_stac_asset)
 
         gdf_stac_catalog.add_item(gds_stac_item)
+        outcome = cast(
+            StacCatalog, source.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+        )
+        assert gdf_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
+        source.metadata.crs = (
+            -3.14
+        )  # manually create an invalid adapter by deleting the crs
+        assert source.to_stac_catalog(on_error=NoDataStrategy.SKIP) is None
 
 
 def test_get_geodataframe_path(data_catalog):
@@ -1234,6 +1253,15 @@ class TestGetGeoDataset:
         gds_stac_item.add_asset(gds_base_name, gds_stac_asset)
 
         gds_stac_catalog.add_item(gds_stac_item)
+
+        outcome = cast(
+            StacCatalog, source.to_stac_catalog(on_error=NoDataStrategy.RAISE)
+        )
+        assert gds_stac_catalog.to_dict() == outcome.to_dict()  # type: ignore
+        source.metadata.crs = (
+            -3.14
+        )  # manually create an invalid adapter by deleting the crs
+        assert source.to_stac_catalog(NoDataStrategy.IGNORE) is None
 
 
 def test_get_geodataset_artifact_data(data_catalog):


### PR DESCRIPTION
## Issue addressed
Fixes #1036 
## Explanation
HandleNodataStrategy is much more widely used in the driver side, while ErrorHandlingMethod was only really really used for stac. Thefore we're deprecating the latter in favour of the former

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist
- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been chagned
- [ ] `data/chagnelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
