### PR TITLE
Sort urls in convention resolver log statements

### DIFF
--- a/hydromt/data_catalog/uri_resolvers/convention_resolver.py
+++ b/hydromt/data_catalog/uri_resolvers/convention_resolver.py
@@ -205,7 +205,7 @@ class ConventionResolver(URIResolver):
                 self.name,
                 len(uris),
                 uri_expanded,
-                uris,
+                sorted(uris),
             )
 
         return uris


### PR DESCRIPTION
I could add extra code to make sorting perfect (in case of weird keys like `1`,`10`,`2`), but given our usage is mostly years, this is good enough.