### PR TITLE
move additions merged v1.4.0 from v1.4.0 to unreleased section

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,10 @@ Changed
 Fixed
 -----
 - ``SlippyTileDriver`` no longer crashes when an AWS credential provider raises while resolving (e.g. an expired SSO token); it now falls back to anonymous access, so public buckets remain reachable.
+- ``readers.open_mfraster`` now uses the numeric basename as the concatenation index for files matched by a bare wildcard (e.g. ``*.tif`` matching ``1.tif`` .. ``12.tif``) instead of the file-order fallback, and sorts the matched files so the concat order and variable name no longer depend on the filesystem glob order. (#1465)
+- ``preprocessing.harmonise_dims`` no longer applies 0-360 to -180-180 longitude normalisation to projected datasets (x in metres, all > 180), which silently shifted the grid by -360. Normalisation is now only applied for geographic CRS; datasets without a CRS are left unchanged with a warning. (#1476)
+- ``RasterDatasetAdapter`` now respects ``handle_nodata`` when requested ``variables`` are missing from the source: ``NoDataStrategy.WARN`` and ``NoDataStrategy.IGNORE`` return ``None`` (and warn) instead of always raising ``NoDataException``. (#1407)
+- A ``DataFrame`` source without an explicit driver now defaults to the ``pandas`` driver instead of incorrectly inferring ``geodataframe_table`` (which also claims ``.csv``/``.parquet``) and failing validation. (#1403)
 
 v1.4.0 (2026-06-02)
 ===================
@@ -48,10 +52,6 @@ Fixed
 - The functions ``_strip_scheme`` and ``_strip_vsi`` in ``hydromt._utils.uris`` no longer use ``lstrip`` to remove leading characters, but now remove only the exact prefix. (#1438)
 - ``Datacatalog.export_data`` no longer applies unit conversion twice. (#1459)
 - ``RasterioDriver.write`` now always produces filenames that are parseable by ``readers.open_mfraster`` when provided with a pattern with no prefix e.g. ``*.tif``. (#1459)
-- ``readers.open_mfraster`` now uses the numeric basename as the concatenation index for files matched by a bare wildcard (e.g. ``*.tif`` matching ``1.tif`` .. ``12.tif``) instead of the file-order fallback, and sorts the matched files so the concat order and variable name no longer depend on the filesystem glob order. (#1465)
-- ``preprocessing.harmonise_dims`` no longer applies 0-360 to -180-180 longitude normalisation to projected datasets (x in metres, all > 180), which silently shifted the grid by -360. Normalisation is now only applied for geographic CRS; datasets without a CRS are left unchanged with a warning. (#1476)
-- ``RasterDatasetAdapter`` now respects ``handle_nodata`` when requested ``variables`` are missing from the source: ``NoDataStrategy.WARN`` and ``NoDataStrategy.IGNORE`` return ``None`` (and warn) instead of always raising ``NoDataException``. (#1407)
-- A ``DataFrame`` source without an explicit driver now defaults to the ``pandas`` driver instead of incorrectly inferring ``geodataframe_table`` (which also claims ``.csv``/``.parquet``) and failing validation. (#1403)
 
 Deprecated
 ----------


### PR DESCRIPTION
## Explanation

I missed that the latest PR's merged into main added the changelog updates to the already released `v1.4.0` section. 
This moves them to unreleased (`v1.4.1` in the future).

