### PR TITLE
Fix update CLI

### DIFF
--- a/docs/guides/plugin_dev/migrating_to_v1.rst
+++ b/docs/guides/plugin_dev/migrating_to_v1.rst
@@ -93,6 +93,7 @@ An example of a fictional Wflow YAML file would be:
 		data_libs: deltares_data
 		components:
 			config:
+				type: ConfigComponent
 				filename: wflow_sbm_calibrated.toml
 	steps:
 		- setup_basemaps:

--- a/hydromt/cli/_utils.py
+++ b/hydromt/cli/_utils.py
@@ -75,24 +75,14 @@ def parse_json(_ctx: click.Context, _param, value: str) -> Dict[str, Any]:
 
 ### general parsing methods ##
 def parse_config(
-    path: Optional[Union[Path, str]] = None, opt_cli: Optional[Dict[str, Any]] = None
+    path: Optional[Union[Path, str]] = None,
 ) -> Dict[str, Any]:
-    """Parse config from `path` and combine with command line options `opt_cli`."""
+    """Parse config from `path`."""
     opt = {}
     if path is not None and isfile(path):
         opt = _config_read(path, abs_path=True, skip_abspath_sections=["setup_config"])
     elif path is not None:
         raise IOError(f"Config not found at {path}")
-    if opt_cli is not None:
-        for section in opt_cli:
-            if not isinstance(opt_cli[section], dict):
-                raise ValueError(
-                    "No section found in --opt values: "
-                    "use <section>.<option>=<value> notation."
-                )
-            if section not in opt:
-                opt[section] = opt_cli[section]
-                continue
-            for option, value in opt_cli[section].items():
-                opt[section].update({option: value})
+    else:
+        raise ValueError("Config path is required. Use -i or --config <path>")
     return opt

--- a/hydromt/cli/main.py
+++ b/hydromt/cli/main.py
@@ -112,14 +112,6 @@ verbose_opt = click.option("--verbose", "-v", count=True, help="Increase verbosi
 
 quiet_opt = click.option("--quiet", "-q", count=True, help="Decrease verbosity.")
 
-opt_cli = click.option(
-    "--opt",
-    multiple=True,
-    callback=_utils.parse_opt,
-    help="Method specific keyword arguments, see the method documentation "
-    "of the specific model for more information about the arguments.",
-)
-
 data_opt = click.option(
     "-d",
     "--data",
@@ -199,7 +191,6 @@ def main(ctx, models, components, plugins):
     type=str,
 )
 @arg_root
-@opt_cli
 @opt_config
 @data_opt
 @deltares_data_opt
@@ -212,7 +203,6 @@ def build(
     _ctx: click.Context,
     model,
     model_root,
-    opt,
     config,
     data,
     dd,
@@ -226,18 +216,19 @@ def build(
     Example usage:
     --------------
 
-    To build a wflow model for a subbasin using a point coordinates snapped to cells
-    with upstream area >= 50 km2
-    hydromt build wflow /path/to/model_root -i /path/to/wflow_config.yml -d
-    deltares_data -d /path/to/data_catalog.yml -v To build a sfincs model based on a
-    bbox hydromt build sfincs /path/to/model_root  -i /path/to/sfincs_config.yml  -r
-    "{'bbox': [4.6891,52.9750,4.9576,53.1994]}"  -d /path/to/data_catalog.yml -v
+    To build a wflow model:
+    hydromt build wflow /path/to/model_root -i /path/to/wflow_config.yml
+    -d deltares_data -d /path/to/data_catalog.yml -v 
+    
+    To build a sfincs model: 
+    hydromt build sfincs /path/to/model_root  -i /path/to/sfincs_config.yml
+    -d /path/to/data_catalog.yml -v
     """  # noqa: E501
     log_level = max(10, 30 - 10 * (verbose - quiet))
     log._setuplog(join(model_root, HYDROMT_LOG_PATH), log_level=log_level, append=False)
     logger.info(f"Building instance of {model} model at {model_root}.")
     logger.info("User settings:")
-    opt = _utils.parse_config(config, opt_cli=opt)
+    opt = _utils.parse_config(config)
     kwargs = opt.pop("global", {})
     modeltype = opt.pop("modeltype", model)
     # parse data catalog options from global section in config and cli options
@@ -285,13 +276,6 @@ def build(
     callback=lambda c, p, v: v if v else c.params["model_root"],
 )
 @opt_config
-@click.option(
-    "-c",
-    "--components",
-    multiple=True,
-    help="Model methods from configuration file to run",
-)
-@opt_cli
 @data_opt
 @deltares_data_opt
 @overwrite_opt
@@ -305,8 +289,6 @@ def update(
     model_root,
     model_out,
     config,
-    components,
-    opt,
     data,
     dd,
     fo,
@@ -322,9 +304,6 @@ def update(
     Example usage:
     --------------
 
-    Update (overwrite!) landuse-landcover based maps in a Wflow model:
-    hydromt update wflow /path/to/model_root -c setup_lulcmaps --opt lulc_fn=vito -d /path/to/data_catalog.yml -v
-
     Update Wflow model components outlined in an .yml configuration file and
     write the model to a directory:
     hydromt update wflow /path/to/model_root  -o /path/to/model_out  -i /path/to/wflow_config.yml  -d /path/to/data_catalog.yml -v
@@ -336,10 +315,8 @@ def update(
     logger.info(f"Updating {model} model at {model_root} ({mode}).")
     logger.info(f"Output dir: {model_out}")
     # parse settings
-    if len(components) == 1 and not isinstance(opt.get(components[0]), dict):
-        opt = {components[0]: opt}
     logger.info("User settings:")
-    opt = _utils.parse_config(config, opt_cli=opt)
+    opt = _utils.parse_config(config)
     kwargs = opt.pop("global", {})
     modeltype = opt.pop("modeltype", model)
     if modeltype not in PLUGINS.model_plugins:
@@ -358,12 +335,7 @@ def update(
             **kwargs,
         )
         mod.data_catalog.cache = cache
-        # keep only components + setup_config
-        if len(components) > 0:
-            opt0 = opt.get("setup_config", {})
-            opt = {c: opt.get(c, {}) for c in components}
-            opt.update({"setup_config": opt0})
-        mod.update(model_out=model_out, opt=opt, forceful_overwrite=fo)
+        mod.update(model_out=model_out, steps=opt["steps"], forceful_overwrite=fo)
     except Exception as e:
         logger.exception(e)  # catch and log errors
         raise

--- a/hydromt/model/model.py
+++ b/hydromt/model/model.py
@@ -141,7 +141,7 @@ class Model(object, metaclass=ABCMeta):
                 )
             if len(has_region_components) == 0:
                 logger.warning("No region component found in components.")
-                return ""
+                return None
             return has_region_components[0][0]
 
     def _add_components(self, components: Dict[str, Any]) -> None:
@@ -307,8 +307,8 @@ class Model(object, metaclass=ABCMeta):
             Model build configuration. The configuration can be parsed from a
             configuration file using :py:meth:`~hydromt.io.readers.configread`.
             This is a list of nested dictionary where the first-level keys are the names
-            of a component followed by the name of the method to run seperated by a dot.
-            anny subsequent pairs will be passed to the method as arguments.
+            of a component followed by the name of the method to run separated by a dot.
+            any subsequent pairs will be passed to the method as arguments.
 
             .. code-block:: text
 
@@ -339,7 +339,7 @@ class Model(object, metaclass=ABCMeta):
             self.root.set(model_out, mode=mode)
 
         # check if model has a region
-        if self.region is None:
+        if self._region_component_name is not None and self.region is None:
             raise ValueError("Model region not found, setup model using `build` first.")
 
         # loop over methods from config file

--- a/tests/data/build_config.yml
+++ b/tests/data/build_config.yml
@@ -1,0 +1,13 @@
+global:
+  components:
+    config:
+      type: ConfigComponent
+      filename: run_config.toml
+steps:
+  - config.update:
+      data:
+        starttime: 2010-01-01
+        model.type: model
+  - write:
+      components:
+        - config

--- a/tests/data/update_config.yml
+++ b/tests/data/update_config.yml
@@ -1,0 +1,13 @@
+global:
+  components:
+    config:
+      type: ConfigComponent
+      filename: run_config.toml
+steps:
+  - config.update:
+      data:
+        starttime: 2020-01-01
+        endtime: 2020-12-31
+  - write:
+      components:
+        - config


### PR DESCRIPTION
## Issue addressed

Fixes #1242 

## Explanation

Because the config needs to have "steps" as a list, the update CLI command was broken.
I also fixed the tests. Some of them should have been broken already before but were not designed well enough to catch errors.

While fixing these, I also realised the --opt and -c options in the build/update CLI were broken also because they were not converted to the "steps" list. As we removed the way more used --region argument, I decided to stop support and just make the config file mandatory. I still like that you can supply it with a -i or --config option rather than having to follow a precise order so I prefered to add an ValueError message when parsing. 

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
