### PR TITLE
Fix: The bounds of geoms component

### DIFF
--- a/hydromt/model/components/geoms.py
+++ b/hydromt/model/components/geoms.py
@@ -88,12 +88,12 @@ class GeomsComponent(SpatialModelComponent):
         # Use the total bounds of all geometries as region
         if len(self.data) == 0:
             return None
-        bounds = np.column_stack([geom.bounds for geom in self.data.values()])
+        bounds = np.column_stack([geom.total_bounds for geom in self.data.values()])
         total_bounds = (
-            bounds[:, 0].min(),
-            bounds[:, 1].min(),
-            bounds[:, 2].max(),
-            bounds[:, 3].max(),
+            bounds[0, :].min(),
+            bounds[1, :].min(),
+            bounds[2, :].max(),
+            bounds[3, :].max(),
         )
         region = gpd.GeoDataFrame(geometry=[box(*total_bounds)], crs=self.model.crs)
 


### PR DESCRIPTION
## Issue addressed

Fixes #1194 

## Explanation

Fixed the indexing of the column_stack of all the individual geodataframe total bounds.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

No.
