### PR TITLE
Clarify and update write and read nc

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,12 +12,15 @@ Unreleased
 
 New
 ---
+- Added option for delayed compute in writing netcdf files
+- Set compression in `_write_nc`
 
 Changed
 -------
 
 Fixed
 -----
+- CF compliant dimensions in netcdf files
 
 Deprecated
 ----------

--- a/hydromt/_io/__init__.py
+++ b/hydromt/_io/__init__.py
@@ -11,6 +11,7 @@ from .readers import (
     _open_vector,
     _open_vector_from_table,
     _read_nc,
+    _read_ncs,
     _read_toml,
     _read_yaml,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "_open_vector",
     "_open_vector_from_table",
     "_read_nc",
+    "_read_ncs",
     "_read_toml",
     "_read_yaml",
     "_write_nc",

--- a/hydromt/_io/readers.py
+++ b/hydromt/_io/readers.py
@@ -937,8 +937,10 @@ def _read_ncs(
 
     Parameters
     ----------
-    file : str
-        filename relative to model root, may contain wildcards
+    filename_template : str
+        Filename relative to model root, may contain wildcards
+    root : Path
+        The path to the model directory in which to write
     mask_and_scale : bool, optional
         If True, replace array values equal to _FillValue with NA and scale values
         according to the formula original_values * scale_factor + add_offset, where

--- a/hydromt/_io/writers.py
+++ b/hydromt/_io/writers.py
@@ -163,7 +163,7 @@ def _write_nc(
     force_overwrite: bool = False,
     **kwargs,
 ) -> Optional[DeferedFileClose]:
-    """Write dictionnary of xarray.Dataset and/or xarray.DataArray to netcdf files.
+    """Write xarray.Dataset and/or xarray.DataArray to netcdf file.
 
     Possibility to update the xarray objects attributes to get GDAL compliant NetCDF
     files, using :py:meth:`~hydromt.raster.gdal_compliant`.
@@ -177,7 +177,7 @@ def _write_nc(
     Parameters
     ----------
     ds : xr.DataArray | xr.Dataset
-        Data to be written to the drive
+        Dataset to be written to the drive
     filepath : Path | str
         Full path to the outgoing file
     compress : bool, optional

--- a/hydromt/_io/writers.py
+++ b/hydromt/_io/writers.py
@@ -3,7 +3,7 @@
 import os
 from logging import Logger, getLogger
 from os import makedirs
-from os.path import dirname, exists, isdir, isfile, join
+from os.path import dirname, exists, isdir, join
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional, Union, cast
@@ -11,10 +11,11 @@ from typing import Any, Dict, List, Optional, Union, cast
 import geopandas as gpd
 import numpy as np
 import xarray as xr
+from dask.diagnostics import ProgressBar
 from tomli_w import dump as dump_toml
 from yaml import dump as dump_yaml
 
-from hydromt._typing.type_def import DeferedFileClose, StrPath, XArrayDict
+from hydromt._typing.type_def import DeferedFileClose, StrPath
 
 logger: Logger = getLogger(__name__)
 
@@ -119,11 +120,43 @@ def _zarr_writer(
     return write_path
 
 
+def _compute_nc(
+    ds: xr.Dataset,
+    filepath: Path,
+    compute: bool = True,
+    **kwargs,
+):
+    """Write and compute the dataset.
+
+    Either compute directly or with a progressbar.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The dataset to be written.
+    filepath : Path
+        The full path to the outgoing file.
+    compute : bool, optional
+        Whether to compute the output directly, by default True
+    """
+    obj = ds.to_netcdf(
+        filepath,
+        compute=compute,
+        **kwargs,
+    )
+    if compute:
+        return
+
+    with ProgressBar():
+        obj.compute()
+    obj = None
+
+
 def _write_nc(
-    nc_dict: XArrayDict,
-    filename_template: str,
-    root: Path,
+    ds: xr.DataArray | xr.Dataset,
+    filepath: Path | str,
     *,
+    compress: bool = False,
     gdal_compliant: bool = False,
     rename_dims: bool = False,
     force_sn: bool = False,
@@ -143,54 +176,82 @@ def _write_nc(
 
     Parameters
     ----------
-    nc_dict: dict
-        Dictionary of xarray.Dataset and/or xarray.DataArray to write
-    path: str
-        filename relative to model root and should contain a {name} placeholder
-    temp_data_dir: StrPath, optional
-            Temporary directory to write grid to. If not given a TemporaryDirectory
-            is generated.
-    gdal_compliant: bool, optional
+    ds : xr.DataArray | xr.Dataset
+        Data to be written to the drive
+    filepath : Path | str
+        Full path to the outgoing file
+    compress : bool, optional
+        Whether or not to compress the data, by default False
+    gdal_compliant : bool, optional
         If True, convert xarray.Dataset and/or xarray.DataArray to gdal compliant
-        format using :py:meth:`~hydromt.raster.gdal_compliant`
-    rename_dims: bool, optional
+        format using :py:meth:`~hydromt.raster.gdal_compliant`, by default False
+    rename_dims : bool, optional
         If True, rename x_dim and y_dim to standard names depending on the CRS
         (x/y for projected and lat/lon for geographic). Only used if
-        ``gdal_compliant`` is set to True. By default, False.
-    force_sn: bool, optional
+        ``gdal_compliant`` is set to True. By default False
+    force_sn : bool, optional
         If True, forces the dataset to have South -> North orientation. Only used
-        if ``gdal_compliant`` is set to True. By default, False.
-    **kwargs:
+        if ``gdal_compliant`` is set to True. By default False
+    **kwargs : dict
         Additional keyword arguments that are passed to the `to_netcdf`
-        function.
+        function
     """
-    for name, ds in nc_dict.items():
-        if not isinstance(ds, (xr.Dataset, xr.DataArray)) or len(ds) == 0:
-            logger.error(f"{name} object of type {type(ds).__name__} not recognized")
-            continue
-        logger.debug(f"Writing file {filename_template.format(name=name)}")
-        _path = join(root, filename_template.format(name=name))
-        if isfile(_path) and not force_overwrite:
-            raise IOError(f"File {_path} already exists")
-        if not isdir(dirname(_path)):
-            os.makedirs(dirname(_path))
-        if gdal_compliant:
-            ds = ds.raster.gdal_compliant(rename_dims=rename_dims, force_sn=force_sn)
-        try:
-            ds.to_netcdf(_path, **kwargs)
-        except PermissionError:
-            logger.warning(f"Could not write to file {_path}, defering write")
-            temp_data_dir = TemporaryDirectory()
+    # Force typing
+    filepath = Path(filepath)
+    # Check the typing
+    if not isinstance(ds, (xr.Dataset, xr.DataArray)) or len(ds) == 0:
+        logger.error(f"Dataset object of type {type(ds).__name__} not recognized")
+        return
+    if isinstance(ds, xr.DataArray):
+        if ds.name is None:
+            ds.name = filepath.stem
+        ds = ds.to_dataset()
+    logger.debug(f"Writing file {filepath.as_posix()}")
+    # Check whether the file already exists
+    if filepath.is_file() and not force_overwrite:
+        raise IOError(f"File {filepath.as_posix()} already exists")
+    if not filepath.parent.is_dir():
+        filepath.parent.mkdir(parents=True)
 
-            temp_path = join(str(temp_data_dir), f"{_path}.tmp")
-            ds.to_netcdf(temp_path, **kwargs)
+    # Focus on the encoding and set these for all dims, coords and data vars
+    encoding = kwargs.pop("encoding", {})
+    for var in set(list(ds.coords) + list(ds.data_vars)):
+        if var not in encoding:
+            encoding[var] = {}
 
-            return DeferedFileClose(
-                ds=ds,
-                original_path=join(str(temp_data_dir), _path),
-                temp_path=temp_path,
-                close_attempts=1,
-            )
+    # Remove the nodata val specifier for the dimensions, CF compliant that is
+    for dim in ds.dims:
+        ds[dim].attrs.pop("_FillValue", None)
+        if dim in encoding:
+            encoding[dim].update({"_FillValue": None})
+
+    # Set compression if True
+    if compress:
+        for var in ds.data_vars:
+            encoding[var].update({"zlib": True})
+    kwargs["encoding"] = encoding
+
+    # Make gdal compliant if True, only in case of a spatial dataset
+    if gdal_compliant:
+        ds = ds.raster.gdal_compliant(rename_dims=rename_dims, force_sn=force_sn)
+
+    # Try to write the file
+    try:
+        _compute_nc(ds, filepath=filepath, **kwargs)
+    except PermissionError:
+        logger.warning(f"Could not write to file {filepath.as_posix()}, defering write")
+        temp_data_dir = TemporaryDirectory()
+
+        temp_filepath = Path(temp_data_dir.name, filepath.name)
+        _compute_nc(ds, filepath=temp_filepath, **kwargs)
+
+        return DeferedFileClose(
+            ds=ds,
+            original_path=filepath,
+            temp_path=temp_filepath,
+            close_attempts=1,
+        )
+
     return None
 
 

--- a/hydromt/_io/writers.py
+++ b/hydromt/_io/writers.py
@@ -215,7 +215,7 @@ def _write_nc(
 
     # Focus on the encoding and set these for all dims, coords and data vars
     encoding = kwargs.pop("encoding", {})
-    for var in set(list(ds.coords) + list(ds.data_vars)):
+    for var in set(ds.coords) | set(ds.data_vars):
         if var not in encoding:
             encoding[var] = {}
 

--- a/hydromt/_utils/caching.py
+++ b/hydromt/_utils/caching.py
@@ -177,7 +177,9 @@ def _cache_vrt_tiles(
                 if scheme is None:
                     # local path
                     # Get relative uri that the vrt points to
-                    relative_uri_ref: Path = Path(vrt_ref.lstrip(stripped))
+                    relative_uri_ref: Path = Path(
+                        os.path.relpath(vrt_ref, dirname(stripped))
+                    )
                     # Set download uri to match vrt_uri
                     src_uri: str = vrt_ref
                 else:

--- a/hydromt/model/components/datasets.py
+++ b/hydromt/model/components/datasets.py
@@ -1,6 +1,7 @@
 """Xarrays component."""
 
 from logging import Logger, getLogger
+from pathlib import Path
 from shutil import move
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union, cast
 
@@ -8,7 +9,7 @@ import xarray as xr
 from pandas import DataFrame
 from xarray import DataArray, Dataset
 
-from hydromt._io.readers import _read_nc
+from hydromt._io.readers import _read_ncs
 from hydromt._io.writers import _write_nc
 from hydromt._typing.type_def import DeferedFileClose, XArrayDict
 from hydromt.model.components.base import ModelComponent
@@ -133,7 +134,7 @@ class DatasetsComponent(ModelComponent):
         self._initialize(skip_read=True)
         kwargs = {**{"engine": "netcdf4"}, **kwargs}
         filename_template = filename or self._filename
-        ncs = _read_nc(
+        ncs = _read_ncs(
             filename_template,
             root=self.root.path,
             single_var_as_array=single_var_as_array,
@@ -189,16 +190,19 @@ class DatasetsComponent(ModelComponent):
             return
 
         kwargs = {**{"engine": "netcdf4"}, **kwargs}
-        _write_nc(
-            self.data,
-            filename_template=filename or self._filename,
-            force_overwrite=self.root.mode.is_override_mode(),
-            root=self.root.path,
-            gdal_compliant=gdal_compliant,
-            rename_dims=rename_dims,
-            force_sn=force_sn,
-            **kwargs,
-        )
+
+        filename = filename or self._filename
+        for name, ds in self.data.items():
+            filepath = Path(self.root.path, filename.format(name=name))
+            _write_nc(
+                ds,
+                filepath=filepath,
+                gdal_compliant=gdal_compliant,
+                rename_dims=rename_dims,
+                force_sn=force_sn,
+                force_overwrite=self.root.mode.is_override_mode(),
+                **kwargs,
+            )
 
     def _cleanup(
         self, forceful_overwrite=False, max_close_attempts=2

--- a/hydromt/model/components/grid.py
+++ b/hydromt/model/components/grid.py
@@ -12,7 +12,7 @@ from affine import Affine
 from pyproj import CRS
 from shapely.geometry import box
 
-from hydromt._io.readers import _read_nc
+from hydromt._io.readers import _read_ncs
 from hydromt._io.writers import _write_nc
 from hydromt._typing.error import NoDataStrategy, exec_nodata_strat
 from hydromt._typing.type_def import DeferedFileClose, Number
@@ -172,9 +172,8 @@ class GridComponent(SpatialModelComponent):
         self.write_region()
         # write_nc requires dict - use dummy 'grid' key
         return _write_nc(
-            {"grid": self.data},
-            filename or self._filename,
-            root=self.model.root.path,
+            self.data,
+            filepath=Path(self.root.path, filename or self._filename),
             gdal_compliant=gdal_compliant,
             rename_dims=rename_dims,
             force_overwrite=self.root.mode.is_override_mode(),
@@ -212,7 +211,7 @@ class GridComponent(SpatialModelComponent):
         # Load grid data in r+ mode to allow overwriting netcdf files
         if self.root.is_reading_mode() and self.root.is_writing_mode():
             kwargs["load"] = True
-        loaded_nc_files = _read_nc(
+        loaded_nc_files = _read_ncs(
             filename or self._filename,
             self.root.path,
             single_var_as_array=False,

--- a/hydromt/model/components/mesh.py
+++ b/hydromt/model/components/mesh.py
@@ -13,7 +13,7 @@ import xugrid as xu
 from pyproj import CRS
 from shapely.geometry import box
 
-from hydromt._io.readers import _read_nc
+from hydromt._io.readers import _read_ncs
 from hydromt.gis.raster import GEO_MAP_COORD
 from hydromt.model.components.base import ModelComponent
 from hydromt.model.components.spatial import SpatialModelComponent
@@ -195,7 +195,7 @@ class MeshComponent(SpatialModelComponent):
         self._initialize(skip_read=True)
 
         filename = filename or str(self._filename)
-        files = _read_nc(
+        files = _read_ncs(
             filename,
             root=self.root.path,
             single_var_as_array=False,

--- a/tests/components/test_grid_component.py
+++ b/tests/components/test_grid_component.py
@@ -74,7 +74,9 @@ def test_read(tmpdir, mock_model, hydds, mocker: MockerFixture):
         grid_component.read()
     mock_model.root = ModelRoot(path=tmpdir, mode="r+")
     grid_component = GridComponent(model=mock_model)
-    mocker.patch("hydromt.model.components.grid._read_nc", return_value={"grid": hydds})
+    mocker.patch(
+        "hydromt.model.components.grid._read_ncs", return_value={"grid": hydds}
+    )
     grid_component.read()
     assert grid_component.data == hydds
 


### PR DESCRIPTION
## Issue addressed

Fixes #<issue number>

## Explanation

Added compression and CF compliant dimensions encoding to `_write_nc`. Also added the option do to delay the compute of the datasets and use a dask progressbar instead. Also made `_write_nc` write a single file a simple loop over the data of the components where necessary. This in order to take away the footfun that was the encoding in the old `_write_nc`. Separated `_read_nc` into  `_read_nc` for a single file and `_read_ncs` for the read of multiple files using a pattern.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
