### PR TITLE
Fix: make geotransform attr optional

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ New
 
 Changed
 -------
+- GeoTransform attribute is not written by default anymore when calling `RasterDataArray.gdal_compliant`, as this can lead to unexpected behaviour. Use `write_transform` argument to toggle this (#1454).
 - ``log.initialize_logging()`` is no longer called when hydromt is imported. It is now the users responsibility to configure logging at the start of their scripts (#1399).
 
 Fixed

--- a/hydromt/gis/raster.py
+++ b/hydromt/gis/raster.py
@@ -597,7 +597,10 @@ class XRasterBase(XGeoBase):
         )
 
     def gdal_compliant(
-        self, rename_dims=True, force_sn=False
+        self,
+        rename_dims: bool = True,
+        force_sn: bool = False,
+        write_transform: bool = False,
     ) -> Union[xr.DataArray, xr.Dataset]:
         """Update attributes to get GDAL compliant NetCDF files.
 
@@ -608,6 +611,10 @@ class XRasterBase(XGeoBase):
             (x/y for projected and lat/lon for geographic).
         force_sn: bool, optional
             If True, forces the dataset to have South -> North orientation.
+        write_transform : bool, optional
+            Whether or not to write the geotransform as an attribute of the
+            'spatial_ref' information coordinate. Writing this can make life easier for
+            GDAL, but it can also cause conflict. Use with caution. By default False.
 
         Returns
         -------
@@ -638,7 +645,7 @@ class XRasterBase(XGeoBase):
         crs_wkt = crs.to_wkt()
         grid_map_attrs["spatial_ref"] = crs_wkt
         grid_map_attrs["crs_wkt"] = crs_wkt
-        if transform is not None:
+        if transform is not None and write_transform:
             grid_map_attrs["GeoTransform"] = " ".join(
                 [str(item) for item in transform.to_gdal()]
             )

--- a/tests/gis/test_raster.py
+++ b/tests/gis/test_raster.py
@@ -105,7 +105,7 @@ def test_crs():
     assert da.raster.crs.to_epsg() == 9518  # return horizontal crs
 
 
-def test_gdal(tmp_path: Path):
+def test_gdal_compliant(tmp_path: Path):
     da = raster_utils.full_from_transform(*testdata[0], name="test")
     # Add crs
     da.attrs.update(crs=4326)
@@ -129,6 +129,24 @@ def test_gdal(tmp_path: Path):
     with rasterio.open(netcdf_path) as src:
         src.read()
         assert ds2.raster.crs == src.crs
+
+
+def test_gdal_compliant_gtf(tmp_path: Path):
+    # Create a dummy dataset
+    da = raster_utils.full_from_transform(*testdata[0], name="test")
+    # Add crs
+    da.raster.set_crs(4326)
+
+    # Make gdal compliant without gtf (default)
+    da = da.raster.gdal_compliant()
+    # Assert the state
+    assert "GeoTransform" not in da.spatial_ref.attrs
+
+    # Make gdal compliant with gtf
+    da = da.raster.gdal_compliant(write_transform=True)
+    # Assert the state
+    assert "GeoTransform" in da.spatial_ref.attrs
+    assert da.spatial_ref.attrs["GeoTransform"] == "3.0 0.5 0.0 -9.0 0.0 -0.5"
 
 
 def test_attrs_errors(rioda):


### PR DESCRIPTION
## Issue addressed

Fixes #<issue number>

## Explanation

The GeoTransform attribute in the `spatial_ref` information coordiante can lead to unexpected behaviour by GDAL in some cases. Therefore I made it's addition optional.
 
## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
