### PR TITLE
Add sonarcloud properties for tests and python versions

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,2 @@
+sonar.tests = hydromt/tests
+sonar.python.version = 3.9, 3.10, 3.11

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 HydroMT: Automated and reproducible model building and analysis
 ===============================================================
 
-|pypi| |conda forge| |docs_latest| |docs_stable| |binder| |codecov| |license| |doi| |joss_paper|
+|pypi| |conda forge| |docs_latest| |docs_stable| |binder| |codecov| |sonarqube| |license| |doi| |joss_paper|
 
 
 What is HydroMT?
@@ -119,3 +119,7 @@ happy to discuss how it can be implemented for your model.
 
 .. |joss_paper| image:: https://joss.theoj.org/papers/10.21105/joss.04897/status.svg
    :target: https://doi.org/10.21105/joss.04897
+
+.. |sonarqube| image:: https://sonarcloud.io/api/project_badges/measure?project=Deltares_hydromt&metric=alert_status
+    :target: https://sonarcloud.io/summary/new_code?id=Deltares_hydromt
+    :alt: SonarQube status


### PR DESCRIPTION
## Issue addressed
Fixes #1124 

## Explanation
Add `.sonarcloud.properties` file with python version and test folder. Stick with automatic analysis.

## General Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist
- [x] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [x] None of the old `data_catalog.yml` files have been chagned
- [x] `data/chagnelog.rst` has been updated
- [x] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [x] New file has been tested locally
- [x] Tests have been added using the new file in the test suite

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
