### PR TITLE
update `SONARCLOUD_TOKEN_2025` to the new `SONAR_TOKEN` gh secret

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -47,4 +47,4 @@ jobs:
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v8
         env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN_2025 }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The previous secret doesnt exist anymore.

https://github.com/Deltares/hydromt/settings/secrets/actions