### PR TITLE
fix: add backwards compat log module import path and deprecation warning

### DIFF
--- a/.github/workflows/downstream-plugins.yml
+++ b/.github/workflows/downstream-plugins.yml
@@ -44,10 +44,14 @@ jobs:
         with:
           pixi-version: "v0.59.0"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.17"
+
       - name: Build hydromt wheel
         run: |
-          pixi run python -m pip install --upgrade pip build
-          pixi run python -m build --wheel
+          pixi run uv build --wheel
 
       - name: Record hydromt dist path
         run: echo "HYDROMT_DIST=$GITHUB_WORKSPACE/dist" >> $GITHUB_ENV
@@ -76,9 +80,7 @@ jobs:
         working-directory: plugin
         run: |
           pixi run -e ${{ matrix.plugin.environment }} --no-install \
-            python -m ensurepip --upgrade
-          pixi run -e ${{ matrix.plugin.environment }} --no-install \
-            python -m pip install --force-reinstall --no-deps "$HYDROMT_DIST"/hydromt-*.whl
+            uv pip install --force-reinstall --no-deps "$HYDROMT_DIST"/hydromt-*.whl
 
       - name: Echo solved environment
         working-directory: plugin
@@ -88,9 +90,9 @@ jobs:
           pixi list -e ${{ matrix.plugin.environment }} --no-install
 
           # what python will import
-          echo "pip freeze output:"
+          echo "uv pip freeze output:"
           pixi run -e ${{ matrix.plugin.environment }} --no-install \
-            python -m pip freeze
+            uv pip freeze
 
       - name: Run plugin compatibility tests
         working-directory: plugin

--- a/.github/workflows/downstream-plugins.yml
+++ b/.github/workflows/downstream-plugins.yml
@@ -16,7 +16,6 @@ jobs:
   downstream:
     name: Test ${{ matrix.plugin.name }} (deps=${{ matrix.with_deps }})
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     strategy:
       fail-fast: false

--- a/hydromt/_utils/__init__.py
+++ b/hydromt/_utils/__init__.py
@@ -47,22 +47,6 @@ __all__ = [
 ]
 
 
-def __getattr__(name):
-    if name == "log":
-        import warnings
-
-        from hydromt import log
-
-        warnings.warn(
-            "Importing 'log' from 'hydromt._utils' is deprecated. "
-            "Use 'from hydromt import log' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return log
-    raise AttributeError(f"module 'hydromt._utils' has no attribute {name!r}")
-
-
 class _classproperty(property):
     def __get__(self, owner_self, owner_cls):
         return self.fget(owner_cls)

--- a/hydromt/_utils/__init__.py
+++ b/hydromt/_utils/__init__.py
@@ -47,6 +47,22 @@ __all__ = [
 ]
 
 
+def __getattr__(name):
+    if name == "log":
+        import warnings
+
+        from hydromt import log
+
+        warnings.warn(
+            "Importing 'log' from 'hydromt._utils' is deprecated. "
+            "Use 'from hydromt import log' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return log
+    raise AttributeError(f"module 'hydromt._utils' has no attribute {name!r}")
+
+
 class _classproperty(property):
     def __get__(self, owner_self, owner_cls):
         return self.fget(owner_cls)

--- a/hydromt/_utils/log.py
+++ b/hydromt/_utils/log.py
@@ -1,0 +1,12 @@
+import warnings
+
+from hydromt import log
+
+warnings.warn(
+    "importing 'log' from 'hydromt._utils' is deprecated. "
+    "use 'from hydromt import log' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = ["log"]

--- a/hydromt/_utils/log.py
+++ b/hydromt/_utils/log.py
@@ -1,6 +1,6 @@
 import warnings
 
-from hydromt import log
+from hydromt.log import *  # noqa: F403
 
 warnings.warn(
     "importing 'log' from 'hydromt._utils' is deprecated. "
@@ -8,5 +8,3 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
-
-__all__ = ["log"]


### PR DESCRIPTION
## Issue addressed

Adds backwards compat + deprecation warning to the moved `_utils.log` module.

see: https://www.lesinskis.com/deprecating-module-scope-variables.html
