### PR TITLE
improve driver logging

### DIFF
--- a/hydromt/_utils/unused_kwargs.py
+++ b/hydromt/_utils/unused_kwargs.py
@@ -12,6 +12,6 @@ def _warn_on_unused_kwargs(obj_name: str, name_value_dict: Dict[str, Any]):
     """Warn on unused kwargs."""
     for name, value in name_value_dict.items():
         if value is not None:
-            logger.warning(
+            logger.debug(
                 f"object: {obj_name} does not use kwarg {name} with value {value}."
             )


### PR DESCRIPTION
## Issue addressed

None opened

## Explanation

The driver _warn_on_unused_kwargs function is way too ugly for users especially since the unused kwargs is expected behavior and not warning. Users won't understand what is happening from these messages and they should actually not worry.

For now I put it from warn to debug but I think the message has no purpose and could be deleted altogether.

Before:

```
2025-11-11 11:05:37,306 - hydromt.model.model - model - INFO - build: setup_temp_pet_forcing
2025-11-11 11:05:37,307 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.pet_method=debruin
2025-11-11 11:05:37,307 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.press_correction=True
2025-11-11 11:05:37,307 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.temp_correction=True
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.wind_correction=True
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.wind_altitude=10
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.reproj_method=nearest_index
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.fillna_method=None
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.dem_forcing_fn=era5_orography
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.skip_pet=False
2025-11-11 11:05:37,309 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.chunksize=None
2025-11-11 11:05:37,309 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.temp_pet_fn=era5
2025-11-11 11:05:37,315 - hydromt.data_catalog.sources.data_source - data_source - INFO - Reading era5 RasterDataset data from C:\Users\boisgont\.hydromt\artifact_data\latest\era5.nc
2025-11-11 11:05:37,321 - hydromt._utils.unused_kwargs - unused_kwargs - WARNING - object: RasterDatasetXarrayDriver does not use kwarg mask with value                                             geometry
0  POLYGON ((12.83667 45.50667, 12.83667 46.69, 1....
2025-11-11 11:05:37,322 - hydromt._utils.unused_kwargs - unused_kwargs - WARNING - object: RasterDatasetXarrayDriver does not use kwarg variables with value ['temp', 'press_msl', 'kin', 'kout'].
2025-11-11 11:05:37,322 - hydromt._utils.unused_kwargs - unused_kwargs - WARNING - object: RasterDatasetXarrayDriver does not use kwarg metadata with value crs=<Geographic 2D CRS: EPSG:4326>
Name: WGS 84
Axis Info [ellipsoidal]:
- Lat[north]: Geodetic latitude (degree)
- Lon[east]: Geodetic longitude (degree)
Area of Use:
- name: World.
- bounds: (-180.0, -90.0, 180.0, 90.0)
Datum: World Geodetic System 1984 ensemble
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich
 unit=None extent={} nodata=None attrs={} category='meteo' history='Extracted from Copernicus Climate Data Store; resampled by Deltares to daily frequency' paper_doi='10.1002/qj.3803' paper_ref='Hersbach et al. (2019)' url='https://doi.org/10.24381/cds.bd0915c6' license='https://cds.climate.copernicus.eu/cdsapp/#!/terms/licence-to-use-copernicus-products'.
2025-11-11 11:05:37,457 - hydromt.data_catalog.sources.data_source - data_source - INFO - Reading era5_orography RasterDataset data from C:\Users\boisgont\.hydromt\artifact_data\latest\era5_orography.nc
2025-11-11 11:05:37,463 - hydromt._utils.unused_kwargs - unused_kwargs - WARNING - object: RasterDatasetXarrayDriver does not use kwarg mask with value                                             geometry
0  POLYGON ((11.625 46.875, 11.625 45.375, 13.125....
2025-11-11 11:05:37,463 - hydromt._utils.unused_kwargs - unused_kwargs - WARNING - object: RasterDatasetXarrayDriver does not use kwarg variables with value ['elevtn'].
2025-11-11 11:05:37,464 - hydromt._utils.unused_kwargs - unused_kwargs - WARNING - object: RasterDatasetXarrayDriver does not use kwarg metadata with value crs=<Geographic 2D CRS: EPSG:4326>
Name: WGS 84
Axis Info [ellipsoidal]:
- Lat[north]: Geodetic latitude (degree)
- Lon[east]: Geodetic longitude (degree)
Area of Use:
- name: World.
- bounds: (-180.0, -90.0, 180.0, 90.0)
Datum: World Geodetic System 1984 ensemble
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich
 unit=None extent={} nodata=None attrs={} category='meteo' history='Extracted from Copernicus Climate Data Store' paper_doi='10.1002/qj.3803' paper_ref='Hersbach et al. (2019)' url='https://doi.org/10.24381/cds.bd0915c6' license='https://cds.climate.copernicus.eu/cdsapp/#!/terms/licence-to-use-copernicus-products'.
2025-11-11 11:05:38,177 - hydromt.model.model - model - INFO - build: setup_constant_pars
```
 After:

```
2025-11-11 11:05:37,306 - hydromt.model.model - model - INFO - build: setup_temp_pet_forcing
2025-11-11 11:05:37,307 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.pet_method=debruin
2025-11-11 11:05:37,307 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.press_correction=True
2025-11-11 11:05:37,307 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.temp_correction=True
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.wind_correction=True
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.wind_altitude=10
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.reproj_method=nearest_index
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.fillna_method=None
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.dem_forcing_fn=era5_orography
2025-11-11 11:05:37,308 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.skip_pet=False
2025-11-11 11:05:37,309 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.chunksize=None
2025-11-11 11:05:37,309 - hydromt.model.model - model - INFO - setup_temp_pet_forcing.temp_pet_fn=era5
2025-11-11 11:05:37,315 - hydromt.data_catalog.sources.data_source - data_source - INFO - Reading era5 RasterDataset data from C:\Users\boisgont\.hydromt\artifact_data\latest\era5.nc
2025-11-11 11:05:37,457 - hydromt.data_catalog.sources.data_source - data_source - INFO - Reading era5_orography RasterDataset data from C:\Users\boisgont\.hydromt\artifact_data\latest\era5_orography.nc
2025-11-11 11:05:38,177 - hydromt.model.model - model - INFO - build: setup_constant_pars
```


## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
