### PR TITLE
Fix binder integration

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,15 +1,13 @@
-# currently we haven't published an official hydromt image yet, so for now
-# I import from an export I've put on my own account. this should be moved
-# to the official image as soon as it's published.
-FROM deltares/hydromt:slim as binder
-# Binder hard requires all of these steps when they build the imae
+FROM deltares/hydromt:slim AS binder
+# Binder hard requires all of these steps when they build the image
 # therefore these steps aren't taken sooner
 
-ENV HOME=/home/mambauser \
+ENV HOME=/home/deltares \
     NUMBA_CACHE_DIR=${HOME}/.cahce/numba\
     USE_PYGEOS=0 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYDEVD_DISABLE_FILE_VALIDATION=1
+RUN pixi shell
 WORKDIR ${HOME}
-ENTRYPOINT ["micromamba","run","-n","hydromt"]
+ENTRYPOINT []
 CMD ["jupyter","notebook","--port=8888","--ip=0.0.0.0"]

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -7,7 +7,6 @@ ENV HOME=/home/deltares \
     USE_PYGEOS=0 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYDEVD_DISABLE_FILE_VALIDATION=1
-RUN pixi shell
 WORKDIR ${HOME}
-ENTRYPOINT []
-CMD ["jupyter","notebook","--port=8888","--ip=0.0.0.0"]
+ENTRYPOINT ["pixi", "run", "-e", "slim-py311"]
+CMD ["pixi", "run", "-e", "slim-py311","jupyter","notebook","--port=8888","--ip=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim AS base
 ARG PIXIENV
-RUN apt-get update && apt-get install -y curl && apt clean && useradd deltares
+RUN apt-get update && apt-get install -y curl && apt clean && useradd deltares --uid 1000
 
 USER deltares
 WORKDIR /home/deltares

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Changed
 Fixed
 -----
 - Fixed incorrect arguments causing crashes in ``geom_component._region_data()`` (#1091)
+- Fixed binder integration dockerfile (#1098)
 
 Deprecated
 ----------


### PR DESCRIPTION
## Issue addressed
Fixes #1098

## Explanation
The dockerfile for the binder integration seemingly hasn't been updated since we moved to pixi since it still references mamba. Updating it to use pixi solved the issue. 

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist
- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been chagned
- [ ] `data/chagnelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
