### PR TITLE
fix finalize-release workflow

### DIFF
--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -122,14 +122,14 @@ jobs:
         run: |
             git config user.name "GitHub Actions Bot"
             git config user.email "<>"
-            git checkout -b "post-v$RELEASE_VERSION-release"
+            git checkout -b "post-$RELEASE_VERSION-release"
 
             # post release stuff so we don't forget
-            sed -i "s/v$RELEASE_VERSION/Unreleased\n==========\n\nNew\n---\n\nChanged\n-------\n\nFixed\n-----\n\nDeprecated\n----------\n\nv$RELEASE_VERSION/" docs/changelog.rst
+            sed -i "s/$RELEASE_VERSION/Unreleased\n==========\n\nNew\n---\n\nChanged\n-------\n\nFixed\n-----\n\nDeprecated\n----------\n\n$RELEASE_VERSION/" docs/changelog.rst
             sed -i 's/__version__.*=.*"\(.*\)".*/__version__ = "\1.dev0"/' hydromt/__init__.py
 
             git add hydromt/__init__.py docs/changelog.rst
-            git commit -m "Post release v$RELEASE_VERSION"
-            git push --set-upstream origin "post-v$RELEASE_VERSION-release"
+            git commit -m "Post release $RELEASE_VERSION"
+            git push --set-upstream origin "post-$RELEASE_VERSION-release"
 
-            gh pr create -B "main" -H "post-v$RELEASE_VERSION-release" -t "Post v$RELEASE_VERSION release cleanup" -b "Add new changelog headers and set version back to dev"
+            gh pr create -B "main" -H "post-$RELEASE_VERSION-release" -t "Post $RELEASE_VERSION release cleanup" -b "Add new changelog headers and set version back to dev"


### PR DESCRIPTION
The $RELEASE_VERSION variable already included a v, which made the sed command fail.
 

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
