### PR TITLE
fix(slippy_tile_driver): fall back to anonymous S3 access when creden…

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this page.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+Unreleased
+==========
+
+Fixed
+-----
+- ``SlippyTileDriver`` no longer crashes when an AWS credential provider raises while resolving (e.g. an expired SSO token); it now falls back to anonymous access, so public buckets remain reachable.
+
 v1.4.0 (2026-06-02)
 ===================
 

--- a/hydromt/data_catalog/drivers/raster/slippy_tile_driver.py
+++ b/hydromt/data_catalog/drivers/raster/slippy_tile_driver.py
@@ -300,10 +300,12 @@ def _png2value(
 def has_credentials() -> bool:
     """Return True if AWS credentials are available in the environment.
 
-    Falls back to ``False`` if a credential provider (e.g. SSO with an
-    expired token) raises while resolving — anonymous S3 access still
-    works for public buckets.
+    Returns ``False`` if ``s3fs``/``botocore`` are not installed, or if a
+    credential provider (e.g. SSO with an expired token) raises while
+    resolving — anonymous S3 access still works for public buckets.
     """
+    if not HAS_S3FS:
+        return False
     session = botocore.session.get_session()
     try:
         creds = session.get_credentials()

--- a/hydromt/data_catalog/drivers/raster/slippy_tile_driver.py
+++ b/hydromt/data_catalog/drivers/raster/slippy_tile_driver.py
@@ -298,9 +298,20 @@ def _png2value(
 # S3 tile download
 # ---------------------------------------------------------------------------
 def has_credentials() -> bool:
-    """Return True if AWS credentials are available in the environment."""
+    """Return True if AWS credentials are available in the environment.
+
+    Falls back to ``False`` if a credential provider (e.g. SSO with an
+    expired token) raises while resolving — anonymous S3 access still
+    works for public buckets.
+    """
     session = botocore.session.get_session()
-    creds = session.get_credentials()
+    try:
+        creds = session.get_credentials()
+    except Exception as e:
+        logger.debug(
+            f"Could not resolve AWS credentials ({e}); using anonymous access."
+        )
+        return False
     return creds is not None and creds.access_key is not None
 
 

--- a/tests/data_catalog/drivers/raster/test_slippy_tile_driver.py
+++ b/tests/data_catalog/drivers/raster/test_slippy_tile_driver.py
@@ -323,6 +323,7 @@ def test_options_defaults():
     assert opts.s3_bucket is None
 
 
+@pytest.mark.skipif(not HAS_S3FS, reason="s3fs/botocore required for credential test")
 def test_has_credentials_handles_provider_error():
     """A failing credential provider (e.g. expired SSO token) must not raise.
 
@@ -340,6 +341,14 @@ def test_has_credentials_handles_provider_error():
     with patch(
         "hydromt.data_catalog.drivers.raster.slippy_tile_driver.botocore.session.get_session",
         return_value=fake_session,
+    ):
+        assert has_credentials() is False
+
+
+def test_has_credentials_returns_false_when_s3fs_missing():
+    """Without s3fs/botocore the function must return False, not NameError."""
+    with patch(
+        "hydromt.data_catalog.drivers.raster.slippy_tile_driver.HAS_S3FS", False
     ):
         assert has_credentials() is False
 

--- a/tests/data_catalog/drivers/raster/test_slippy_tile_driver.py
+++ b/tests/data_catalog/drivers/raster/test_slippy_tile_driver.py
@@ -22,6 +22,7 @@ from hydromt.data_catalog.drivers.raster.slippy_tile_driver import (
     _num2xy,
     _png2value,
     _xy2num,
+    has_credentials,
 )
 from hydromt.error import NoDataException, NoDataStrategy
 
@@ -320,6 +321,27 @@ def test_options_defaults():
     assert opts.variable_name == "elevation"
     assert opts.max_zoom is None
     assert opts.s3_bucket is None
+
+
+def test_has_credentials_handles_provider_error():
+    """A failing credential provider (e.g. expired SSO token) must not raise.
+
+    botocore can raise ``CredentialRetrievalError`` from ``get_credentials()``
+    when an SSO config is present but the token has expired. ``has_credentials``
+    should swallow that and return ``False`` so anonymous S3 access remains
+    available for public buckets.
+    """
+    from botocore.exceptions import CredentialRetrievalError
+
+    fake_session = MagicMock()
+    fake_session.get_credentials.side_effect = CredentialRetrievalError(
+        provider="sso", error_msg="Token has expired and refresh failed"
+    )
+    with patch(
+        "hydromt.data_catalog.drivers.raster.slippy_tile_driver.botocore.session.get_session",
+        return_value=fake_session,
+    ):
+        assert has_credentials() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…tials lookup fails

`has_credentials()` called `session.get_credentials()`, which evaluates every botocore credential provider. When an SSO profile exists but the token has expired, the SSO provider raises `CredentialRetrievalError` instead of returning `None`. The exception propagated up through `_download_missing_tiles` and broke tile download for public buckets (e.g. the GEBCO 2024 tile set on `deltares-ddb`), even though anonymous access would have worked.

Wrap the lookup in `try/except` so any credential-provider failure is logged and treated as "no credentials available", falling back to `anon=True` for the `S3FileSystem`.

## Issue addressed

Fixes #<issue number>

## Explanation

Explain how you addressed the bug/feature request, what choices you made and why.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
