### PR TITLE
Move logging of first line outside of initialize_logging

### DIFF
--- a/hydromt/_utils/log.py
+++ b/hydromt/_utils/log.py
@@ -33,7 +33,6 @@ def initialize_logging() -> None:
         console.setLevel(logging.INFO)
         console.setFormatter(_DEFAULT_FORMATTER)
         _ROOT_LOGGER.addHandler(console)
-    _ROOT_LOGGER.info(f"HydroMT version: {__version__}")
 
 
 def set_log_level(log_level: int) -> None:
@@ -89,6 +88,10 @@ def _add_filehandler(
     else:
         logger.debug(f"Writing log messages to new file {path}.")
     return filehandler
+
+
+def log_version() -> None:
+    _ROOT_LOGGER.info(f"HydroMT version: {__version__}")
 
 
 @contextmanager

--- a/hydromt/cli/main.py
+++ b/hydromt/cli/main.py
@@ -237,6 +237,7 @@ def build(
     """  # noqa: E501
     log_level = max(10, 30 - 10 * (verbose - quiet))
     log.set_log_level(log_level=log_level)
+    log.log_version()
     # Model.build will manage the filehandlers and logging
 
     modeltype, kwargs, steps = read_workflow_yaml(config, modeltype=model)
@@ -318,6 +319,7 @@ def update(
     # logger
     log_level = max(10, 30 - 10 * (verbose - quiet))
     log.set_log_level(log_level=log_level)
+    log.log_version()
     # Model.update will manage the filehandlers and logging
 
     mode = "r+" if model_root == model_out else "r"
@@ -450,6 +452,7 @@ def check(
     log_path = Path.cwd() / "hydromt_check.log"
     log.set_log_level(log_level=log_level)
     with log.to_file(log_path):
+        log.log_version()
         results = []
         for cat_path in data:
             results.append(_validate_catalog(Path(cat_path), format, upgrade))
@@ -526,6 +529,7 @@ def export(
     log.set_log_level(log_level=log_level)
     log_path = Path(export_dest_path, "hydromt_export.log")
     with log.to_file(log_path):
+        log.log_version()
         if error_on_empty:
             handle_nodata = NoDataStrategy.RAISE
         else:

--- a/hydromt/model/model.py
+++ b/hydromt/model/model.py
@@ -299,6 +299,7 @@ class Model(object, metaclass=ABCMeta):
 
         """
         with log.to_file(Path(self.root.path) / "hydromt.log"):
+            log.log_version()
             steps = steps or []
             _validate_steps(self, steps)
 
@@ -379,9 +380,9 @@ class Model(object, metaclass=ABCMeta):
         """
         # read current model & optionally clear log file
         with log.to_file(
-            self.root.path / "hydromt.log",
-            append=self.root.is_reading_mode(),
+            self.root.path / "hydromt.log", append=self.root.is_reading_mode()
         ):
+            log.log_version()
             steps = steps or []
             _validate_steps(self, steps)
             if not self.root.is_writing_mode():
@@ -403,6 +404,7 @@ class Model(object, metaclass=ABCMeta):
 
         # No need to clear the log file here since we did that already if needed above
         with log.to_file(self.root.path / "hydromt.log", append=True):
+            log.log_version()
             # check if model has a region
             if self._region_component_name is not None and self.region is None:
                 raise ValueError(


### PR DESCRIPTION
Otherwise you would already get logging on import, breaking --version

Example:

If you have hydromt_wflow and you import hydromt_wflow, you would already get a line on the terminal, while we don't want that, because we are parsing the terminal output for the version of hydromt_wflow only.

## Explanation

Likely fixes docs building

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
