### PR TITLE
Harmonize write functions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,7 @@
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
+            "justMyCode": false,
             "purpose": [
                 "debug-test"
             ]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ Unreleased
 New
 ---
 - Added option for delayed compute in writing netcdf files
-- Set compression in `_write_nc`
+- Set compression in `write_nc`
 - Allow masking in `GridComponent.set`. (#1229)
 
 Fixed

--- a/hydromt/_io/__init__.py
+++ b/hydromt/_io/__init__.py
@@ -16,17 +16,17 @@ from .readers import (
     _read_yaml,
 )
 from .writers import (
-    _netcdf_writer,
-    _write_nc,
-    _write_toml,
-    _write_xy,
-    _write_yaml,
-    _zarr_writer,
+    netcdf_writer,
+    write_nc,
+    write_toml,
+    write_xy,
+    write_yaml,
+    zarr_writer,
 )
 
 __all__ = [
     "_config_read",
-    "_netcdf_writer",
+    "netcdf_writer",
     "_open_geodataset",
     "_open_mfcsv",
     "_open_raster",
@@ -39,9 +39,9 @@ __all__ = [
     "_read_ncs",
     "_read_toml",
     "_read_yaml",
-    "_write_nc",
-    "_write_toml",
-    "_write_xy",
-    "_write_yaml",
-    "_zarr_writer",
+    "write_nc",
+    "write_toml",
+    "write_xy",
+    "write_yaml",
+    "zarr_writer",
 ]

--- a/hydromt/_io/writers.py
+++ b/hydromt/_io/writers.py
@@ -32,7 +32,7 @@ def _write_toml(path: StrPath, data: Dict[str, Any]):
         dump_toml(data, f)
 
 
-def _write_xy(path, gdf, fmt="%.4f"):
+def write_xy(path, gdf, fmt="%.4f"):
     """Write geopandas.GeoDataFrame with Point geometries to point xy files.
 
     Parameters
@@ -51,7 +51,7 @@ def _write_xy(path, gdf, fmt="%.4f"):
         np.savetxt(f, xy, fmt=fmt)
 
 
-def _netcdf_writer(
+def netcdf_writer(
     obj: Union[xr.Dataset, xr.DataArray],
     data_root: Union[str, Path],
     data_name: str,
@@ -91,7 +91,7 @@ def _netcdf_writer(
     return write_path
 
 
-def _zarr_writer(
+def zarr_writer(
     obj: Union[xr.Dataset, xr.DataArray],
     data_root: Union[str, Path],
     data_name: str,
@@ -152,7 +152,7 @@ def _compute_nc(
     obj = None
 
 
-def _write_nc(
+def write_nc(
     ds: xr.DataArray | xr.Dataset,
     filepath: Path | str,
     *,

--- a/hydromt/model/components/base.py
+++ b/hydromt/model/components/base.py
@@ -1,5 +1,6 @@
 """Provides the base class for model components."""
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict, cast
 from weakref import ReferenceType, ref
@@ -9,6 +10,8 @@ from hydromt.data_catalog import DataCatalog
 if TYPE_CHECKING:
     from hydromt.model import Model
     from hydromt.model.root import ModelRoot
+
+logger = logging.getLogger(__name__)
 
 
 class ModelComponent(ABC):
@@ -31,6 +34,14 @@ class ModelComponent(ABC):
     def model(self) -> "Model":
         """Return the model object this component is associated with."""
         return cast("Model", self.__model_ref())
+
+    @property
+    def name_in_model(self) -> str:
+        """Find the name of the component in the parent model components."""
+        for name, component in self.model.components.items():
+            if component is self:
+                return name
+        raise ValueError("Component not found in model components.")
 
     @property
     def data_catalog(self) -> DataCatalog:

--- a/hydromt/model/components/config.py
+++ b/hydromt/model/components/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast
 
 from hydromt._io.readers import _read_toml, _read_yaml
-from hydromt._io.writers import _write_toml, _write_yaml
+from hydromt._io.writers import write_toml, write_yaml
 from hydromt._utils.path import _make_config_paths_relative
 from hydromt.model.components.base import ModelComponent
 from hydromt.model.steps import hydromt_step
@@ -94,9 +94,9 @@ class ConfigComponent(ModelComponent):
             write_data = _make_config_paths_relative(self.data, self.root.path)
             ext = splitext(p)[-1]
             if ext in _YAML_EXTS:
-                _write_yaml(write_path, write_data)
+                write_yaml(write_path, write_data)
             elif ext == _TOML_EXT:
-                _write_toml(write_path, write_data)
+                write_toml(write_path, write_data)
             else:
                 raise ValueError(f"Unknown file extension: {ext}")
 

--- a/hydromt/model/components/datasets.py
+++ b/hydromt/model/components/datasets.py
@@ -10,7 +10,7 @@ from pandas import DataFrame
 from xarray import DataArray, Dataset
 
 from hydromt._io.readers import _read_ncs
-from hydromt._io.writers import _write_nc
+from hydromt._io.writers import write_nc
 from hydromt._typing.type_def import DeferedFileClose, XArrayDict
 from hydromt.model.components.base import ModelComponent
 from hydromt.model.steps import hydromt_step
@@ -194,7 +194,7 @@ class DatasetsComponent(ModelComponent):
         filename = filename or self._filename
         for name, ds in self.data.items():
             filepath = Path(self.root.path, filename.format(name=name))
-            _write_nc(
+            write_nc(
                 ds,
                 filepath=filepath,
                 gdal_compliant=gdal_compliant,

--- a/hydromt/model/components/geoms.py
+++ b/hydromt/model/components/geoms.py
@@ -1,10 +1,7 @@
 """Geoms component."""
 
-import os
 from glob import glob
 from logging import Logger, getLogger
-from os.path import dirname, isdir, join
-from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union, cast
 
 import geopandas as gpd
@@ -170,6 +167,7 @@ class GeomsComponent(SpatialModelComponent):
             filename relative to model root. should contain a {name} placeholder
             which will be used to determine the names/keys of the geometries.
             if None, the path that was provided at init will be used.
+            Can be a relative path.
         to_wgs84: bool, optional
             If True, the geoms will be reprojected to WGS84(EPSG:4326) before they are written.
         **kwargs:
@@ -179,32 +177,29 @@ class GeomsComponent(SpatialModelComponent):
         self.root._assert_write_mode()
 
         if len(self.data) == 0:
-            logger.debug("No geoms data found, skip writing.")
+            logger.info(
+                f"{self.model.name}.{self.name_in_model}: No geoms data found, skip writing."
+            )
             return
+
+        filename = filename or self._filename
 
         for name, gdf in self.data.items():
             if len(gdf) == 0:
-                logger.warning(f"{name} is empty. Skipping...")
+                logger.warning(
+                    f"{self.model.name}.{self.name_in_model}: {name} is empty. Skipping..."
+                )
                 continue
 
-            geom_filename = filename or self._filename
-
-            write_path = Path(
-                join(
-                    self.root.path,
-                    geom_filename.format(name=name),
-                )
+            write_path = self.root.path / filename.format(name=name)
+            write_path.parent.mkdir(parents=True, exist_ok=True)
+            logger.info(
+                f"{self.model.name}.{self.name_in_model}: Writing geoms to {write_path}."
             )
-
-            logger.debug(f"Writing file {write_path}")
-
-            write_folder = dirname(write_path)
-            if not isdir(write_folder):
-                os.makedirs(write_folder, exist_ok=True)
 
             if to_wgs84 and (
                 kwargs.get("driver") == "GeoJSON"
-                or str(write_path).lower().endswith(".geojson")
+                or write_path.suffix.lower() == ".geojson"
             ):
                 gdf.to_crs(epsg=4326, inplace=True)
 

--- a/hydromt/model/components/grid.py
+++ b/hydromt/model/components/grid.py
@@ -12,7 +12,7 @@ from pyproj import CRS
 from shapely.geometry import box
 
 from hydromt._io.readers import _read_ncs
-from hydromt._io.writers import _write_nc
+from hydromt._io.writers import write_nc
 from hydromt._typing.type_def import DeferedFileClose
 from hydromt.model.components.base import ModelComponent
 from hydromt.model.components.spatial import SpatialModelComponent
@@ -177,7 +177,7 @@ class GridComponent(SpatialModelComponent):
             return None
 
         # write_nc requires dict - use dummy 'grid' key
-        return _write_nc(
+        return write_nc(
             self.data,
             filepath=Path(self.root.path, filename or self._filename),
             gdal_compliant=gdal_compliant,

--- a/hydromt/model/components/grid.py
+++ b/hydromt/model/components/grid.py
@@ -1,7 +1,6 @@
 """Grid Component."""
 
 from logging import Logger, getLogger
-from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union, cast
 
 import geopandas as gpd
@@ -173,13 +172,22 @@ class GridComponent(SpatialModelComponent):
         self.root._assert_write_mode()
 
         if len(self.data) == 0:
-            logger.warning("No grid data found, skip writing.")
-            return None
+            logger.info(
+                f"{self.model.name}.{self.name_in_model}: No grid data found, skip writing."
+            )
+            return
+
+        filename = filename or self._filename
+        full_path = self.root.path / filename
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            f"{self.model.name}.{self.name_in_model}: Writing grid data to {full_path}."
+        )
 
         # write_nc requires dict - use dummy 'grid' key
         return write_nc(
             self.data,
-            filepath=Path(self.root.path, filename or self._filename),
+            file_path=full_path,
             gdal_compliant=gdal_compliant,
             rename_dims=rename_dims,
             force_overwrite=self.root.mode.is_override_mode(),

--- a/hydromt/model/components/spatial.py
+++ b/hydromt/model/components/spatial.py
@@ -8,7 +8,7 @@ import geopandas as gpd
 from geopandas import GeoDataFrame
 from pyproj import CRS
 
-from hydromt._io.writers import _write_region
+from hydromt._io.writers import write_region
 from hydromt._typing.type_def import StrPath
 from hydromt.model.components.base import ModelComponent
 
@@ -119,7 +119,7 @@ class SpatialModelComponent(ModelComponent, ABC):
             logger.warning("No region data available to write.")
             return
 
-        _write_region(
+        write_region(
             self.region,
             filename=filename or self._region_filename,
             to_wgs84=to_wgs84,

--- a/hydromt/model/components/spatialdatasets.py
+++ b/hydromt/model/components/spatialdatasets.py
@@ -11,7 +11,7 @@ from pandas import DataFrame
 from xarray import DataArray, Dataset
 
 from hydromt._io.readers import _read_ncs
-from hydromt._io.writers import _write_nc
+from hydromt._io.writers import write_nc
 from hydromt._typing.type_def import DeferedFileClose, XArrayDict
 from hydromt.model.components.base import ModelComponent
 from hydromt.model.components.spatial import SpatialModelComponent
@@ -216,7 +216,7 @@ class SpatialDatasetsComponent(SpatialModelComponent):
         filename = filename or self._filename
         for name, ds in self.data.items():
             filepath = Path(self.root.path, filename.format(name=name))
-            _write_nc(
+            write_nc(
                 ds,
                 filepath=filepath,
                 gdal_compliant=gdal_compliant,

--- a/hydromt/model/components/spatialdatasets.py
+++ b/hydromt/model/components/spatialdatasets.py
@@ -80,7 +80,7 @@ class SpatialDatasetsComponent(SpatialModelComponent):
     def _initialize(self, skip_read=False) -> None:
         """Initialize geoms."""
         if self._data is None:
-            self._data = dict()
+            self._data = {}
             if self.root.is_reading_mode() and not skip_read:
                 self.read()
 
@@ -170,6 +170,7 @@ class SpatialDatasetsComponent(SpatialModelComponent):
     def write(
         self,
         filename: Optional[str] = None,
+        *,
         gdal_compliant: bool = False,
         rename_dims: bool = False,
         force_sn: bool = False,
@@ -209,16 +210,24 @@ class SpatialDatasetsComponent(SpatialModelComponent):
         self.root._assert_write_mode()
 
         if len(self.data) == 0:
-            logger.debug("No data found, skiping writing.")
+            logger.info(
+                f"{self.model.name}.{self.name_in_model}: No data found, skipping writing."
+            )
             return
 
-        kwargs = {**{"engine": "netcdf4"}, **kwargs}
+        kwargs.setdefault("engine", "netcdf4")
         filename = filename or self._filename
+
         for name, ds in self.data.items():
-            filepath = Path(self.root.path, filename.format(name=name))
+            file_path = self.root.path / filename.format(name=name)
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            logger.info(
+                f"{self.model.name}.{self.name_in_model}: Writing spatial dataset to {file_path}."
+            )
+
             write_nc(
                 ds,
-                filepath=filepath,
+                file_path=file_path,
                 gdal_compliant=gdal_compliant,
                 rename_dims=rename_dims,
                 force_sn=force_sn,

--- a/hydromt/model/components/vector.py
+++ b/hydromt/model/components/vector.py
@@ -15,7 +15,7 @@ from pyproj import CRS
 from shapely.geometry import box
 
 from hydromt._io.readers import _read_ncs
-from hydromt._io.writers import _write_nc
+from hydromt._io.writers import write_nc
 from hydromt.gis.vector import GeoDataset
 from hydromt.model.components.base import ModelComponent
 from hydromt.model.components.spatial import SpatialModelComponent
@@ -332,7 +332,7 @@ class VectorComponent(SpatialModelComponent):
             else:
                 ds = ds.vector.update_geometry(geom_format="wkt", geom_name="ogc_wkt")
             # write_nc requires dict - use dummy key
-            _write_nc(
+            write_nc(
                 ds,
                 filepath=Path(self.root.path, filename),
                 engine="netcdf4",
@@ -355,7 +355,7 @@ class VectorComponent(SpatialModelComponent):
             logger.debug(f"Writing file {full_path}")
             gdf.to_file(full_path)
             # write_nc requires dict - use dummy key
-            _write_nc(
+            write_nc(
                 ds.drop_vars("geometry"),
                 filepath=Path(self.root.path, filename),
                 **kwargs,

--- a/tests/components/test_config_component.py
+++ b/tests/components/test_config_component.py
@@ -6,7 +6,7 @@ from tomli_w import dump as toml_dump
 from yaml import dump as yaml_dump
 
 from hydromt._io.readers import _config_read, _read_yaml
-from hydromt._io.writers import _write_yaml
+from hydromt._io.writers import write_yaml
 from hydromt._utils.path import _make_config_paths_abs, _make_config_paths_relative
 from hydromt.model import Model
 from hydromt.model.components.config import ConfigComponent
@@ -49,7 +49,7 @@ def test_config_create_always_reads(tmpdir):
     filename = "myconfig.yaml"
     config_path = join(tmpdir, filename)
     config_data = {"a": 1, "b": 3.14, "c": None, "d": {"e": {"f": True}}}
-    _write_yaml(config_path, config_data)
+    write_yaml(config_path, config_data)
     # notice the write mode
     model = Model(root=tmpdir, mode="w")
     config_component = ConfigComponent(
@@ -65,7 +65,7 @@ def test_config_does_not_read_at_lazy_init(tmpdir):
     filename = "myconfig.yaml"
     config_path = join(tmpdir, filename)
     config_data = {"a": 1, "b": 3.14, "c": None, "d": {"e": {"f": True}}}
-    _write_yaml(config_path, config_data)
+    write_yaml(config_path, config_data)
     # notice the write mode
     model = Model(root=tmpdir, mode="w")
     config_component = ConfigComponent(

--- a/tests/components/test_grid_component.py
+++ b/tests/components/test_grid_component.py
@@ -57,11 +57,13 @@ def test_write(
     mock_model, tmpdir, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
 ):
     grid_component = GridComponent(model=mock_model)
+    mock_model.components["grid"] = grid_component
+    mock_model.name = "foo"
     grid_component.root.is_reading_mode.return_value = False
     # Test skipping writing when no grid data has been set
-    caplog.set_level(logging.WARNING)
-    grid_component.write()
-    assert "No grid data found, skip writing" in caplog.text
+    with caplog.at_level(logging.INFO):
+        grid_component.write()
+    assert "foo.grid: No grid data found, skip writing" in caplog.text
     # Test raise IOerror when model is in read only mode
     mock_model.root = ModelRoot(tmpdir, mode="r")
     grid_component = GridComponent(model=mock_model)

--- a/tests/components/test_vector_component.py
+++ b/tests/components/test_vector_component.py
@@ -23,7 +23,10 @@ def test_write_empty_data(
     model = mocker.Mock(set=Model)
     model.root = mocker.Mock(set=ModelRoot)
     model.root.path = tmpdir
+    model.name = "foo"
     vector = VectorComponent(model)
+    model.components = {}
+    model.components["vector"] = vector
     with caplog.at_level(DEBUG):
         vector.write()
-    assert "No vector data found, skip writing." in caplog.text
+    assert "foo.vector: No vector data found, skip writing." in caplog.text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -620,6 +620,7 @@ def artifact_data():
 @pytest.fixture
 def mock_model(tmpdir, mocker: MockerFixture):
     model = mocker.create_autospec(Model)
+    model.components = {}
     model.root = mocker.create_autospec(ModelRoot(tmpdir), instance=True)
     model.root.path.return_value = tmpdir
     model.data_catalog = mocker.create_autospec(DataCatalog)

--- a/tests/data_catalog/test_data_catalog.py
+++ b/tests/data_catalog/test_data_catalog.py
@@ -25,7 +25,7 @@ from shapely import box
 from yaml import dump
 
 from hydromt._compat import HAS_GCSFS, HAS_GDAL, HAS_OPENPYXL, HAS_S3FS
-from hydromt._io.writers import _write_xy
+from hydromt._io.writers import write_xy
 from hydromt._typing import Bbox, TimeRange
 from hydromt._typing.error import NoDataException, NoDataStrategy
 from hydromt.config import Settings
@@ -1139,7 +1139,7 @@ class TestGetGeoDataset:
     @pytest.fixture
     def xy_dataset(self, geodf: gpd.GeoDataFrame, tmp_dir: Path) -> str:
         uri_csv_locs = str(tmp_dir / "test_locs.xy")
-        _write_xy(uri_csv_locs, geodf)
+        write_xy(uri_csv_locs, geodf)
         return uri_csv_locs
 
     @pytest.fixture

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -21,7 +21,7 @@ from hydromt._io.readers import (
     _open_vector,
     _open_vector_from_table,
 )
-from hydromt._io.writers import _write_xy
+from hydromt._io.writers import write_xy
 
 
 def test_open_vector(tmpdir, df, geodf, world):
@@ -37,7 +37,7 @@ def test_open_vector(tmpdir, df, geodf, world):
     if _compat.HAS_OPENPYXL:
         df.to_excel(xls_path)
     geodf.to_file(geojson_path, driver="GeoJSON")
-    _write_xy(xy_path, geodf)
+    write_xy(xy_path, geodf)
     geodf.to_file(shp_path)
     geodf.to_file(gpkg_path, driver="GPKG")
     # read csv


### PR DESCRIPTION
## Issue addressed

Fixes #1239

## Explanation

Last part of #1239 that harmonizes the write function's logging capabilities. All components are now sending info to the logger.

Also ensured to use pathlib more than os to do the file path manipulations.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
