### PR TITLE
fix docs and clean up finish release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,8 +51,21 @@ jobs:
       - name: Generate docs
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          pixi run --locked -e full-py311 html
-          echo "DOC_VERSION=$(pixi run --locked -e full-py311 python -c 'from hydromt import __version__ as v; print("dev" if "dev" in v else "v"+v.replace(".dev",""))')" >> $GITHUB_ENV
+          pixi run --locked -e full-py311 docs
+          export CURRENT_VERSION=$(grep "__version__" hydromt/__init__.py | cut -d= -f 2 | tr -d "\" ")
+          if [ -z "$CURRENT_VERSION" ]; then
+            echo "Could not determine version, exiting..."
+            exit 1
+          fi
+
+          # are we a dev version or not?
+          if echo "$CURRENT_VERSION" | grep -q "dev"; then
+            # no dev, just echo the version number
+            echo "v$CURRENT_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "dev" >> "$GITHUB_ENV"
+          fi
+
 
       - name: Upload to GitHub Pages
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -8,10 +8,6 @@ on:
     branches:
     - 'release/**'
   workflow_dispatch:
-    inputs:
-      run_id:
-        type: number
-        description: "The id of the workflow run that created the artifacts"
 
 jobs:
   # publish-docker:


### PR DESCRIPTION
## Issue addressed
Fixes #1071 

## Explanation
the pixi command was outdated (`html` is now `docs`) so I removed that. 

Aside from that I also think the docs version hasn't been detected correctly for a bit, leading to previous docs disappearing with some more explicit bash this should be at least noticed sooner I think. I'll revert previous versions soon 

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist
- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been chagned
- [ ] `data/chagnelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
