### PR TITLE
Feat: add expansion of user directory

### DIFF
--- a/hydromt/readers.py
+++ b/hydromt/readers.py
@@ -1020,13 +1020,18 @@ def read_toml(path: str | Path) -> dict[str, Any]:
 
 
 def _yml_from_uri_or_path(uri_or_path: str | Path) -> dict[str, Any]:
+    # From a url
     if _is_valid_url(str(uri_or_path)):
+        # Stream that bad boy
         with requests.get(str(uri_or_path), stream=True) as r:
             r.raise_for_status()
             yml = _parse_yaml(r.text)
 
+    # (Local) Path
     else:
-        yml = read_yaml(uri_or_path)
+        # Ensure typing
+        uri_or_path = Path(uri_or_path)
+        yml = read_yaml(uri_or_path.expanduser())  # Expand the user (~)
     return yml
 
 


### PR DESCRIPTION
## Issue addressed
Fixes Providing paths pointing to the user home directory (~)

## Explanation
Ensure `Path` typing for (local) paths (non urls) and then expand the user sign.

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
