### PR TITLE
Fix: fill value when 0

### DIFF
--- a/hydromt/gis/raster_utils.py
+++ b/hydromt/gis/raster_utils.py
@@ -99,7 +99,9 @@ def full(
             shape = cs.shape
             if hasattr(cs, "dims"):
                 dims = cs.dims
-    data = f(shape, (fill_value or nodata), dtype=dtype)
+    if fill_value is None:
+        fill_value = nodata
+    data = f(shape, fill_value, dtype=dtype)
     da = xr.DataArray(data, coords, dims, name, attrs)
     da.raster.set_nodata(nodata)
     da.raster.set_crs(crs)


### PR DESCRIPTION
## Issue addressed
Fixes minor issue

## Explanation

When setting the fill value to zeros in `full` from `hydromt.gis.raster_utils`, it got ignored as '0' is `False`.
Added a separate check for `None` instead of relying on the `or` statement.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
