### PR TITLE
transform totalbounds to 4326 before trying to guess utm

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changed
 Fixed
 -----
 -  Pandas driver does not receive unnecessary metadata (#1141)
+- Transform total bounds of region to 4326 before guessing UTM crs in `grid_from_region` (#1154)
 
 Deprecated
 ----------

--- a/hydromt/gis/_gis_utils.py
+++ b/hydromt/gis/_gis_utils.py
@@ -58,7 +58,7 @@ def utm_crs(bbox):
     return CRS.from_epsg(epsg)
 
 
-def _parse_crs(crs: Any, bbox: List[float] = None) -> CRS:
+def _parse_crs(crs: Any, bbox: Optional[List[float]] = None) -> CRS:
     """Parse crs string to pyproj.CRS.
 
     Parameters
@@ -260,8 +260,7 @@ def _zoom_to_overview_level(
         overview_level = zoom
         if overview_level not in zls_dict:
             raise ValueError(
-                f"Overview level {overview_level} not defined."
-                f"Select from {zls_dict}."
+                f"Overview level {overview_level} not defined.Select from {zls_dict}."
             )
         dst_res = zls_dict[overview_level]
     elif (

--- a/hydromt/model/processes/grid.py
+++ b/hydromt/model/processes/grid.py
@@ -39,7 +39,7 @@ def create_grid_from_region(
     *,
     data_catalog: Optional[DataCatalog] = None,
     res: Optional[Number] = None,
-    crs: Optional[int] = None,
+    crs: Optional[Union[int, str]] = None,
     region_crs: int = 4326,
     rotated: bool = False,
     hydrography_path: Optional[str] = None,
@@ -69,8 +69,9 @@ def create_grid_from_region(
     res: float or int, optional
         Resolution used to generate 2D grid [unit of the CRS], required if region
         is not based on 'grid'.
-    crs : int, optional
-        EPSG code of the grid to create.
+    crs : int, or str optional
+        EPSG code of the grid to create, or 'utm'. if crs is 'utm' the closest utm grid will be
+        guessed at.
     region_crs : int, optional
         EPSG code of the region geometry, by default 4326. Only applies if
         region is of kind 'bbox' or if geom crs is not defined in the file itself.

--- a/tests/gis/test_raster.py
+++ b/tests/gis/test_raster.py
@@ -6,14 +6,17 @@ from pathlib import Path
 import dask
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 import pytest
 import rasterio
 import xarray as xr
 from affine import Affine
+from shapely import Polygon
 from shapely.geometry import LineString, Point, box
 
 from hydromt._io import _open_raster
 from hydromt.gis import _gis_utils, raster
+from hydromt.model.processes.grid import create_grid_from_region
 
 # origin, rotation, res, shape, internal_bounds
 # NOTE a rotated grid with a negative dx is not supported
@@ -590,3 +593,26 @@ def test_to_mapstack(rioda: xr.DataArray, tmp_dir: Path):
     ds.raster.to_mapstack(str(tmp_dir), prefix=prefix, mask=True, driver="GTiff")
     for name in ds.raster.vars:
         assert (tmp_dir / f"{prefix}{name}.tif").is_file()
+
+
+def test_grid_utm_parsing():
+    # Generate a simple quadrilateral polygon in a reasonable UTM 33N range
+    coords = [
+        (652586.4996784809, 5431261.715665519),
+        (582167.8955685529, 5682488.643002097),
+        (306934.9094089565, 5908444.4717937615),
+        (427948.6828043202, 5559713.185517933),
+        (525236.8723501079, 5513048.859599449),
+    ]
+
+    polygon = Polygon(coords)
+
+    # Create a GeoDataFrame
+    region = gpd.GeoDataFrame(pd.DataFrame({"id": [1]}), geometry=[polygon], crs=32633)
+
+    # Now finally call the function
+    _ = create_grid_from_region(
+        region={"geom": region},
+        crs="utm",
+        res=100,
+    )

--- a/tests/gis/test_raster.py
+++ b/tests/gis/test_raster.py
@@ -15,7 +15,10 @@ from shapely.geometry import LineString, Point, Polygon, box
 
 from hydromt._io import _open_raster
 from hydromt.gis import _gis_utils, raster
-from hydromt.model.processes.grid import create_grid_from_region, create_rotated_grid_from_geom
+from hydromt.model.processes.grid import (
+    create_grid_from_region,
+    create_rotated_grid_from_geom,
+)
 
 # origin, rotation, res, shape, internal_bounds
 # NOTE a rotated grid with a negative dx is not supported


### PR DESCRIPTION
## Issue addressed

Fixes #1120 

## Explanation
to guess the nearest `UTM` crs the bounds need to be provided in 4326. Previously the bounds were provided in the region crs. To avoid having to reproject twice, we transform the bounds "manually" 

## General Checklist

- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
