### PR TITLE
fix: record-release workflow

### DIFF
--- a/.github/scripts/record-release-on-main.sh
+++ b/.github/scripts/record-release-on-main.sh
@@ -37,6 +37,10 @@ COMPUTED_NEXT="${MAJOR}.$((MINOR + 1)).0.dev0"
 # Read main's current version.
 VERSION_LINE=$(git show origin/main:hydromt/__init__.py | grep "^__version__")
 MAIN_VERSION=$(echo "$VERSION_LINE" | cut -d= -f2 | tr -d "\"' \t")
+if [[ -z "$MAIN_VERSION" ]]; then
+  echo "ERROR: failed to read version from the main branch" >&2
+  exit 1
+fi
 
 # Pick whichever version is higher.
 MAIN_MAJOR=$(echo "$MAIN_VERSION" | cut -d. -f1)

--- a/.github/scripts/record-release-on-main.sh
+++ b/.github/scripts/record-release-on-main.sh
@@ -35,8 +35,8 @@ MINOR=$(echo "$NEW_VERSION" | cut -d. -f2)
 COMPUTED_NEXT="${MAJOR}.$((MINOR + 1)).0.dev0"
 
 # Read main's current version.
-MAIN_VERSION=$(git show origin/main:hydromt/__init__.py \
-  | grep "^__version__" | cut -d= -f2 | tr -d "\" ")
+VERSION_LINE=$(git show origin/main:hydromt/__init__.py | grep "^__version__")
+MAIN_VERSION=$(echo "$VERSION_LINE" | cut -d= -f2 | tr -d "\"' \t")
 
 # Pick whichever version is higher.
 MAIN_MAJOR=$(echo "$MAIN_VERSION" | cut -d. -f1)

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -169,6 +169,10 @@ jobs:
 
           RECORD_BRANCH=$(bash .github/scripts/record-release-on-main.sh \
             "$RELEASE_BRANCH" "$NEW_VERSION" | tail -n 1)
+          if [[ -z "$RECORD_BRANCH" ]]; then
+            echo "ERROR: record-release-on-main.sh did not emit a branch name" >&2
+            exit 1
+          fi
 
           PR_BODY=$(cat <<EOF
           Automated merge-back PR for the **v$NEW_VERSION** release.


### PR DESCRIPTION
The workflow file used to create the branch did not have the correct regex, resulting in grep returning multiple lines.

We read `hydromt.__init__.py` and called `grep __version__` to get the version string.

However, since the rasterio sys.excepthook fix, the file now has multiple occurences of the string `__version__`.
This lead to grep returning something unexpected and then erroring.

The error was swallowed and it continued as if grep returned nothing.

The regex was fixed already by grepping `^__version__`, which only matches lines that start with `__version__`.

See old regex without the anchor `^` (this is fixed on main already, but not on the v1.4 tag): https://github.com/Deltares/hydromt/blob/cd3e5ae25a4b97835fe613664ada6e097edc8a3b/.github/scripts/record-release-on-main.sh#L39

Now we check and manually throw if the versions are not defined (thought this was already enabled tbh)