### PR TITLE
Security: Incorrect prefix removal using `lstrip` can corrupt URIs and bypass parsing assumptions

### DIFF
--- a/hydromt/_utils/uris.py
+++ b/hydromt/_utils/uris.py
@@ -13,7 +13,7 @@ def _strip_scheme(uri: str) -> Tuple[Optional[str], str]:
     except StopIteration:
         # no scheme found
         return (None, uri)
-    return (scheme, uri.lstrip(scheme))
+    return (scheme, uri[len(scheme) :])
 
 
 def _strip_vsi(uri: str) -> Tuple[Optional[str], str]:
@@ -23,7 +23,7 @@ def _strip_vsi(uri: str) -> Tuple[Optional[str], str]:
     except StopIteration:
         # No prefix found
         return None, uri
-    return (prefix, uri.lstrip(prefix))
+    return (prefix, uri[len(prefix) :])
 
 
 def _is_valid_url(uri: str | Path) -> bool:


### PR DESCRIPTION
## Summary

Security: Incorrect prefix removal using `lstrip` can corrupt URIs and bypass parsing assumptions

## Problem

**Severity**: `Medium` | **File**: `hydromt/_utils/uris.py:L15`

`_strip_scheme` and `_strip_vsi` remove prefixes using `str.lstrip(...)`, which strips any leading characters contained in the argument rather than the exact prefix. This can unintentionally remove extra characters from attacker-controlled inputs and lead to incorrect URI normalization/validation behavior.

## Solution

Replace `lstrip(prefix)` with exact slicing: `uri[len(prefix):]` after verifying `uri.startswith(prefix)`. This preserves input semantics and avoids normalization bypasses.

## Changes

- `hydromt/_utils/uris.py` (modified)