### PR TITLE
fix: parse_region correctly handles integer xy coords

### DIFF
--- a/hydromt/model/processes/region.py
+++ b/hydromt/model/processes/region.py
@@ -1,6 +1,7 @@
 """parse a region from a dict. See parse_region for information on usage."""
 
 import logging
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -324,6 +325,15 @@ def _parse_region_value(
     kwarg: dict[str, Any] = {}
     if isinstance(value, np.ndarray):
         value = value.tolist()
+
+    if kind is None:
+        warnings.warn(
+            "Passing kind=None to `_parse_region_value` is deprecated and will "
+            "be removed in a future release. Pass an explicit kind "
+            "('basin', 'subbasin', 'interbasin', 'bbox', 'xy', etc.) instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     if kind == "bbox":
         if isinstance(value, list) and len(value) == 4:

--- a/hydromt/model/processes/region.py
+++ b/hydromt/model/processes/region.py
@@ -1,9 +1,8 @@
 """parse a region from a dict. See parse_region for information on usage."""
 
 import logging
-from os.path import isdir, isfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import geopandas as gpd
 import numpy as np
@@ -18,7 +17,6 @@ from hydromt.error import NoDataStrategy
 from hydromt.gis import parse_crs
 from hydromt.model.processes.basin_mask import get_basin_geometry
 from hydromt.plugins import PLUGINS
-from hydromt.typing.type_def import StrPath
 
 if TYPE_CHECKING:
     from hydromt.model.model import Model
@@ -40,8 +38,8 @@ def parse_region_basin(
     region: dict,
     *,
     data_catalog: DataCatalog,
-    hydrography_path: StrPath,
-    basin_index_path: Optional[StrPath] = None,
+    hydrography_path: str | Path,
+    basin_index_path: str | Path | None = None,
 ) -> gpd.GeoDataFrame:
     """Parse a basin /subbasin / interbasin region and return the GeoDataFrame.
 
@@ -95,9 +93,9 @@ def parse_region_basin(
         * {'interbasin': /path/to/polygon_geometry, 'outlets': true}
     data_catalog : DataCatalog
         DataCatalog object containing the data sources.
-    hydrography_fn : strPath
+    hydrography_fn : str | Path
         Path of the hydrography raster dataset in the data catalog.
-    basin_index_path : StrPath, optional
+    basin_index_path : str | Path, optional
         Path of the basin index raster dataset in the data catalog.
     """
     var_thresh_kwargs = region.copy()
@@ -106,7 +104,7 @@ def parse_region_basin(
 
     _assert_parse_key(kind, "basin", "interbasin", "subbasin")
 
-    kwargs = _parse_region_value(value0, data_catalog=data_catalog)
+    kwargs = _parse_region_value(value0, data_catalog=data_catalog, kind=kind)
     kwargs.update(var_thresh_kwargs)
 
     if kind == "basin":
@@ -146,7 +144,7 @@ def parse_region_bbox(region: dict, *, crs: int = 4326) -> gpd.GeoDataFrame:
 
     _assert_parse_key(kind, "bbox")
 
-    kwargs.update(_parse_region_value(value0, data_catalog=None))
+    kwargs.update(_parse_region_value(value0, data_catalog=None, kind=kind))
 
     _assert_parsed_values(
         key=next(iter(kwargs)), region_value=value0, kind="bbox", expected=["bbox"]
@@ -161,8 +159,8 @@ def parse_region_bbox(region: dict, *, crs: int = 4326) -> gpd.GeoDataFrame:
 def parse_region_geom(
     region: dict,
     *,
-    crs: Optional[int] = None,
-    data_catalog: Optional[DataCatalog] = None,
+    crs: int | None = None,
+    data_catalog: DataCatalog | None = None,
 ) -> gpd.GeoDataFrame:
     """Parse a region and return the GeoDataFrame.
 
@@ -183,7 +181,7 @@ def parse_region_geom(
 
     _assert_parse_key(kind, "geom")
 
-    kwargs.update(_parse_region_value(value0, data_catalog=data_catalog))
+    kwargs.update(_parse_region_value(value0, data_catalog=data_catalog, kind=kind))
 
     _assert_parsed_values(
         key=next(iter(kwargs)), region_value=value0, kind="geom", expected=["geom"]
@@ -193,8 +191,7 @@ def parse_region_geom(
     geom = kwargs["geom"]
     if geom.crs is None:
         logger.debug(f'Model region "geom" has no CRS, setting to {crs}')
-        _update_crs(geom, crs)
-
+        geom = _update_crs(geom, crs)
     return geom
 
 
@@ -286,7 +283,7 @@ def parse_region_mesh(region: dict) -> xu.UgridDataset:
 
     _assert_parse_key(kind, "mesh")
 
-    if isinstance(value0, (str, Path)) and isfile(value0):
+    if isinstance(value0, (str, Path)) and Path(value0).is_file():
         return xu.open_dataset(value0)
     elif isinstance(value0, (xu.UgridDataset, xu.UgridDataArray)):
         return value0
@@ -299,8 +296,8 @@ def parse_region_mesh(region: dict) -> xu.UgridDataset:
 
 
 def _update_crs(
-    geom: gpd.GeoDataFrame, crs: Optional[Union[CRS, int]]
-) -> Optional[gpd.GeoDataFrame]:
+    geom: gpd.GeoDataFrame, crs: CRS | int | str | None
+) -> gpd.GeoDataFrame:
     if crs is not None:
         crs = parse_crs(crs, bbox=geom.total_bounds)
         return geom.to_crs(crs)
@@ -308,33 +305,63 @@ def _update_crs(
 
 
 def _parse_region_value(
-    value: Any, *, data_catalog: Optional[DataCatalog]
-) -> Dict[str, Any]:
-    kwarg: Dict[str, Any] = {}
-    if isinstance(value, np.ndarray):
-        value = value.tolist()  # array to list
+    value: Any, *, data_catalog: DataCatalog | None, kind: str | None = None
+) -> dict[str, Any]:
+    """Parse a region value and return a dictionary with the corresponding keyword arguments.
 
-    if isinstance(value, list):
-        if np.all([isinstance(p0, int) and abs(p0) > 180 for p0 in value]):  # all int
-            kwarg = dict(basid=value)
-        elif len(value) == 4:  # 4 floats
+    Parameters
+    ----------
+    value : Any
+        The value to parse. Can be a string, a list, a tuple, a numpy
+        array, a GeoDataFrame, or a Path.
+    data_catalog : DataCatalog | None
+        DataCatalog object containing the data sources.
+    kind : str | None, optional
+        The kind of region value. Can be 'bbox', 'xy', 'basin', 'subbasin',
+        'interbasin', or None. If None, the kind will be inferred from the
+        value. Default is None.
+    """
+    kwarg: dict[str, Any] = {}
+    if isinstance(value, np.ndarray):
+        value = value.tolist()
+
+    if kind == "bbox":
+        if isinstance(value, list) and len(value) == 4:
             kwarg = dict(bbox=value)
-        elif len(value) == 2:  # 2 floats
+    elif kind == "xy":
+        if isinstance(value, (list, tuple)) and len(value) == 2:
             kwarg = dict(xy=value)
-    elif isinstance(value, tuple) and len(value) == 2:  # tuple of x and y coords
-        kwarg = dict(xy=value)
-    elif isinstance(value, int):  # single int
-        kwarg = dict(basid=value)
-    elif isinstance(value, (str, Path)) and isdir(value):
-        kwarg = dict(root=value)
-    elif isinstance(value, (str, Path)):
-        data_catalog = data_catalog or DataCatalog()
-        geom = data_catalog.get_geodataframe(value)
-        kwarg = dict(geom=geom)
-    elif isinstance(value, gpd.GeoDataFrame):  # geometry
-        kwarg = dict(geom=value)
-    else:
-        raise ValueError(f"Region value {value} not understood.")
+    elif kind in ("basin", None):
+        # kind=None preserves backward-compatible behaviour (same as basin)
+        if isinstance(value, int):
+            kwarg = dict(basid=value)
+        elif isinstance(value, list) and np.all(
+            [isinstance(p0, int) and abs(p0) > 180 for p0 in value]
+        ):
+            kwarg = dict(basid=value)
+        elif isinstance(value, list) and len(value) == 4:
+            kwarg = dict(bbox=value)
+        elif isinstance(value, (list, tuple)) and len(value) == 2:
+            kwarg = dict(xy=value)
+    elif kind in ("subbasin", "interbasin"):
+        if isinstance(value, list) and len(value) == 4:
+            kwarg = dict(bbox=value)
+        elif isinstance(value, (list, tuple)) and len(value) == 2:
+            kwarg = dict(xy=value)
+
+    if not kwarg:
+        # shared across all kinds: path/geom/model root
+        if isinstance(value, (str, Path)):
+            if Path(value).is_dir():
+                kwarg = dict(root=value)
+            else:
+                data_catalog = data_catalog or DataCatalog()
+                geom = data_catalog.get_geodataframe(value)
+                kwarg = dict(geom=geom)
+        elif isinstance(value, gpd.GeoDataFrame):
+            kwarg = dict(geom=value)
+        else:
+            raise ValueError(f"Region value {value} not understood for kind={kind}.")
 
     if "geom" in kwarg and np.all(kwarg["geom"].geometry.type == "Point"):
         xy = (
@@ -342,6 +369,7 @@ def _parse_region_value(
             kwarg["geom"].geometry.y.values,
         )
         kwarg = dict(xy=xy)
+
     return kwarg
 
 
@@ -364,7 +392,7 @@ def _assert_parse_key(key: str, *expected: str) -> None:
 
 
 def _assert_parsed_values(
-    *, key: str, region_value: Any, kind: str, expected: List[str]
+    *, key: str, region_value: Any, kind: str, expected: list[str]
 ) -> None:
     if key not in expected:
         raise ValueError(

--- a/tests/model/processes/test_region.py
+++ b/tests/model/processes/test_region.py
@@ -178,25 +178,138 @@ def test_region_from_model(tmp_path: Path, world, mocker: MockerFixture):
     assert read_model.region is world
 
 
-def test_region_value_basin_ids():
-    data_catalog = DataCatalog()
-    array = np.array([1001, 1002, 1003, 1004, 1005])
-    kwarg = _parse_region_value(array, data_catalog=data_catalog, kind="basin")
-    assert kwarg.get("basid") == array.tolist()
+@pytest.mark.parametrize(
+    ("value", "kind", "expected_kwarg"),
+    [
+        pytest.param(
+            np.array([1001, 1002, 1003, 1004, 1005]),
+            "basin",
+            {"basid": [1001, 1002, 1003, 1004, 1005]},
+            id="basin_ids",
+        ),
+        pytest.param(
+            (1.0, -1.0),
+            "xy",
+            {"xy": (1.0, -1.0)},
+            id="xy_tuple",
+        ),
+        pytest.param(
+            "./",
+            None,
+            {"root": "./"},
+            id="root_path",
+        ),
+        pytest.param(
+            42,
+            "basin",
+            {"basid": 42},
+            id="basin_single_id",
+        ),
+        pytest.param(
+            [277400, 2749239],
+            "basin",
+            {"basid": [277400, 2749239]},
+            id="basin_large_int_list",
+        ),
+        pytest.param(
+            [1.0, 2.0, 3.0, 4.0],
+            "basin",
+            {"bbox": [1.0, 2.0, 3.0, 4.0]},
+            id="basin_bbox",
+        ),
+        pytest.param(
+            [1.0, 2.0],
+            "basin",
+            {"xy": [1.0, 2.0]},
+            id="basin_xy_list",
+        ),
+        pytest.param(
+            (1.0, 2.0),
+            "basin",
+            {"xy": (1.0, 2.0)},
+            id="basin_xy_tuple",
+        ),
+        pytest.param(
+            [277400, 2749239],
+            "subbasin",
+            {"xy": [277400, 2749239]},
+            id="subbasin_large_ints_as_xy",
+        ),
+        pytest.param(
+            [277400.0, 2749239.0],
+            "subbasin",
+            {"xy": [277400.0, 2749239.0]},
+            id="subbasin_float_xy",
+        ),
+        pytest.param(
+            [1.0, 2.0, 3.0, 4.0],
+            "subbasin",
+            {"bbox": [1.0, 2.0, 3.0, 4.0]},
+            id="subbasin_bbox",
+        ),
+        pytest.param(
+            [277400, 2749239],
+            "interbasin",
+            {"xy": [277400, 2749239]},
+            id="interbasin_large_ints_as_xy",
+        ),
+        pytest.param(
+            [12.0, 45.0, 12.25, 45.25],
+            "bbox",
+            {"bbox": [12.0, 45.0, 12.25, 45.25]},
+            id="bbox_kind",
+        ),
+        pytest.param(
+            [277400, 2749239],
+            None,
+            {"basid": [277400, 2749239]},
+            id="kind_none_large_ints_as_basid",
+        ),
+        pytest.param(
+            [1.0, 2.0, 3.0, 4.0],
+            None,
+            {"bbox": [1.0, 2.0, 3.0, 4.0]},
+            id="kind_none_bbox",
+        ),
+        pytest.param(
+            np.array([1.0, 2.0, 3.0, 4.0]),
+            "bbox",
+            {"bbox": [1.0, 2.0, 3.0, 4.0]},
+            id="bbox_numpy_array",
+        ),
+    ],
+)
+def test_parse_region_value(value, kind, expected_kwarg):
+    kwarg = _parse_region_value(value, data_catalog=DataCatalog(), kind=kind)
+    assert kwarg == expected_kwarg
 
 
-def test_region_value_xy():
-    data_catalog = DataCatalog()
-    xy = (1.0, -1.0)
-    kwarg = _parse_region_value(xy, data_catalog=data_catalog, kind="xy")
-    assert kwarg.get("xy") == xy
+@pytest.mark.parametrize(
+    ("value", "kind"),
+    [
+        pytest.param(
+            42,
+            "subbasin",
+            id="subbasin_single_int_raises",
+        ),
+        pytest.param(
+            [1.0, 2.0],
+            "bbox",
+            id="bbox_wrong_length_raises",
+        ),
+    ],
+)
+def test_parse_region_value_errors(value, kind):
+    with pytest.raises(ValueError, match="not understood"):
+        _parse_region_value(value, data_catalog=DataCatalog(), kind=kind)
 
 
-def test_region_value_cat():
-    data_catalog = DataCatalog()
-    root = "./"
-    kwarg = _parse_region_value(root, data_catalog=data_catalog)
-    assert kwarg.get("root") == root
+def test_region_value_kind_none_large_ints_are_basid():
+    # kind=None preserves pre-refactor behaviour: large ints are basid.
+    kwarg = _parse_region_value(
+        [277400, 2749239], data_catalog=DataCatalog(), kind=None
+    )
+    assert kwarg == {"basid": [277400, 2749239]}
 
 
 def test_region_mesh(griduda):

--- a/tests/model/processes/test_region.py
+++ b/tests/model/processes/test_region.py
@@ -181,14 +181,14 @@ def test_region_from_model(tmp_path: Path, world, mocker: MockerFixture):
 def test_region_value_basin_ids():
     data_catalog = DataCatalog()
     array = np.array([1001, 1002, 1003, 1004, 1005])
-    kwarg = _parse_region_value(array, data_catalog=data_catalog)
+    kwarg = _parse_region_value(array, data_catalog=data_catalog, kind="basin")
     assert kwarg.get("basid") == array.tolist()
 
 
 def test_region_value_xy():
     data_catalog = DataCatalog()
     xy = (1.0, -1.0)
-    kwarg = _parse_region_value(xy, data_catalog=data_catalog)
+    kwarg = _parse_region_value(xy, data_catalog=data_catalog, kind="xy")
     assert kwarg.get("xy") == xy
 
 
@@ -209,7 +209,7 @@ def test_parse_region_mesh_path(mocker: MockerFixture):
     xu_open_dataset_mock = mocker.patch(
         "hydromt.model.processes.region.xu.open_dataset", return_value=ugrid_mock
     )
-    mocker.patch("hydromt.model.processes.region.isfile", return_value=True)
+    mocker.patch("hydromt.model.processes.region.Path.is_file", return_value=True)
     mesh = parse_region_mesh({"mesh": "path/to/mesh.nc"})
     xu_open_dataset_mock.assert_called_once_with("path/to/mesh.nc")
     assert mesh is ugrid_mock

--- a/tests/model/processes/test_region.py
+++ b/tests/model/processes/test_region.py
@@ -259,6 +259,9 @@ def test_region_from_model(tmp_path: Path, world, mocker: MockerFixture):
             {"bbox": [12.0, 45.0, 12.25, 45.25]},
             id="bbox_kind",
         ),
+        # This case only shows that the previous behavior described in #751 is preserved, if you pass kind=None.
+        # it will treat a list of ints as basin ids, but it is not the intended behavior.
+        # To not hit this old behaviour, callers must explicitly pass kind as an argument.
         pytest.param(
             [277400, 2749239],
             None,
@@ -280,7 +283,11 @@ def test_region_from_model(tmp_path: Path, world, mocker: MockerFixture):
     ],
 )
 def test_parse_region_value(value, kind, expected_kwarg):
-    kwarg = _parse_region_value(value, data_catalog=DataCatalog(), kind=kind)
+    if kind is None:
+        with pytest.warns(FutureWarning, match="Passing kind=None"):
+            kwarg = _parse_region_value(value, data_catalog=DataCatalog(), kind=kind)
+    else:
+        kwarg = _parse_region_value(value, data_catalog=DataCatalog(), kind=kind)
     assert kwarg == expected_kwarg
 
 
@@ -304,12 +311,13 @@ def test_parse_region_value_errors(value, kind):
         _parse_region_value(value, data_catalog=DataCatalog(), kind=kind)
 
 
-def test_region_value_kind_none_large_ints_are_basid():
-    # kind=None preserves pre-refactor behaviour: large ints are basid.
-    kwarg = _parse_region_value(
-        [277400, 2749239], data_catalog=DataCatalog(), kind=None
-    )
-    assert kwarg == {"basid": [277400, 2749239]}
+def test_region_value_kind_none_warns():
+    with pytest.warns(FutureWarning, match="Passing kind=None"):
+        _parse_region_value(
+            [277400, 2749239],
+            data_catalog=DataCatalog(),
+            kind=None,
+        )
 
 
 def test_region_mesh(griduda):


### PR DESCRIPTION
## Issue addressed

Fixes [#751](https://github.com/Deltares/hydromt_wflow/issues/751)

## Explanation

Add `kind` param to  `_parse_region_value` to better select what to do with the value.

Problem described in the issue was due to the `_parse_region_value` function trying to infer the kind. 
Now its an argument, with default = None for backwards compat. (passing None is the same behaviour as before this PR.)

Corresponding PR in hydromt_wflow: https://github.com/Deltares/hydromt_wflow/pull/784 (should be merged after this change is merged and released.)

## General Checklist

- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

## Data/Catalog checklist

- [ ] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [ ] None of the old `data_catalog.yml` files have been changed
- [ ] `data/changelog.rst` has been updated
- [ ] new file uses `LF` line endings (done automatically if you used `update_versions.py`)
- [ ] New file has been tested locally
- [ ] Tests have been added using the new file in the test suite

## Additional Notes (optional)

Add any additional notes or information that may be helpful.
