### PR TITLE
use predicate arg in vector driver

### DIFF
--- a/hydromt/data_catalog/drivers/geodataset/vector_driver.py
+++ b/hydromt/data_catalog/drivers/geodataset/vector_driver.py
@@ -42,7 +42,6 @@ class GeoDatasetVectorDriver(GeoDatasetDriver):
         _warn_on_unused_kwargs(
             self.__class__.__name__,
             {
-                "predicate": predicate,
                 "variables": variables,
                 "time_range": time_range,
                 "metadata": metadata,
@@ -65,7 +64,9 @@ class GeoDatasetVectorDriver(GeoDatasetDriver):
                 raise ValueError(f"unknown preprocessor: '{preprocessor_name}'")
 
         crs: Optional[CRS] = metadata.crs if metadata else None
-        data = _open_geodataset(loc_path=uri, geom=mask, crs=crs, **options)
+        data = _open_geodataset(
+            loc_path=uri, geom=mask, crs=crs, predicate=predicate, **options
+        )
 
         if preprocessor is None:
             out = data


### PR DESCRIPTION
## Issue addressed
Fixes #983 

## Explanation
Predicate argument is still needed. I have added it in the `geodataset_vector`,  `GeoDatasetDriver`. We can implement these for geodataframe drivers in the future

## General Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `v1`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst
