### PR TITLE
add workflow to create prerelease

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -2,10 +2,6 @@ name: Pre-release
 description: Create a pre-release from any branch, publish it to pypi and GitHub to allow for easier testing.
 
 on:
-  # TODO: remove push trigger before merging to main
-  push:
-    branches:
-      - feat/add-prerelease-workflow
   workflow_dispatch:
     inputs:
       description:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,6 +8,24 @@ on:
         description: "Description for this pre-release"
         required: true
         type: string
+      base_version:
+        description: "Base version (e.g. 1.2.0). Defaults to current version in source."
+        required: false
+        type: string
+      identifier:
+        description: "Pre-release identifier. One of: rc, alpha, beta, or timestamp."
+        required: false
+        type: choice
+        options:
+          - timestamp
+          - rc
+          - alpha
+          - beta
+        default: timestamp
+      build_nr:
+        description: "Build number (e.g. 1, 2). Defaults to lowest non-existing tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -22,7 +40,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.12"
 
       - name: Install build tools
         run: pip install flit twine
@@ -30,10 +48,40 @@ jobs:
       - name: Compute pre-release version
         id: version
         run: |
-          BASE_VERSION=$(grep "__version__" hydromt/__init__.py \
-            | cut -d= -f 2 | tr -d "\" " | sed 's/\.dev0$//')
-          TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
-          PRE_VERSION="${BASE_VERSION}.dev${TIMESTAMP}"
+          SOURCE_VERSION=$(grep "__version__" hydromt/__init__.py \
+            | cut -d= -f 2 | tr -d '" ' | sed 's/\.dev0$//')
+
+          BASE="${{ inputs.base_version }}"
+          if [ -z "$BASE" ]; then
+            BASE="$SOURCE_VERSION"
+          fi
+
+          IDENTIFIER="${{ inputs.identifier }}"
+
+          if [ "$IDENTIFIER" = "timestamp" ]; then
+            TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
+            PRE_VERSION="${BASE}.dev${TIMESTAMP}"
+          else
+            case "$IDENTIFIER" in
+              rc)    RELEASE_KIND="rc"    ;;
+              alpha) RELEASE_KIND="a"     ;;
+              beta)  RELEASE_KIND="b"     ;;
+            esac
+
+            BUILD_NR="${{ inputs.build_nr }}"
+            if [ -z "$BUILD_NR" ]; then
+              # Find the lowest N where the tag doesn't exist
+              N=1
+              git fetch --tags --quiet
+              while git tag --list | grep -qx "v${BASE}.${RELEASE_KIND}${N}"; do
+                N=$((N + 1))
+              done
+              BUILD_NR="$N"
+            fi
+
+            PRE_VERSION="${BASE}.${RELEASE_KIND}${BUILD_NR}"
+          fi
+
           echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "TAG=v${PRE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Pre-release version: $PRE_VERSION"
@@ -70,14 +118,11 @@ jobs:
           DESCRIPTION="${{ inputs.description }}"
           BRANCH="${GITHUB_REF_NAME}"
 
-          # tag the current commit
           git tag "$TAG"
           git push origin "$TAG"
 
-          # build release title
           TITLE="$TAG - $DESCRIPTION"
 
-          # generate a short body
           echo "Pre-release \`$TAG\` built from \`$BRANCH\` ($(git rev-parse --short HEAD))." > notes.md
           echo "" >> notes.md
           echo "> $DESCRIPTION" >> notes.md

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -47,8 +47,11 @@ jobs:
         id: version
         run: |
           SOURCE_VERSION=$(grep "__version__" hydromt/__init__.py \
-            | cut -d= -f 2 | tr -d '" ' \ # remove quote chars
-            | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/') # extract base version, throw away release ident + build nr
+            | cut -d= -f 2 | tr -d '" ' \
+            | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+            # 'cut' removes quote chars
+            # 'sed' extract base version, throw away release ident + build nr
+
           if [ -z "$SOURCE_VERSION" ]; then
             echo "ERROR: Failed to extract base version from hydromt/__init__.py"
             exit 1

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,7 +7,6 @@ on:
       description:
         description: "Description for this pre-release"
         required: true
-        default: "test pre-release"
         type: string
 
 permissions:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -2,11 +2,16 @@ name: Pre-release
 description: Create a pre-release from any branch, publish it to pypi and GitHub to allow for easier testing.
 
 on:
+  # TODO: remove push trigger before merging to main
+  push:
+    branches:
+      - feat/add-prerelease-workflow
   workflow_dispatch:
     inputs:
       description:
         description: "Description for this pre-release"
         required: true
+        default: "test pre-release"
         type: string
 
 permissions:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,15 +13,13 @@ on:
         required: false
         type: string
       identifier:
-        description: "Pre-release identifier. One of: rc, alpha, beta, or timestamp."
+        description: "Pre-release identifier. One of: rc or dev."
         required: false
         type: choice
         options:
-          - timestamp
           - rc
-          - alpha
-          - beta
-        default: timestamp
+          - dev
+        default: dev
       build_nr:
         description: "Build number (e.g. 1, 2). Defaults to lowest non-existing tag."
         required: false
@@ -40,7 +38,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install build tools
         run: pip install flit twine
@@ -49,38 +47,56 @@ jobs:
         id: version
         run: |
           SOURCE_VERSION=$(grep "__version__" hydromt/__init__.py \
-            | cut -d= -f 2 | tr -d '" ' | sed 's/\.dev0$//')
+            | cut -d= -f 2 | tr -d '" ' \ # remove quote chars
+            | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/') # extract base version, throw away release ident + build nr
+          if [ -z "$SOURCE_VERSION" ]; then
+            echo "ERROR: Failed to extract base version from hydromt/__init__.py"
+            exit 1
+          fi
 
           BASE="${{ inputs.base_version }}"
           if [ -z "$BASE" ]; then
             BASE="$SOURCE_VERSION"
           fi
 
-          IDENTIFIER="${{ inputs.identifier }}"
-
-          if [ "$IDENTIFIER" = "timestamp" ]; then
-            TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
-            PRE_VERSION="${BASE}.dev${TIMESTAMP}"
-          else
-            case "$IDENTIFIER" in
-              rc)    RELEASE_KIND="rc"    ;;
-              alpha) RELEASE_KIND="a"     ;;
-              beta)  RELEASE_KIND="b"     ;;
-            esac
-
-            BUILD_NR="${{ inputs.build_nr }}"
-            if [ -z "$BUILD_NR" ]; then
-              # Find the lowest N where the tag doesn't exist
-              N=1
-              git fetch --tags --quiet
-              while git tag --list | grep -qx "v${BASE}.${RELEASE_KIND}${N}"; do
-                N=$((N + 1))
-              done
-              BUILD_NR="$N"
-            fi
-
-            PRE_VERSION="${BASE}.${RELEASE_KIND}${BUILD_NR}"
+          # Validate base version has the form x.y.z
+          if ! [[ "$BASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: base_version must be in format X.Y.Z (e.g. 1.2.0). Got: '$BASE'"
+            exit 1
           fi
+
+          IDENTIFIER="${{ inputs.identifier }}"
+          case "$IDENTIFIER" in
+            rc)    RELEASE_IDENT="rc"    ;;
+            dev)   RELEASE_IDENT=".dev"  ;;
+            *)
+              echo "ERROR: Unsupported identifier '$IDENTIFIER'. Allowed: rc, dev"
+              exit 1
+              ;;
+          esac
+
+          BUILD_NR="${{ inputs.build_nr }}"
+
+          # Determine build nr if not provided
+          if [ -z "$BUILD_NR" ]; then
+            N=1
+            git fetch --tags --quiet
+            while git tag --list "v${BASE}${RELEASE_IDENT}${N}" | grep -q .; do
+              N=$((N + 1))
+            done
+            BUILD_NR="$N"
+          fi
+
+          # Validate build nr
+          if [ -n "$BUILD_NR" ]; then
+            # Validate build number if provided
+            if ! [[ "$BUILD_NR" =~ ^[0-9]+$ ]]; then
+              echo "ERROR: build_nr must be a positive integer. Got: '$BUILD_NR'"
+              exit 1
+            fi
+          fi
+
+          PRE_VERSION="${BASE}${RELEASE_IDENT}${BUILD_NR}"
 
           echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "TAG=v${PRE_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,93 @@
