### PR TITLE
Setup SonarQube via CLI scanning

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,10 +44,8 @@ jobs:
         with:
           pixi-version: "v0.41.1"
       - name: Test
-        run: |
-          export NUMBA_DISABLE_JIT=1
-          pixi run --locked test-cov
+        run: pixi run --locked test-cov
       - name: SonarQube Scan
-        uses: SonarSource/sonarcloud-github-action@v5
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,53 @@
+name: SonarQube Scan and coverage
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - v1
+    paths:
+      - tests/**/*
+      - hydromt/**/*
+      - data/**/*
+      - pyproject.toml
+      - pixi.lock
+      - .github/workflows/sonar.yml
+  pull_request:
+    branches:
+      - main
+      - v1
+    paths:
+      - tests/**/*
+      - hydromt/**/*
+      - data/**/*
+      - pyproject.toml
+      - pixi.lock
+      - .github/workflows/sonar.yml
+  workflow_run:
+    workflows: [Pixi auto update]
+    types:
+      - completed
+
+
+jobs:
+  scan:
+    defaults:
+      run:
+        shell: bash -e -l {0}
+
+    name: run test coverage and SonarQube scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.2
+        with:
+          pixi-version: "v0.41.1"
+      - name: Test
+        run: |
+          export NUMBA_DISABLE_JIT=1
+          pixi run --locked test-cov
+      - name: SonarQube Scan
+        uses: SonarSource/sonarcloud-github-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ on:
 
 
 jobs:
-  build:
+  test:
     defaults:
       run:
         shell: bash -e -l {0}
@@ -57,4 +57,4 @@ jobs:
       - name: Test
         run: |
           export NUMBA_DISABLE_JIT=1
-          pixi run --locked -e ${{ matrix.dependencies }}-py${{ matrix.python-version }} test-cov
+          pixi run --locked -e ${{ matrix.dependencies }}-py${{ matrix.python-version }} test

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,0 @@
-sonar.tests = hydromt/tests
-sonar.python.version = 3.9, 3.10, 3.11, 3.12, 3.13

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey = Deltares_hydromt
 sonar.organization = deltares
-sonar.tests = hydromt/tests
+sonar.tests = tests
 sonar.python.version = 3.9, 3.10, 3.11, 3.12, 3.13
 sonar.python.coverage.reportPaths = coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey = Deltares_hydromt
+sonar.organization = deltares
+sonar.tests = hydromt/tests
+sonar.python.version = 3.9, 3.10, 3.11, 3.12, 3.13
+sonar.python.coverage.reportPaths = coverage.xml


### PR DESCRIPTION
Add code coverage support

## Issue addressed

Fixes #1077

## Explanation

We have migrated to SonarQube Cloud, and it also supports code coverage. So we want to have all the information in one place.

## General Checklist

- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
