### PR TITLE
Only run create release artifacts on release branches

### DIFF
--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -25,6 +25,7 @@ jobs:
             echo "which is not a release branch. If this was accidental please run it "
             echo "on a release branch instead. If it happened as part of a workflow"
             echo "something went wrong. In that case please report this as a bug report"
+            exit 1
           fi
   pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Explanation
During the last release some artifacts were created and released under the wrong version number (which has now been cleaned up), because I accidentally ran the `create-release-artifacts` workflow in the context of the main branch instead of the release branch. This PR adds an extra safeguard to make sure that doesn't happen. 

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