+name: Pre-release
+description: Create a pre-release from any branch, publish it to pypi and GitHub to allow for easier testing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      description:
+        description: "Description for this pre-release"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install build tools
+        run: pip install flit twine
+
+      - name: Compute pre-release version
+        id: version
+        run: |
+          BASE_VERSION=$(grep "__version__" hydromt/__init__.py \
+            | cut -d= -f 2 | tr -d "\" " | sed 's/\.dev0$//')
+          TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
+          PRE_VERSION="${BASE_VERSION}.dev${TIMESTAMP}"
+          echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "TAG=v${PRE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Pre-release version: $PRE_VERSION"
+
+      - name: Set version in source
+        run: |
+          sed -i "s/__version__.*=.*\".*\"/__version__ = \"${{ steps.version.outputs.PRE_VERSION }}\"/" \
+            hydromt/__init__.py
+          grep "__version__" hydromt/__init__.py
+
+      - name: Build artifacts
+        run: |
+          flit build
+          python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: prerelease-artifacts
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          verbose: true
+          skip-existing: true
+
+      - name: Create GitHub pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          DESCRIPTION="${{ inputs.description }}"
+          BRANCH="${GITHUB_REF_NAME}"
+
+          # tag the current commit
+          git tag "$TAG"
+          git push origin "$TAG"
+
+          # build release title
+          TITLE="$TAG - $DESCRIPTION"
+
+          # generate a short body
+          echo "Pre-release \`$TAG\` built from \`$BRANCH\` ($(git rev-parse --short HEAD))." > notes.md
+          echo "" >> notes.md
+          echo "> $DESCRIPTION" >> notes.md
+          echo "" >> notes.md
+          echo "Install with:" >> notes.md
+          echo '```' >> notes.md
+          echo "pip install hydromt==${{ steps.version.outputs.PRE_VERSION }}" >> notes.md
+          echo '```' >> notes.md
+
+          gh release create "$TAG" dist/* \
+            --title "$TITLE" \
+            --notes-file notes.md \
+            --prerelease

--- a/docs/dev/core_dev/release.rst
+++ b/docs/dev/core_dev/release.rst
@@ -1,3 +1,38 @@
+.. _create_pre_release:
+
+Creating a pre-release
+----------------------
+
+A pre-release allows you to publish a timestamped development build from any branch to PyPI and GitHub,
+making it easy to share and test changes before a full release.
+
+1. Go to the `actions` tab on GitHub, select `Pre-release` from the actions list on the left, then use
+   the `Run workflow` button.
+2. You will be prompted to enter a **description** for the pre-release (e.g. ``"Fix broken reader API"``
+   or ``"amazing untested feature"``). This description appears in the GitHub release title and body.
+3. The workflow will automatically compute a version number of the form
+   ``<BASE_VERSION>.dev<TIMESTAMP>`` (for example ``1.2.3.dev20260414153000``), set it in the source,
+   and build the package.
+4. The built artifacts are uploaded to the repository's internal artifact cache and published to PyPI.
+   Anyone can then install the pre-release with::
+
+       pip install hydromt==<PRE_VERSION>
+
+   The exact install command is shown in the body of the GitHub release that is created automatically.
+5. A GitHub pre-release is created and tagged as ``v<PRE_VERSION>``, linked to the commit on the branch
+   you ran the workflow from.
+
+.. note::
+   Pre-releases are built from whatever branch you select when running the workflow — they are not
+   restricted to ``main`` or ``release/*`` branches. This makes them suitable for sharing in-progress
+   work or testing a hotfix branch before it is merged.
+
+.. warning::
+   Pre-release versions are marked as pre-releases on GitHub and are not promoted as the latest
+   stable release. They are intended for testing purposes only. Do not use a pre-release version as
+   the basis for a full release; follow the :ref:`create_release` process instead.
+
+
 .. _create_release:
 
 

--- a/docs/dev/core_dev/release.rst
+++ b/docs/dev/core_dev/release.rst
@@ -23,6 +23,7 @@ A pre-release allows you to publish a development build from any branch to PyPI 
 A release candidate is very similar, but meant as a feature-complete build that is expected to become the final release unless critical issues are found. Unlike general pre-releases, which may include experimental or unstable changes, a release candidate should be considered production-ready and is primarily used for final validation, testing, and stakeholder sign-off.
 
 .. admonition:: When to use either
+
    Use a pre-release when the goal is early feedback.
    Use a release candidate when no new features are expected or planned anymore and you are preparing for an actual release.
 

--- a/docs/dev/core_dev/release.rst
+++ b/docs/dev/core_dev/release.rst
@@ -1,38 +1,3 @@
-.. _create_pre_release:
-
-Creating a pre-release
-----------------------
-
-A pre-release allows you to publish a timestamped development build from any branch to PyPI and GitHub,
-making it easy to share and test changes before a full release.
-
-1. Go to the `actions` tab on GitHub, select `Pre-release` from the actions list on the left, then use
-   the `Run workflow` button.
-2. You will be prompted to enter a **description** for the pre-release (e.g. ``"Fix broken reader API"``
-   or ``"amazing untested feature"``). This description appears in the GitHub release title and body.
-3. The workflow will automatically compute a version number of the form
-   ``<BASE_VERSION>.dev<TIMESTAMP>`` (for example ``1.2.3.dev20260414153000``), set it in the source,
-   and build the package.
-4. The built artifacts are uploaded to the repository's internal artifact cache and published to PyPI.
-   Anyone can then install the pre-release with::
-
-       pip install hydromt==<PRE_VERSION>
-
-   The exact install command is shown in the body of the GitHub release that is created automatically.
-5. A GitHub pre-release is created and tagged as ``v<PRE_VERSION>``, linked to the commit on the branch
-   you ran the workflow from.
-
-.. note::
-   Pre-releases are built from whatever branch you select when running the workflow — they are not
-   restricted to ``main`` or ``release/*`` branches. This makes them suitable for sharing in-progress
-   work or testing a hotfix branch before it is merged.
-
-.. warning::
-   Pre-release versions are marked as pre-releases on GitHub and are not promoted as the latest
-   stable release. They are intended for testing purposes only. Do not use a pre-release version as
-   the basis for a full release; follow the :ref:`create_release` process instead.
-
-
 .. _create_release:
 
 
@@ -47,6 +12,47 @@ Creating a release
 6. The newly published PyPi package will trigger a new PR to the `HydroMT feedstock repos of conda-forge <https://github.com/conda-forge/hydromt-feedstock>`_.
    Here you can use the comment posted to the release PR to see if the `meta.yml` needs to be updated. Merge the PR to release the new version on conda-forge.
 7. celebrate the new release!
+
+
+.. _create_pre_release:
+
+Creating a pre-release / release candidate
+------------------------------------------
+
+A pre-release allows you to publish a development build from any branch to PyPI and GitHub, making it easy to share and test changes before a full release.
+A release candidate is very similar, but meant as a feature-complete build that is expected to become the final release unless critical issues are found. Unlike general pre-releases, which may include experimental or unstable changes, a release candidate should be considered production-ready and is primarily used for final validation, testing, and stakeholder sign-off.
+
+.. admonition:: When to use either
+   Use a pre-release when the goal is early feedback.
+   Use a release candidate when no new features are expected or planned anymore and you are preparing for an actual release.
+
+Luckily, both types of releases can be made with the same workflow: ``pre-release.yml``
+The workflow will automatically compute a version number of the form ``<BASE_VERSION><IDENTIFIER><BUILD_NR>`` ( ``1.2.3.dev1`` or ``1.2.3rc2``), set it in the source, and build the package.
+
+1. Go to the ``actions`` tab on GitHub, select ``Pre-release`` from the actions list on the left, then use the ``Run workflow`` button.
+2. You will be prompted to enter:
+   - **identifier** (``rc`` or ``dev``). Determines the type of release
+   - **description** (``Fix broken reader API`` or ``amazing untested feature``). This description appears in the GitHub release title and body.
+   - **base_version** (``1.2.3`` or ``2.0.0``). Optional base version to use in the release, defaults to what is defined in ``hydromt.__version__``.
+   - **build_nr** (``1``, or ``2``). Optional build nr to use, defaults to the lowest non-existing build nr.
+3. The built artifacts are uploaded to the repository's internal artifact cache and published to PyPI.
+   Anyone can then install the pre-release with::
+
+       pip install hydromt==<PRE_VERSION>
+
+   The exact install command is shown in the body of the GitHub release that is created automatically.
+4. A GitHub pre-release is created and tagged as ``v<PRE_VERSION>``, linked to the commit on the branch
+   you ran the workflow from.
+
+.. note::
+   Pre-releases are built from whatever branch you select when running the workflow - they are not
+   restricted to ``main`` or ``release/*`` branches. This makes them suitable for sharing in-progress
+   work or testing a hotfix branch before it is merged.
+
+.. warning::
+   Pre-release versions are marked as pre-releases on GitHub and are not promoted as the latest
+   stable release. They are intended for testing purposes only. Do not use a pre-release version as
+   the basis for a full release; follow the :ref:`create_release` process instead.
 
 Plugin compatibility test
 -------------------------

--- a/pixi.lock
+++ b/pixi.lock
@@ -11430,7 +11430,7 @@ packages:
 - pypi: ./
   name: hydromt
   version: 1.4.0.dev0
-  sha256: 5111404a5fa790cd2dc68b698ddbdda6b46aaffc3413dce61876f9222256d403
+  sha256: a78a6810b19e8e6a9ac122a80e5293081c6957a0f8868284f473c377e9d8563c
   requires_dist:
   - affine
   - bottleneck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 	"pyarrow",                # Apache Arrow bindings
 	"pydantic~=2.4",          # Validation
 	"pydantic-settings~=2.2", # Settings Management
-	"pyflwdir>=0.5.10",        # Hight models and derivatives
+	"pyflwdir>=0.5.10",       # Height models and derivatives
 	"pyogrio>=0.6",           # io for geopandas dataframes
 	"pyproj",                 # projections for Coordinate reference systems
 	"pystac",                 # STAC integration
@@ -42,7 +42,7 @@ dependencies = [
 	"universal_pathlib>=0.2", # provides path compatability between different filesystems
 	"xarray",                 # ndim data arrays
 	"xmltodict",              # xml parser also used to read VRT
-	"xugrid>=0.15.1",          # xarray wrapper for mesh processing
+	"xugrid>=0.15.1",         # xarray wrapper for mesh processing
 	"zarr>=3.1,<4",           # zarr
 ]
 
@@ -91,7 +91,7 @@ dev = [
 	"types-xmltodict", # type hints for xmltodict
 ]
 test = [
-	"pytest>=9.0.3",      # testing framework
+	"pytest>=9.0.3",  # testing framework
 	"pytest-cov",     # test coverage
 	"pytest-mock",    # mocking
 	"pytest-timeout", # darn hanging tests


### PR DESCRIPTION
## Issue addressed

Fixes #1428

## Explanation

Add a workflow that creates a pre-release from any branch and publishes it to Pypi and GitHub.

Added a push trigger temporarily to run the workflow and created this pre-release: https://github.com/Deltares/hydromt/releases/tag/v1.4.0.dev20260413131052
Using this succesfull workflow: https://github.com/Deltares/hydromt/actions/runs/24345179576/job/71083973853

Removed the push trigger, so we can merge this now.