### PR TITLE
Trigger docs on all recursive files, not just in the folder itself

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,21 +5,19 @@ on:
   push:
     branches: [main]
     paths:
-      - tests/*
-      - hydromt/*
-      - data/*
-      - docs/*
-      - examples/*
+      - hydromt/**
+      - data/**
+      - docs/**
+      - examples/**
       - pyproject.toml
       - .github/workflows/docs.yml
   pull_request:
     branches: [main]
     paths:
-      - tests/*
-      - hydromt/*
-      - data/*
-      - docs/*
-      - examples/*
+      - hydromt/**
+      - data/**
+      - docs/**
+      - examples/**
       - pyproject.toml
       - .github/workflows/docs.yml
 


### PR DESCRIPTION
The docs were not trigger when changing files that were in deeper layers of the file structure.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
