### PR TITLE
skip sonar scan for dependabot and forks

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,6 +33,9 @@ defaults:
 
 jobs:
   scan:
+    if: | # skip for dependabot and forks since they dont have the secrets
+      github.actor != 'dependabot[bot]' &&
+      ( github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork )
     name: run test coverage and SonarQube scan
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Explanation

SonarScan was broken sometimes due to a missing token.
I think I traced it to the secrets not being available for dependabot or forks.

So I added a guard to conditionally run the scan.

A more generic guard could be this

```yml
if: ${{ secrets.SONAR_TOKEN != '' }}
```

But I also like being explicit, since this will silently skip the scan if the secret name is changed.
