### PR TITLE
bump version to v1.0.1.dev0

### DIFF
--- a/hydromt/__init__.py
+++ b/hydromt/__init__.py
@@ -1,7 +1,7 @@
 """HydroMT: Automated and reproducible model building and analysis."""
 
 # version number without 'v' at start
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.1.dev0"
 
 # This is only here to suppress the bug described in
 # https://github.com/pydata/xarray/issues/7259


### PR DESCRIPTION
## Issue addressed
Fixes #1093 

## Explanation
post release the version number was updated incorrectly making two validation tests fail. This should fix them again

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist
- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been chagned
- [ ] `data/chagnelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
