### PR TITLE
Encoding fix after rename dims

### DIFF
--- a/hydromt/_io/writers.py
+++ b/hydromt/_io/writers.py
@@ -233,7 +233,11 @@ def _write_nc(
 
     # Make gdal compliant if True, only in case of a spatial dataset
     if gdal_compliant:
+        y_old, x_old = ds.raster.dims
         ds = ds.raster.gdal_compliant(rename_dims=rename_dims, force_sn=force_sn)
+        y_dim, x_dim = ds.raster.dims
+        encoding[y_dim] = encoding.pop(y_old)
+        encoding[x_dim] = encoding.pop(x_old)
 
     # Try to write the file
     try:


### PR DESCRIPTION
## Issue addressed

Fixes #<issue number>

## Explanation

After renaming of the spatial dimensions, the encoding dictionary wasn't adjusted.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
