### PR TITLE
added hydromt_delft3dfm as downstream plugin

### DIFF
--- a/.github/workflows/downstream-plugins.yml
+++ b/.github/workflows/downstream-plugins.yml
@@ -43,6 +43,13 @@ jobs:
             pixi_version: v0.65.0
             branch: main
 
+          - name: hydromt-delft3dfm
+            repo: Deltares/hydromt_delft3dfm
+            environment: default
+            pixi_task: test
+            pixi_version: v0.67.1
+            branch: main
+
     steps:
       - name: Checkout hydromt
         uses: actions/checkout@v6

--- a/.github/workflows/downstream-plugins.yml
+++ b/.github/workflows/downstream-plugins.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
     branches: [release/**]
   pull_request:
-    branches: [release/**]
+    branches: [release/**, main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/downstream-plugins.yml
+++ b/.github/workflows/downstream-plugins.yml
@@ -16,6 +16,12 @@ jobs:
   downstream:
     name: Test ${{ matrix.plugin.name }} (deps=${{ matrix.with_deps }})
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_BRANCH: main
+      DEFAULT_PIXI_FEATURE: default
+      DEFAULT_PIXI_ENVIRONMENT: default
+      DEFAULT_PIXI_TASK: test
+      DEFAULT_PIXI_VERSION: v0.59.0
 
     strategy:
       fail-fast: false
@@ -24,31 +30,19 @@ jobs:
         plugin:
           - name: hydromt-wflow
             repo: Deltares/hydromt_wflow
-            branch: main
-            pixi_environment: default
-            pixi_task: test
-            pixi_version: v0.59.0
 
           - name: hydromt-sfincs
             repo: Deltares/hydromt_sfincs
-            branch: main
-            pixi_environment: default
             pixi_task: tests
-            pixi_version: v0.59.0
 
           - name: hydromt-fiat
             repo: Deltares/hydromt_fiat
-            branch: main
-            pixi_environment: default
-            pixi_task: test
             pixi_version: v0.65.0
 
           - name: hydromt-delft3dfm
             repo: Deltares/hydromt_delft3dfm
-            pixi_branch: main
             pixi_feature: hydromt_dev
             pixi_environment: dev-314
-            pixi_task: test
             pixi_version: v0.67.1
 
     steps:
@@ -58,7 +52,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: ${{ matrix.plugin.pixi_version }}
+          pixi-version: ${{ matrix.plugin.pixi_version || env.DEFAULT_PIXI_VERSION }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -78,25 +72,25 @@ jobs:
           repository: ${{ matrix.plugin.repo }}
           path: plugin
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ matrix.plugin.branch }}
+          ref: ${{ matrix.plugin.branch || env.DEFAULT_BRANCH }}
 
       - name: Solve environment for hydromt candidate (with deps)
         if: matrix.with_deps == true
         working-directory: plugin
         run: |
           wheel_file=$(ls "$HYDROMT_DIST"/hydromt-*.whl)
-          pixi add "hydromt@file:$wheel_file" --pypi --feature ${{ matrix.plugin.pixi_feature || 'default' }}
+          pixi add "hydromt@file:$wheel_file" --pypi --feature ${{ matrix.plugin.pixi_feature || env.DEFAULT_PIXI_FEATURE }}
 
       - name: Install plugin env
         working-directory: plugin
         run: |
-          pixi install -e ${{ matrix.plugin.pixi_environment }}
+          pixi install -e ${{ matrix.plugin.pixi_environment || env.DEFAULT_PIXI_ENVIRONMENT }}
 
       - name: Install hydromt candidate (no deps)
         if: matrix.with_deps == false
         working-directory: plugin
         run: |
-          pixi run -e ${{ matrix.plugin.pixi_environment }} --no-install \
+          pixi run -e ${{ matrix.plugin.pixi_environment || env.DEFAULT_PIXI_ENVIRONMENT }} --no-install \
             uv pip install --force-reinstall --no-deps "$HYDROMT_DIST"/hydromt-*.whl
 
       - name: Echo solved environment
@@ -104,11 +98,11 @@ jobs:
         run: |
           # what pixi thinks is installed
           echo "pixi list output:"
-          pixi list -e ${{ matrix.plugin.pixi_environment }} --no-install
+          pixi list -e ${{ matrix.plugin.pixi_environment || env.DEFAULT_PIXI_ENVIRONMENT }} --no-install
 
           # what python will import
           echo "uv pip freeze output:"
-          pixi run -e ${{ matrix.plugin.pixi_environment }} --no-install \
+          pixi run -e ${{ matrix.plugin.pixi_environment || env.DEFAULT_PIXI_ENVIRONMENT }} --no-install \
             uv pip freeze
 
       - name: Run plugin compatibility tests
@@ -116,7 +110,7 @@ jobs:
         env:
           PYTEST_ADDOPTS: "-p no:warnings"
         run: |
-          pixi run -e ${{ matrix.plugin.pixi_environment }} --no-install ${{ matrix.plugin.pixi_task }}
+          pixi run -e ${{ matrix.plugin.pixi_environment || env.DEFAULT_PIXI_ENVIRONMENT }} --no-install ${{ matrix.plugin.pixi_task || env.DEFAULT_PIXI_TASK }}
 
       - name: Failure guidance
         if: failure()

--- a/.github/workflows/downstream-plugins.yml
+++ b/.github/workflows/downstream-plugins.yml
@@ -24,31 +24,32 @@ jobs:
         plugin:
           - name: hydromt-wflow
             repo: Deltares/hydromt_wflow
-            environment: default
+            branch: main
+            pixi_environment: default
             pixi_task: test
             pixi_version: v0.59.0
-            branch: main
 
           - name: hydromt-sfincs
             repo: Deltares/hydromt_sfincs
-            environment: default
+            branch: main
+            pixi_environment: default
             pixi_task: tests
             pixi_version: v0.59.0
-            branch: main
 
           - name: hydromt-fiat
             repo: Deltares/hydromt_fiat
-            environment: default
+            branch: main
+            pixi_environment: default
             pixi_task: test
             pixi_version: v0.65.0
-            branch: main
 
           - name: hydromt-delft3dfm
             repo: Deltares/hydromt_delft3dfm
-            environment: default
+            pixi_branch: main
+            pixi_feature: hydromt_dev
+            pixi_environment: dev-314
             pixi_task: test
             pixi_version: v0.67.1
-            branch: main
 
     steps:
       - name: Checkout hydromt
@@ -84,18 +85,18 @@ jobs:
         working-directory: plugin
         run: |
           wheel_file=$(ls "$HYDROMT_DIST"/hydromt-*.whl)
-          pixi add "hydromt@file:$wheel_file" --pypi
+          pixi add "hydromt@file:$wheel_file" --pypi --feature ${{ matrix.plugin.pixi_feature || 'default' }}
 
       - name: Install plugin env
         working-directory: plugin
         run: |
-          pixi install -e ${{ matrix.plugin.environment }}
+          pixi install -e ${{ matrix.plugin.pixi_environment }}
 
       - name: Install hydromt candidate (no deps)
         if: matrix.with_deps == false
         working-directory: plugin
         run: |
-          pixi run -e ${{ matrix.plugin.environment }} --no-install \
+          pixi run -e ${{ matrix.plugin.pixi_environment }} --no-install \
             uv pip install --force-reinstall --no-deps "$HYDROMT_DIST"/hydromt-*.whl
 
       - name: Echo solved environment
@@ -103,11 +104,11 @@ jobs:
         run: |
           # what pixi thinks is installed
           echo "pixi list output:"
-          pixi list -e ${{ matrix.plugin.environment }} --no-install
+          pixi list -e ${{ matrix.plugin.pixi_environment }} --no-install
 
           # what python will import
           echo "uv pip freeze output:"
-          pixi run -e ${{ matrix.plugin.environment }} --no-install \
+          pixi run -e ${{ matrix.plugin.pixi_environment }} --no-install \
             uv pip freeze
 
       - name: Run plugin compatibility tests
@@ -115,7 +116,7 @@ jobs:
         env:
           PYTEST_ADDOPTS: "-p no:warnings"
         run: |
-          pixi run -e ${{ matrix.plugin.environment }} --no-install ${{ matrix.plugin.pixi_task }}
+          pixi run -e ${{ matrix.plugin.pixi_environment }} --no-install ${{ matrix.plugin.pixi_task }}
 
       - name: Failure guidance
         if: failure()


### PR DESCRIPTION
## Issue addressed

Fixes #1493

## Explanation

Explain how you addressed the bug/feature request, what choices you made and why.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

@LuukBlom I temporarily added main as a trigger to the downstream test workflow, to see if all tests pass (they don't, but they also don't in main). This addition should be removed before merging.

Furthermore, one of the hydromt_delft3dfm tests is failing because of a conflicting hydromt version, because we included a git link in the pyproject.toml as suggested in [the hydromt docs](https://deltares.github.io/hydromt/stable/dev/plugin_dev/testing.html#setting-up-a-github-actions-workflow): 
<img width="726" height="492" alt="image" src="https://github.com/user-attachments/assets/4e411afd-c563-4b7d-ab72-200f032b2c2b" />
I'd like to keep this git link in our toml, is there a way to work around this?