### PR TITLE
Add tests for components with default template

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Fixed
 -  Pandas driver does not receive unnecessary metadata (#1141)
 - Transform total bounds of region to 4326 before guessing UTM crs in `grid_from_region` (#1154)
 - `create_rotated_grid_from_geom` now returns grids with dimensions (y,x) instead if (x,y). (#1153)
+- `ConfigComponent` now actually reads from provided default template files if no data is present (#1171)
 
 Deprecated
 ----------

--- a/hydromt/model/components/config.py
+++ b/hydromt/model/components/config.py
@@ -107,9 +107,19 @@ class ConfigComponent(ModelComponent):
     def read(self, path: Optional[str] = None) -> None:
         """Read model config at <root>/{path}."""
         self._initialize(skip_read=True)
-        p = path or self._filename
-        # if path is abs, join will just return path
-        read_path = join(self.root.path, p)
+
+        if (
+            self._data is not None
+            and len(self._data) == 0
+            and self._default_template_filename
+        ):
+            p = path or self._default_template_filename
+            read_path = join(self.root.path, self._default_template_filename)
+        else:
+            p = path or self._filename
+            # if path is abs, join will just return path
+            read_path = join(self.root.path, p)
+
         if isfile(read_path):
             logger.info(f"Reading model config file from {read_path}.")
         else:


### PR DESCRIPTION
## Explanation

When I was working on the sonarcube issues, I noticed that we lacked test coverage for a config component that is given a default template, which is probably also why we didn't cover that case. This PR fixes that. 

There was no issue for this, but I'm happy to make one if the reviewer would like to see one. 

## General Checklist

- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
