### PR TITLE
mistake in driver plugin loader

### DIFF
--- a/hydromt/data_catalog/drivers/base_driver.py
+++ b/hydromt/data_catalog/drivers/base_driver.py
@@ -41,5 +41,5 @@ class BaseDriver(AbstractBaseModel, ABC):
     @classmethod
     def _load_plugins(cls):
         """Load Driver plugins."""
-        plugins: Dict[str, BaseDriver] = PLUGINS.uri_resolver_plugins
+        plugins: Dict[str, BaseDriver] = PLUGINS.driver_plugins
         logger.debug(f"loaded {cls.__name__} plugins: {plugins}")


### PR DESCRIPTION
## Explanation

`Driver` now load `URIResolver` plugins by accident.
Found it while looking up some pydantic details for another repo :)

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst