### PR TITLE
Update: add sort flag to check command

### DIFF
--- a/hydromt/cli/main.py
+++ b/hydromt/cli/main.py
@@ -334,7 +334,12 @@ def update(
     mod.update(model_out=model_out, steps=steps, forceful_overwrite=fo)
 
 
-def _validate_catalog(cat_path: Path, fmt: Format, upgrade: bool) -> bool:
+def _validate_catalog(
+    cat_path: Path,
+    fmt: Format,
+    upgrade: bool,
+    sort: bool,
+) -> bool:
     """Validate a catalog file. Returns True if valid, False otherwise."""
     logger.info(f"Validating catalog at {cat_path}")
 
@@ -355,6 +360,7 @@ def _validate_catalog(cat_path: Path, fmt: Format, upgrade: bool) -> bool:
                     exclude_defaults=True,
                     exclude_none=True,
                 ),
+                sort_keys=sort,
                 Dumper=CatalogDumper,
             )
             logger.info(f"Upgraded catalog written to {out_path}")
@@ -406,8 +412,22 @@ def _validate_config(config: Path, model: Optional[str], fmt: Format) -> bool:
 @data_opt
 @quiet_opt
 @verbose_opt
-@click.option("--format", type=click.Choice(list(Format)), default=Format.v1)
-@click.option("--upgrade", is_flag=True)
+@click.option(
+    "--format",
+    type=click.Choice(list(Format)),
+    default=Format.v1,
+    help="The HydroMT major version",
+)
+@click.option(
+    "--upgrade",
+    is_flag=True,
+    help="Whether to upgrade the data catalog from v0 to v1",
+)
+@click.option(
+    "--sort",
+    is_flag=True,
+    help="Whether to sort the data catalog when upgrading",
+)
 @click.pass_context
 def check(
     _ctx: click.Context,
@@ -418,6 +438,7 @@ def check(
     verbose: int,
     format: Format,
     upgrade: bool,
+    sort: bool,
 ):
     """
     Verify that provided data catalog and config files are in the correct format.
@@ -442,7 +463,9 @@ def check(
         log.log_version()
         results = []
         for cat_path in data:
-            results.append(_validate_catalog(Path(cat_path), format, upgrade))
+            results.append(
+                _validate_catalog(Path(cat_path), format, upgrade, sort),
+            )
         if config:
             results.append(_validate_config(Path(config), model, format))
 


### PR DESCRIPTION
## Issue addressed
Fixes auto sort check command

## Explanation
Simple addition of a flag to sort when needed, but by default don't.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
