### PR TITLE
fix(ci): make sure tests run after pixi auto update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,10 @@ on:
       - pixi.lock
       - pixi.toml
       - .github/workflows/tests.yml
+  workflow_run:
+    workflows: [Pixi auto update]
+    types:
+      - completed
 
 
 jobs:


### PR DESCRIPTION
## Explanation
Currently tests are not run automatically when the pixi workflow runs to update the dependencies. this should fix that


