### PR TITLE
update driver names to match what should be in the yml

### DIFF
--- a/docs/guides/advanced_user/data_types.rst
+++ b/docs/guides/advanced_user/data_types.rst
@@ -53,13 +53,13 @@ Raster data (RasterDataset)
    * - Driver
      - File formats
      - Comments
-   * - :py:class:`raster <raster.rasterio_driver.RasterioDriver>`
+   * - :py:class:`rasterio <raster.rasterio_driver.RasterioDriver>`
      - GeoTIFF, ArcASCII, VRT, etc. (see `GDAL formats <http://www.gdal.org/formats_list.html>`_)
      - Based on :py:func:`xarray.open_rasterio`
        and :py:func:`rasterio.open`
-   * - :py:class:`raster <raster.rasterio_driver.RasterioDriver>` with the
+   * - :py:class:`rasterio <raster.rasterio_driver.RasterioDriver>` with the
        :py:class:`raster_tindex <hydromt.data_catalog.uri_resolvers.raster_tindex_resolver.RasterTindexResolver>` resolver
-     - raster tile index file (see `gdaltindex <https://gdal.org/programs/gdaltindex.html>`_)
+     - rasterio tile index file (see `gdaltindex <https://gdal.org/programs/gdaltindex.html>`_)
      - Options to merge tiles via `options -> mosaic_kwargs`.
    * - :py:class:`raster_xarray <raster.raster_xarray_driver.RasterDatasetXarrayDriver>`
      - NetCDF and Zarr
@@ -490,7 +490,7 @@ dimension.
    * - Driver
      - File formats
      - Comments
-   * - :py:class:`csv <dataframe.pandas_driver.PandasDriver>`
+   * - :py:class:`pandas <dataframe.pandas_driver.PandasDriver>`
      - any file readable by pandas
      - Provide a sheet name or formatting through options
 


### PR DESCRIPTION
## Issue addressed

Fixes #1294

## Explanation

The driver name mentioned in the docs was `raster`, but that doesnt exist. So I renamed it to `rasterio`.
Similar things for `csv` -> `pandas`


## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
