### PR TITLE
Return correct dims of rotated grid constructed from geom

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changed
 Fixed
 -----
 -  Pandas driver does not receive unnecessary metadata (#1141)
+- `create_rotated_grid_from_geom` now returns grids with dimensions (y,x) instead if (x,y). (#1153)
 
 Deprecated
 ----------

--- a/hydromt/gis/raster.py
+++ b/hydromt/gis/raster.py
@@ -173,7 +173,7 @@ def full_from_transform(
     transform : affine transform
         Two dimensional affine transform for 2D linear mapping.
     shape : tuple of int
-        Length along (dim0, x, y) dimensions, of which the first is optional.
+        Length along (dim0, y, x) dimensions, of which the first is optional.
     nodata : optional
         The nodata value to assign to the DataArray. Defaults to np.nan.
     dtype : optional

--- a/hydromt/model/processes/grid.py
+++ b/hydromt/model/processes/grid.py
@@ -246,7 +246,7 @@ def create_rotated_grid_from_geom(
     )
     return raster.full_from_transform(
         transform,
-        shape=(mmax, nmax),
+        shape=(nmax, mmax),
         nodata=1,
         dtype=np.uint8,
         name="mask",

--- a/tests/gis/test_raster.py
+++ b/tests/gis/test_raster.py
@@ -11,8 +11,7 @@ import pytest
 import rasterio
 import xarray as xr
 from affine import Affine
-from shapely import Polygon
-from shapely.geometry import LineString, Point, box
+from shapely.geometry import LineString, Point, Polygon, box
 
 from hydromt._io import _open_raster
 from hydromt.gis import _gis_utils, raster

--- a/tests/gis/test_raster.py
+++ b/tests/gis/test_raster.py
@@ -571,7 +571,7 @@ def test_rotated(transform, shape, tmpdir):
     assert np.all(da2.raster.box.intersects(da2_reproj.raster.box.to_crs(4326)))
 
 
-def test_create_rotated_grid_from_geom():
+def test_create_rotated_grid_from_geom_axis_aligned():
     coords = [(0, 0), (10, 0), (10, 100), (0, 100), (0, 0)]
     polygon = Polygon(coords)
 
@@ -579,6 +579,24 @@ def test_create_rotated_grid_from_geom():
     region = gpd.GeoDataFrame(pd.DataFrame({"id": [1]}), geometry=[polygon])
     da = create_rotated_grid_from_geom(region, res=1, dec_origin=0, dec_rotation=0)
     expected_shape = (100, 10)
+    assert da.raster.shape == expected_shape
+
+
+def test_create_rotated_grid_from_geom_rotated():
+    # same square as test_create_rotated_grid_from_geom_axis_aligned but rotated 45 deg
+    coords = [
+        (36.81980515339464, 11.109127034739885),
+        (43.890872965260115, 18.18019484660536),
+        (-26.81980515339464, 88.89087296526012),
+        (-33.890872965260115, 81.81980515339464),
+        (36.81980515339464, 11.109127034739885),
+    ]
+    polygon = Polygon(coords)
+
+    # Create a GeoDataFrame
+    region = gpd.GeoDataFrame(pd.DataFrame({"id": [1]}), geometry=[polygon])
+    da = create_rotated_grid_from_geom(region, res=1, dec_origin=0, dec_rotation=0)
+    expected_shape = (10, 101)
     assert da.raster.shape == expected_shape
 
 


### PR DESCRIPTION
## Issue addressed

Fixes #1121 

## Explanation

As mentioned the rotated grid creation returned the dimensions flipped as was reported in the docstring. I added a simple test to solidfy which shapes we should return here 

## General Checklist

- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
