### PR TITLE
fixes calling DataCatalog.get_dataframe with path object 

### DIFF
--- a/hydromt/data_catalog/data_catalog.py
+++ b/hydromt/data_catalog/data_catalog.py
@@ -1755,7 +1755,7 @@ class DataCatalog(object):
                 )
                 name = basename(data_like)
                 source = DataFrameSource(
-                    uri=data_like, name=name, driver=driver, **kwargs
+                    uri=str(data_like), name=name, driver=driver, **kwargs
                 )
                 self.add_source(name, source)
         elif isinstance(data_like, pd.DataFrame):


### PR DESCRIPTION
## Issue addressed

Fixes #1166 

## Explanation
Currently a Path object could be passed on to a DataFrameSource object for the uri argument in the DataCatalog.get_dataframe method. This will cause an validation error because DataFrameSource only accepts a string for the uri argument. I casted the path variable to a string to fix this. In all other get_data methods this was done as well, but someone forgot to add this to the get_dataframe method apparently. 

## General Checklist

- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
