### PR TITLE
fix attrs property of catalog in validator and conversion

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,6 +56,7 @@ Fixed
 - Passing options to ``geodataframe_table`` driver now works. (#1271)
 - Relative path in the workflow yaml were not correctly resolved. (#1304)
 - Fix pydantic for V1 catalog for nodata and fix the catalog upgrade to convert nodata and extra metadata arguments. (#1304)
+- Fix pydantic for V1 catalog for attrs and fix the catalog upgrade to convert attrs arguments.
 - Do not pass metadata "extent" from catalog in xarray objects to avoid issues when writting to netcdf. (#1304)
 - Build and update functions call `ModelComponent.cleanup` and `ModelComponent.finish_write`. Stabilizing the write functionality and making sure that netCDF files can be overwritten when the source and destination are the same. (#778)
 - `hydromt check` has been updated to validate v1 data catalogs (#1265)

--- a/hydromt/_validators/data_catalog_v0x.py
+++ b/hydromt/_validators/data_catalog_v0x.py
@@ -190,6 +190,7 @@ class DataCatalogV0Item(BaseModel):
     meta: DataCatalogV0ItemMetadata | None = None
     unit_add: dict[str, Number] | None = None
     unit_mult: dict[str, Number] | None = None
+    attrs: dict[str, Any] | None = None
     variants: list[SourceVariant] | None = None
     version: str | Number | None = None
 

--- a/hydromt/_validators/data_catalog_v1x.py
+++ b/hydromt/_validators/data_catalog_v1x.py
@@ -164,6 +164,7 @@ class DataCatalogV1ItemMetadata(BaseModel):
 
     crs: str | int | None = None
     nodata: Number | dict[str, Number] | None = None
+    attrs: Dict[str, Any] | None = None
     category: str | None = None
     paper_doi: str | None = None
     paper_ref: str | None = None
@@ -195,13 +196,20 @@ class DataCatalogV1ItemMetadata(BaseModel):
         v0_metadata: DataCatalogV0ItemMetadata | None,
         crs: str | int | None = None,
         nodata: Number | dict[str, Number] | None = None,
+        attrs: Dict[str, Any] | None = None,
     ):
-        if (v0_metadata is None or v0_metadata.is_empty()) and not crs and not nodata:
+        if (
+            (v0_metadata is None or v0_metadata.is_empty())
+            and not crs
+            and not nodata
+            and not attrs
+        ):
             return None
         elif v0_metadata:
             return DataCatalogV1ItemMetadata(
                 crs=crs,
                 nodata=nodata,
+                attrs=attrs,
                 category=v0_metadata.category,
                 paper_doi=v0_metadata.paper_doi,
                 paper_ref=v0_metadata.paper_ref,
@@ -214,7 +222,7 @@ class DataCatalogV1ItemMetadata(BaseModel):
                 **v0_metadata.model_extra,
             )
         else:
-            return DataCatalogV1ItemMetadata(crs=crs, nodata=nodata)
+            return DataCatalogV1ItemMetadata(crs=crs, nodata=nodata, attrs=attrs)
 
     @staticmethod
     def from_dict(input_dict):
@@ -280,7 +288,10 @@ class DataCatalogV1Item(BaseModel):
             driver = None
 
         metadata = DataCatalogV1ItemMetadata.from_v0(
-            v0_metadata=v0_item.meta, crs=v0_item.crs, nodata=v0_item.nodata
+            v0_metadata=v0_item.meta,
+            crs=v0_item.crs,
+            nodata=v0_item.nodata,
+            attrs=v0_item.attrs,
         )
 
         adapter_dict = {}

--- a/tests/data/test_v0_data_catalog.yml
+++ b/tests/data/test_v0_data_catalog.yml
@@ -107,6 +107,9 @@ era5:
     kout: 0.000277778
     precip: 1000
     press_msl: 0.01
+  attrs:
+    precip:
+      unit: mm
 era5_hourly:
   crs: 4326
   data_type: RasterDataset

--- a/tests/data/test_v0_data_catalog_upgraded.yml
+++ b/tests/data/test_v0_data_catalog_upgraded.yml
@@ -107,6 +107,9 @@ era5:
   metadata:
     category: meteo
     crs: 4326
+    attrs:
+      precip:
+        unit: mm
     history: Extracted from Copernicus Climate Data Store; resampled by Deltares to
       daily frequency
     paper_doi: 10.1002/qj.3803


### PR DESCRIPTION
## Issue addressed

No issue opened. Smae as ``nodata``, the ``attrs`` property of the data catalog was not included in the validators and then not in the data catalong conversion.

## Explanation

Add ``attrs`` to validators

## General Checklist

- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [x] Updated documentation
- [x] Updated changelog.rst

## Data/Catalog checklist

- [x] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [x] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
