### PR TITLE
make pet_debruin able to lazily do operations.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ New
 - Added ``precision`` parameter to ``GeomsComponent.write`` to set the number of decimals used when writing (#1415).
 - More informative error messages when calling ``test_equal`` on ConfigComponent (#1430).
 - Added ``SlippyTileDriver`` for reading XYZ/slippy map tiles stored in ``{zoom}/{x}/{y}.png`` (#1417).
+- Added ``MeshComponent.is_empty`` to check for existing data correctly. (#1437)
 
 Changed
 -------
@@ -27,6 +28,8 @@ Fixed
 - Properly log unhandled errors to ``hydromt.log`` (#1399).
 - ``gis.vector_utils.nearest_merge`` now correctly respects ``max_dist`` filtering and ``overwrite`` flag when merging columns (#1414).
 - Normalize geometries before comparing them in ``test_equal`` for ``SpatialModelComponent``, ``GeomsComponent`` and ``VectorComponent`` (#1415).
+- ``pet_debruin`` now keeps all inputs lazy-loaded instead of reading in the entire array. (#1439)
+- The functions ``_strip_scheme`` and ``_strip_vsi`` in ``hydromt._utils.uris`` no longer use ``lstrip`` to remove leading characters, but now remove only the exact prefix. (#1438)
 
 Deprecated
 ----------

--- a/hydromt/model/processes/meteo.py
+++ b/hydromt/model/processes/meteo.py
@@ -568,22 +568,30 @@ def pet_debruin(
     """
     # saturation and actual vapour pressure at given temperature [hPa °C-1]
     esat = 6.112 * np.exp((17.67 * temp) / (temp + 243.5))
+
     # slope of vapour pressure curve [hPa °C-1]
     slope = esat * (17.269 / (temp + 243.5)) * (1.0 - (temp / (temp + 243.5)))
-    # compute latent heat of vapourization [J kg-1]
-    lam = (2.502 * 10**6) - (2250.0 * temp)
+
+    # latent heat of vapourization [J kg-1]
+    lam = (2.502e6) - (2250.0 * temp)
+
     # psychometric constant [hPa °C-1]
     gamma = (cp * press) / (0.622 * lam)
-    # compute ref. evaporation (with global radiation, therefore calling it potential)
-    # in J m-2 over whole period
-    ep_joule = (
-        (slope / (slope + gamma))
-        * (((1.0 - 0.23) * k_in) - (cs * (k_in / (k_ext + 0.00001))))
-    ) + beta
-    ep_joule = xr.where(np.isclose(k_ext, 0.0), 0.0, ep_joule)
-    pet = ((ep_joule / lam) * timestep).astype(np.float32)
-    pet = xr.where(pet > 0.0, pet, 0.0)
-    return pet
+
+    # define mask in a lazy way to avoid division by zero
+    mask = abs(k_ext) > 1e-8
+
+    # compute ref. evaporation [J m-2]
+    ratio = xr.where(mask, k_in / k_ext, 0.0)
+    ep_joule = (slope / (slope + gamma)) * (((1.0 - 0.23) * k_in) - cs * ratio) + beta
+
+    # apply same mask
+    ep_joule = ep_joule.where(mask, 0.0)
+
+    pet = (ep_joule / lam) * timestep
+    pet = pet.clip(min=0.0)
+
+    return pet.astype(np.float32)
 
 
 def pet_makkink(

--- a/hydromt/model/processes/meteo.py
+++ b/hydromt/model/processes/meteo.py
@@ -581,7 +581,8 @@ def pet_debruin(
     # define mask in a lazy way to avoid division by zero
     mask = abs(k_ext) > 1e-8
 
-    # compute ref. evaporation [J m-2]
+    # compute ref. evaporation [J m-2] (with global radiation, therefore calling it potential)
+    # in J m-2 over whole period
     ratio = xr.where(mask, k_in / k_ext, 0.0)
     ep_joule = (slope / (slope + gamma)) * (((1.0 - 0.23) * k_in) - cs * ratio) + beta
 


### PR DESCRIPTION
## Issue addressed

Fixes #1420 

## Explanation

Update pet_debruin to not use any numpy functions since they are eager and try to load all data. 
New implementation replaces numpy with xarray-native operations.

A boolean mask (abs(k_ext) > 1e-8) is defined once and reused to both avoid division by zero and mask invalid regions. 
All operations (where, arithmetic, clip) are Dask-aware and remain lazy
