### PR TITLE
fix `geom_component._region_data()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this page.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+
+Unreleased
+==========
+
+New
+---
+
+Changed
+-------
+
+Fixed
+-----
+- Fixed incorrect arguments causing crashes in geom_component._region_data() (#1091)
+
+Deprecated
+----------
+
 V1
 ==
 
@@ -51,23 +68,6 @@ Removed
 - The function `hydromt.gis.flw.guagemap` has been removed in favour of `hydromt.gis.flw.guage_map`. (#987)
 - The function `hydromt.gis.flw.basinmap` has been removed in favour of `hydromt.gis.flw.basin_map`. (#987)
 - Support for using the `within` predicate in the function `get_basin_geometry` has been removed. (#987)
-
-
-
-Unreleased
-==========
-
-New
----
-
-Changed
--------
-
-Fixed
------
-
-Deprecated
-----------
 
 v1.0.0 (2024-09-26)
 ===================

--- a/hydromt/model/components/geoms.py
+++ b/hydromt/model/components/geoms.py
@@ -95,9 +95,7 @@ class GeomsComponent(SpatialModelComponent):
             bounds[:,2].max(),
             bounds[:,3].max(),
         )
-        region = gpd.GeoDataFrame(
-            geometry=[box(*total_bounds)], crs=self.model.crs
-        )
+        region = gpd.GeoDataFrame(geometry=[box(*total_bounds)], crs=self.model.crs)
 
         return region
 

--- a/hydromt/model/components/geoms.py
+++ b/hydromt/model/components/geoms.py
@@ -95,6 +95,7 @@ class GeomsComponent(SpatialModelComponent):
             bounds[2].max(),
             bounds[3].max(),
         )
+        # TODO: total_bounds should be replaced with *total_bounds
         region = gpd.GeoDataFrame(
             geometry=[gpd.GeoSeries(box(total_bounds))], crs=self.model.crs
         )

--- a/hydromt/model/components/geoms.py
+++ b/hydromt/model/components/geoms.py
@@ -90,10 +90,10 @@ class GeomsComponent(SpatialModelComponent):
             return None
         bounds = np.column_stack([geom.bounds for geom in self.data.values()])
         total_bounds = (
-            bounds[:,0].min(),
-            bounds[:,1].min(),
-            bounds[:,2].max(),
-            bounds[:,3].max(),
+            bounds[:, 0].min(),
+            bounds[:, 1].min(),
+            bounds[:, 2].max(),
+            bounds[:, 3].max(),
         )
         region = gpd.GeoDataFrame(geometry=[box(*total_bounds)], crs=self.model.crs)
 

--- a/hydromt/model/components/geoms.py
+++ b/hydromt/model/components/geoms.py
@@ -90,13 +90,13 @@ class GeomsComponent(SpatialModelComponent):
             return None
         bounds = np.column_stack([geom.bounds for geom in self.data.values()])
         total_bounds = (
-            bounds[0].min(),
-            bounds[1].min(),
-            bounds[2].max(),
-            bounds[3].max(),
+            bounds[:,0].min(),
+            bounds[:,1].min(),
+            bounds[:,2].max(),
+            bounds[:,3].max(),
         )
         region = gpd.GeoDataFrame(
-            geometry=[gpd.GeoSeries(box(*total_bounds))], crs=self.model.crs
+            geometry=[box(*total_bounds)], crs=self.model.crs
         )
 
         return region

--- a/hydromt/model/components/geoms.py
+++ b/hydromt/model/components/geoms.py
@@ -95,9 +95,8 @@ class GeomsComponent(SpatialModelComponent):
             bounds[2].max(),
             bounds[3].max(),
         )
-        # TODO: total_bounds should be replaced with *total_bounds
         region = gpd.GeoDataFrame(
-            geometry=[gpd.GeoSeries(box(total_bounds))], crs=self.model.crs
+            geometry=[gpd.GeoSeries(box(*total_bounds))], crs=self.model.crs
         )
 
         return region

--- a/tests/components/test_geoms_component.py
+++ b/tests/components/test_geoms_component.py
@@ -7,6 +7,7 @@ import geopandas as gpd
 from pyproj import CRS
 from pytest_mock import MockerFixture
 from shapely.geometry import box
+import numpy as np
 
 from hydromt.model import Model
 from hydromt.model.components.geoms import GeomsComponent
@@ -25,11 +26,8 @@ def test_model_set_geoms(tmpdir):
 
     assert list(geom_component.data.keys()) == ["geom_wgs84"]
     assert list(geom_component.data.values())[0].equals(geom)
-    # TODO: this will for sure fail, assertion has to be updated.
-    # at least we should call _region_data since I expect that this shows the bug
-    # I would like to have a failing testcase first before adding the fix
-    # to be sure the fix is covered
-    assert geom_component._region_data() == 1
+    expected_bounds = np.array([[ 4.221067, 51.949474,  4.471006, 52.073727]])
+    assert np.allclose(geom_component._region_data.bounds.values, expected_bounds)
 
 
 def test_model_read_geoms(tmpdir):

--- a/tests/components/test_geoms_component.py
+++ b/tests/components/test_geoms_component.py
@@ -25,6 +25,11 @@ def test_model_set_geoms(tmpdir):
 
     assert list(geom_component.data.keys()) == ["geom_wgs84"]
     assert list(geom_component.data.values())[0].equals(geom)
+    # TODO: this will for sure fail, assertion has to be updated.
+    # at least we should call _region_data since I expect that this shows the bug
+    # I would like to have a failing testcase first before adding the fix
+    # to be sure the fix is covered
+    assert geom_component._region_data() == 1
 
 
 def test_model_read_geoms(tmpdir):

--- a/tests/components/test_geoms_component.py
+++ b/tests/components/test_geoms_component.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from typing import cast
 
 import geopandas as gpd
+import numpy as np
 from pyproj import CRS
 from pytest_mock import MockerFixture
 from shapely.geometry import box
-import numpy as np
 
 from hydromt.model import Model
 from hydromt.model.components.geoms import GeomsComponent
@@ -26,7 +26,7 @@ def test_model_set_geoms(tmpdir):
 
     assert list(geom_component.data.keys()) == ["geom_wgs84"]
     assert list(geom_component.data.values())[0].equals(geom)
-    expected_bounds = np.array([[ 4.221067, 51.949474,  4.471006, 52.073727]])
+    expected_bounds = np.array([[4.221067, 51.949474,  4.471006, 52.073727]])
     assert np.allclose(geom_component._region_data.bounds.values, expected_bounds)
 
 

--- a/tests/components/test_geoms_component.py
+++ b/tests/components/test_geoms_component.py
@@ -15,7 +15,8 @@ from hydromt.model.components.spatial import SpatialModelComponent
 
 
 def test_model_set_geoms(tmpdir):
-    bbox = box(*[4.221067, 51.949474, 4.471006, 52.073727], ccw=True)
+    bbox_list = [4.221067, 51.949474, 4.471006, 52.073727]
+    bbox = box(*bbox_list, ccw=True)
     geom = gpd.GeoDataFrame(geometry=[bbox], crs=4326)
 
     model = Model(root=str(tmpdir), mode="w")
@@ -26,7 +27,7 @@ def test_model_set_geoms(tmpdir):
 
     assert list(geom_component.data.keys()) == ["geom_wgs84"]
     assert list(geom_component.data.values())[0].equals(geom)
-    expected_bounds = np.array([[4.221067, 51.949474,  4.471006, 52.073727]])
+    expected_bounds = np.array([bbox_list])
     assert np.allclose(geom_component._region_data.bounds.values, expected_bounds)
 
 


### PR DESCRIPTION
## Issue addressed
Fixes #1079

## Explanation
My steps:
- added the assertion of `geom_component._region_data()`, since calling that property shows the current bug (fails with `IndexError: index 1 is out of bounds for axis 0 with size 1`)
- solved the IndexError by properly generating `total_bounds` (was calling over the wrong dimension)
- this caused the error `box() missing 3 required positional arguments: 'miny', 'maxx', and 'maxy'` one line below
- solved by adding `*` to expand the `total_bounds` argument form a tuple into four separate arguments
- this resulted in `shapely.errors.GeometryTypeError: Unknown geometry type: 'featurecollection'` >> solved by generating the geodataframe like in `test_model_set_geoms`, but I have no clue if this results in the expected type/format. At least it works, but please check this
- made sure the assertion in the test also checked a valid result

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation >> not relevant
- [x] Updated changelog.rst >> add later to avoid conflicts before this PR is merged, it can be something like "fixed `geom_component._region_data()` (#1091)"

## Data/Catalog checklist
- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been chagned
- [ ] `data/chagnelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite
