### PR TITLE
crs from geodataframe has priority over catalog crs

### DIFF
--- a/hydromt/data_catalog/drivers/geodataframe/pyogrio_driver.py
+++ b/hydromt/data_catalog/drivers/geodataframe/pyogrio_driver.py
@@ -66,9 +66,18 @@ class PyogrioDriver(GeoDataFrameDriver):
         if metadata is not None:
             crs = metadata.crs
         if crs is not None:
-            if gdf.crs is not None:
-                logger.warning(f"Overwriting crs of GeoDataFrame to {crs}")
-            gdf.set_crs(crs)
+            if gdf.crs is None:
+                logger.info(f"Setting crs of GeoDataFrame from catalog crs: {crs}")
+                gdf.set_crs(crs)
+            elif gdf.crs != crs:
+                logger.warning(
+                    f"CRS of GeoDataFrame {gdf.crs} does not match catalog metadata "
+                    f"CRS: {crs}. Keeping the original CRS."
+                )
+        elif gdf.crs is None:
+            raise ValueError(
+                "The GeoDataFrame has no CRS. Set one using the crs option."
+            )
 
         if gdf.index.size == 0:
             exec_nodata_strat(f"No data from driver {self}'.", strategy=handle_nodata)

--- a/hydromt/data_catalog/drivers/geodataframe/pyogrio_driver.py
+++ b/hydromt/data_catalog/drivers/geodataframe/pyogrio_driver.py
@@ -19,7 +19,11 @@ logger: Logger = getLogger(__name__)
 
 
 class PyogrioDriver(GeoDataFrameDriver):
-    """Driver to read GeoDataFrames using the `pyogrio` package."""
+    """
+    Driver to read GeoDataFrames using the `pyogrio` package.
+
+    Options in this driver are passed to `pyogrio.read_dataframe`.
+    """
 
     name = "pyogrio"
     supports_writing = True
@@ -40,8 +44,9 @@ class PyogrioDriver(GeoDataFrameDriver):
 
         Warning
         -------
-        The 'predicate' keyword argument is unused in this method and is only present
-        in the method's signature for compatibility with other functions.
+        The 'predicate' and 'metadata' keyword arguments are unused in this method and
+        are only present in the method's signature for compatibility with other
+        functions.
         """
         if len(uris) > 1:
             raise ValueError(
@@ -61,23 +66,6 @@ class PyogrioDriver(GeoDataFrameDriver):
             )
         if not isinstance(gdf, gpd.GeoDataFrame):
             raise IOError(f"DataFrame from uri: '{_uri}' contains no geometry column.")
-
-        crs = None
-        if metadata is not None:
-            crs = metadata.crs
-        if crs is not None:
-            if gdf.crs is None:
-                logger.info(f"Setting crs of GeoDataFrame from catalog crs: {crs}")
-                gdf.set_crs(crs)
-            elif gdf.crs != crs:
-                logger.warning(
-                    f"CRS of GeoDataFrame {gdf.crs} does not match catalog metadata "
-                    f"CRS: {crs}. Keeping the original CRS."
-                )
-        elif gdf.crs is None:
-            raise ValueError(
-                "The GeoDataFrame has no CRS. Set one using the crs option."
-            )
 
         if gdf.index.size == 0:
             exec_nodata_strat(f"No data from driver {self}'.", strategy=handle_nodata)


### PR DESCRIPTION
## Issue addressed

Fixes #1238 

## Explanation

Data catalog crs should only be used if not defined within the file attributes itself.
While checking other drivers, crs conversion is actually (properly) done in self.transform so in the data adapters rather than in the drivers. There the behavior is as expected.
So I removed this incorrect part form geodataframe driver.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
