### PR TITLE
doc: removed all `logger` parameters from docstrings that were outdated.

### DIFF
--- a/hydromt/_utils/dataset.py
+++ b/hydromt/_utils/dataset.py
@@ -34,8 +34,8 @@ def _shift_dataset_time(
         time delta to shift the time of the dataset
     ds : xr.Dataset
         xarray dataset
-    logger : logging.Logger
-        logger
+    time_unit : str, optional
+        time unit for the time shift, by default "s"
 
     Returns
     -------

--- a/hydromt/data_catalog/data_catalog.py
+++ b/hydromt/data_catalog/data_catalog.py
@@ -105,9 +105,6 @@ class DataCatalog(object):
             By default False.
         cache_dir: str, Path, optional
             Directory root path to cache data to, by default ~/.hydromt
-        logger : logger object, optional
-            The logger object used for logging messages. If not provided, the default
-            logger will be used.
         """
         if data_libs is None:
             data_libs = []

--- a/hydromt/gis/flw.py
+++ b/hydromt/gis/flw.py
@@ -52,9 +52,6 @@ def flwdir_from_da(
     mask : xr.DataArray, bool, optional
         Mask for gridded flow direction data, by default None.
         If True, use the mask coordinate of `da`.
-    logger : logger object, optional
-        The logger object used for logging messages. If not provided, the default
-        logger will be used.
 
     Returns
     -------
@@ -223,22 +220,19 @@ def upscale_flwdir(
         Flow direction raster object.
     scale_ratio: int
         Size of upscaled (coarse) grid cells.
+    method : {'com2', 'com', 'eam', 'dmm'}
+        Upscaling method for flow direction data, by default 'com2'.
     uparea_name : str, optional
         Name of upstream area DataArray, by default None and derived on the fly.
     flwdir_name : str, optional
         Name of upscaled flow direction raster DataArray, by default "flwdir"
-    method : {'com2', 'com', 'eam', 'dmm'}
-        Upscaling method for flow direction data, by default 'com2'.
-    logger : logger object, optional
-        The logger object used for logging messages. If not provided, the default
-        logger will be used.
     **kwargs:
         Additional keyword arguments that are passed to the `flwdir.upscale`
         function.
 
     Returns
     -------
-    da_flwdir = xarray.DataArray
+    da_flwdir : xarray.DataArray
         Upscaled D8 flow direction grid.
     flwdir_out : pyflwdir.FlwdirRaster
         Upscaled pyflwdir flow direction raster object.
@@ -338,9 +332,6 @@ def reproject_hydrography_like(
         in `ds_hydro`.
     kwargs: key-word arguments
         key-word arguments are passed to `d8_from_dem`
-    logger : logger object, optional
-        The logger object used for logging messages. If not provided, the default
-        logger will be used.
 
     Returns
     -------
@@ -476,9 +467,6 @@ def gauge_map(
     max_dist: float, optional
         Maximum distance between original and snapped point location.
         A warning is logged if exceeded. By default 10 km.
-    logger : logger object, optional
-        The logger object used for logging messages. If not provided, the default
-        logger will be used.
 
     Returns
     -------
@@ -729,9 +717,6 @@ def dem_adjust(
     river_d8 : bool
         If True and `connectivity==4`, additionally condition river cells to D8.
         Requires `da_rivmsk`.
-    logger : logger object, optional
-        The logger object used for logging messages. If not provided, the default
-        logger will be used.
 
     Returns
     -------

--- a/hydromt/gis/raster.py
+++ b/hydromt/gis/raster.py
@@ -1128,9 +1128,6 @@ class XRasterBase(XGeoBase):
         method : str, optional
             Reclassification method. For now only 'exact' for
             one-on-one cell value mapping.
-        logger:
-            The logger to be used. If no logger is provided the
-            default one will beused.
 
         Returns
         -------
@@ -1882,8 +1879,6 @@ class RasterDataArray(XRasterBase):
             Nodata value for the DataArray.
             If the nodata property and argument are both None, the _FillValue
             attribute will be removed.
-        logger:
-            The logger to use.
         """
         if nodata is None:
             nodata = self._obj.rio.nodata
@@ -2368,9 +2363,6 @@ class RasterDataArray(XRasterBase):
             Additional keyword arguments to pass into writing the raster. The
             nodata, transform, crs, count, width, and height attributes
             are ignored.
-        logger : logger object, optional
-            The logger object used for logging messages. If not provided, the default
-            logger will be used.
 
         """
         for k in ["height", "width", "count", "transform"]:
@@ -2767,7 +2759,7 @@ class RasterDataset(XRasterBase):
             If True, it will write using the windows of the output raster.
             Default is False.
         mask: bool
-            Whether to apply the mask to the tasterisation.
+            Whether to apply the mask to the rasterization.
         prefix : str, optional
             Prefix to filenames in mapstack
         postfix : str, optional
@@ -2776,9 +2768,6 @@ class RasterDataset(XRasterBase):
             Additional keyword arguments to pass into writing the raster. The
             nodata, transform, crs, count, width, and height attributes
             are ignored.
-        logger : logger object, optional
-            The logger object used for logging messages. If not provided, the default
-            logger will be used.
 
         """
         if driver not in GDAL_EXT_CODE_MAP:

--- a/hydromt/model/processes/grid.py
+++ b/hydromt/model/processes/grid.py
@@ -100,8 +100,6 @@ def create_grid_from_region(
         number of decimals to round the origin coordinates, by default 0
     dec_rotation : int, optional
         number of decimals to round the rotation angle, by default 3
-    logger : Logger
-        Logger object, by default a module level logger is used.
 
     Returns
     -------

--- a/hydromt/model/processes/mesh.py
+++ b/hydromt/model/processes/mesh.py
@@ -74,8 +74,6 @@ def create_mesh2d_from_region(
     align : bool, default True
         Align the mesh to the resolution.
         Required for 'bbox' and 'geom' region types.
-    logger : logging.Logger
-        Logger object, a default module logger is used if not specified.
     data_catalog : DataCatalog, optional
         Optional data catalog to use for reading data.
         Required if region is based on 'geom'.
@@ -140,8 +138,6 @@ def create_mesh2d_from_mesh(
         Optional EPSG code of the mesh if cannot be found.
     bounds : tuple, optional
         Bounding box to clip the mesh.
-    logger : logging.Logger
-        Logger object, a default module logger is used if not specified.
 
     Returns
     -------

--- a/hydromt/model/processes/meteo.py
+++ b/hydromt/model/processes/meteo.py
@@ -188,9 +188,7 @@ def temp(
     t_out.attrs.update(unit="degree C.")
     if freq is not None:
         resample_kwargs.update(upsampling="bfill", downsampling="mean")
-        t_out = resample_time(
-            t_out, freq, conserve_mass=False, logger=logger, **resample_kwargs
-        )
+        t_out = resample_time(t_out, freq, conserve_mass=False, **resample_kwargs)
     return t_out
 
 
@@ -247,7 +245,7 @@ def press(
     if freq is not None:
         resample_kwargs.update(upsampling="bfill", downsampling="mean")
         press_out = resample_time(
-            press_out, freq, conserve_mass=False, logger=logger, **resample_kwargs
+            press_out, freq, conserve_mass=False, **resample_kwargs
         )
     return press_out
 

--- a/hydromt/model/processes/rivers.py
+++ b/hydromt/model/processes/rivers.py
@@ -12,7 +12,7 @@ from scipy import ndimage
 
 from hydromt.gis.raster_utils import spread2d
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = ["river_width", "river_depth"]
 

--- a/hydromt/readers.py
+++ b/hydromt/readers.py
@@ -199,9 +199,6 @@ def open_raster(
     **kwargs:
         key-word arguments are passed to :py:meth:`xarray.open_dataset` with
         "rasterio" engine.
-    logger : logger object, optional
-        The logger object used for logging messages. If not provided, the default
-        logger will be used.
 
     Returns
     -------
@@ -489,9 +486,6 @@ def open_geodataset(
         Cannot be used with bbox.
     **kwargs:
         Key-word argument
-    logger : logger object, optional
-        The logger object used for logging messages. If not provided, the default
-        logger will be used.
 
     Returns
     -------


### PR DESCRIPTION
Came across this issue when investigating: https://github.com/Deltares/hydromt/issues/1356

## Issue addressed

Fixes #1432 

update incorrect docs