### PR TITLE
docs: add AGENTS.md, Copilot instructions, prompt and skill files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,75 @@
+# HydroMT — Copilot instructions
+
+HydroMT is a Python (>=3.11) framework for building and analysing
+hydrology/hydraulics models. Core subsystems: `data_catalog` (DataSource /
+URIResolver / Driver / DataAdapter pipeline), `model` (Model base +
+ModelComponents), `gis` utilities, and a plugin system via Python entry points.
+
+---
+
+## Commands
+
+```bash
+pixi run test        # run tests
+pixi run test-cov    # tests + coverage
+pixi run lint        # ruff + ruff-format (pre-commit)
+pixi run mypy        # type-check
+pixi run docs        # build docs
+```
+
+Use **pixi** for all dependency management. Never use `pip install` directly.
+
+---
+
+## Architecture rules
+
+- **DataCatalog pipeline has four layers** — keep them separate:
+  `DataSource` (metadata + config) → `URIResolver` (URI lookup) → `Driver`
+  (raw I/O) → `DataAdapter` (normalise/slice). Do not merge responsibilities.
+- **`@hydromt_step`** — any `Model` method callable from workflow YAML must
+  carry this decorator. All its positional args must be JSON-safe primitives.
+- **`NoDataStrategy`** (`RAISE`/`WARN`/`IGNORE`) must be accepted and honoured
+  in every data-access path via `exec_nodata_strat` in `hydromt/error.py`.
+- **`ModelComponent.write()`** must have no required positional arguments.
+- **Pydantic v2** for all config/validation. Use `AbstractBaseModel` (from
+  `hydromt/_abstract_base.py`) when you need polymorphic deserialization.
+- **Plugin contracts** — pluggable classes must be registered via entry-point
+  groups in `pyproject.toml` and pass subclass checks in `hydromt/plugins.py`.
+
+---
+
+## Conventions
+
+- **Docstrings**: NumPy format on all public API.
+- **Naming**:
+  - Model/Component/Driver subclasses: `<Name>Model`, `<Name>Component`, `<Name>Driver`.
+  - Arg meaning "catalog key or file path": `_fn` suffix (e.g. `dem_fn`).
+  - Internal modules: `_` prefix (`_utils/`, `_validators/`).
+  - Data type literal strings: PascalCase (`"RasterDataset"`, `"GeoDataFrame"`).
+- **Tests**: mirror source layout in `tests/`; fixtures in `conftest.py`;
+  `test_equal` helpers return `(bool, dict[str, str])` accumulating all errors.
+- **Optional deps**: guard with flags from `hydromt/_compat.py`; use
+  `pytest.mark.skipif(not HAS_X, ...)` in tests.
+
+---
+
+## Every PR must
+
+1. Update `docs/changelog.rst`.
+2. Include or update tests for changed behaviour.
+3. Pass `pixi run lint` and the test suite.
+
+---
+
+## Known gotchas
+
+- `hydromt/__init__.py` has intentional import-time side effects (Rasterio
+  excepthook patch, netCDF4 import ordering). Do not reorder or remove them.
+- Walrus-precedence bug in `data_catalog/adapters/rasterdataset.py`
+  (`_set_nodata`): `if nodata := metadata.nodata is not None:` assigns a bool.
+- `DataType` literal has a case mismatch: `type_def.py` uses `"DataSet"` /
+  `"GeoDataSet"` but factory/sources use `"Dataset"` / `"GeoDataset"`.
+- `contains_source` in `data_catalog.py` (~line 509) has suspicious boolean
+  inversion — verify carefully before refactoring.
+- Docs reference "black" and pip examples; actual tooling is ruff-format + pixi.
+- `_compat.py` Python <3.10 fallback is dead code; do not add more.

--- a/.github/prompts/hydromt-data-catalog.prompt.md
+++ b/.github/prompts/hydromt-data-catalog.prompt.md
@@ -1,0 +1,139 @@
+---
+mode: agent
+description: >
+  Expert guidance for working on the HydroMT DataCatalog subsystem:
+  adding or modifying DataSource types, Drivers, URIResolvers, and
+  DataAdapters. Auto-invoked when editing files under
+  hydromt/data_catalog/.
+applyTo: "hydromt/data_catalog/**"
+---
+
+# HydroMT DataCatalog skill
+
+You are working on the **HydroMT DataCatalog** subsystem
+(`hydromt/data_catalog/`). Follow the rules below precisely.
+
+---
+
+## Pipeline architecture (must preserve)
+
+Data access is a strict 4-layer pipeline. Never collapse layers:
+
+```
+DataSource  →  URIResolver  →  Driver  →  DataAdapter
+(metadata)     (URI lookup)   (raw I/O)  (normalise/slice)
+```
+
+| Layer | Base class | File | Responsibility |
+|---|---|---|---|
+| DataSource | `DataSource` (Pydantic) | `sources/data_source.py` | Metadata, config, `read_data()`, `to_file()`, `to_stac_catalog()` |
+| URIResolver | `URIResolver` (ABC) | `uri_resolvers/uri_resolver.py` | `resolve(source_config) -> list[URI]` |
+| Driver | `BaseDriver` (Pydantic) | `drivers/base_driver.py` | `read(uris, **kwargs)`, `write(path, data)` — raw I/O only |
+| DataAdapter | `DataAdapterBase` (Pydantic) | `adapters/data_adapter_base.py` | `rename`, `unit_add`, `unit_mult`, bbox/time/variable slicing |
+
+---
+
+## Creating a new DataSource type
+
+1. Subclass `DataSource` in `hydromt/data_catalog/sources/`.
+2. Add a Pydantic field `data_type: Literal["YourTypeName"]`.
+3. Implement `read_data(bbox, time_range, variables, …) -> XArray/GeoDataFrame`.
+4. Implement `to_file(data_root, …) -> DataSource`.
+5. Register in `sources/__init__.py` and `sources/factory.py`.
+6. Add entry-point `"YourTypeName" = "hydromt.data_catalog.sources.your_module:YourSource"` under `[project.entry-points."hydromt.catalogs"]` in `pyproject.toml` if externally discoverable.
+
+**`DataType` literal consistency**: the `data_type` string in your source must
+exactly match the key in `factory.py`. Note existing case-mismatch bug:
+`type_def.py` uses `"DataSet"`/`"GeoDataSet"` but factory uses
+`"Dataset"`/`"GeoDataset"` — be consistent with factory, not type_def.
+
+---
+
+## Creating a new Driver
+
+1. Subclass `BaseDriver` in `hydromt/data_catalog/drivers/`.
+2. Create a companion `DriverOptions(pydantic.BaseModel)` for driver-specific config.
+3. Implement `read(uris: list[str], **kwargs) -> DataType`.
+4. Implement `write(path: str | Path, data: DataType, …) -> None` if writable.
+5. Register in `drivers/__init__.py`.
+6. Add entry-point under `[project.entry-points."hydromt.drivers"]`.
+
+Drivers do **raw I/O only** — no renaming, unit conversion, or spatial slicing.
+All post-load normalisation belongs in the adapter layer.
+
+---
+
+## Creating a new URIResolver
+
+1. Subclass `URIResolver` in `hydromt/data_catalog/uri_resolvers/`.
+2. Implement `resolve(source_config) -> list[str]`.
+3. Register in `uri_resolvers/__init__.py`.
+4. Add entry-point under `[project.entry-points."hydromt.uri_resolvers"]`.
+
+---
+
+## NoDataStrategy — required everywhere
+
+All `read_data` implementations must accept a `handle_nodata: NoDataStrategy`
+parameter and call `exec_nodata_strat` from `hydromt/error.py` when data is
+absent:
+
+```python
+from hydromt.error import NoDataStrategy, exec_nodata_strat
+
+def read_data(self, …, handle_nodata: NoDataStrategy = NoDataStrategy.RAISE):
+    if data is None:
+        exec_nodata_strat(
+            f"No data found for {self.name}",
+            strategy=handle_nodata,
+        )
+        return None
+    return data
+```
+
+Never silently return `None` or raise without going through this helper.
+
+---
+
+## DataCatalog public API
+
+Core methods on `DataCatalog` (`hydromt/data_catalog/data_catalog.py`):
+
+| Method | Returns |
+|---|---|
+| `get_rasterdataset(source, …)` | `xr.Dataset` |
+| `get_geodataframe(source, …)` | `gpd.GeoDataFrame` |
+| `get_geodataset(source, …)` | `xr.Dataset` (vector cube) |
+| `get_dataset(source, …)` | `xr.Dataset` |
+| `get_dataframe(source, …)` | `pd.DataFrame` |
+| `export_data(data_root, …)` | writes files + catalog YAML |
+| `from_stac_catalog(stac_url)` | populates catalog from STAC |
+| `to_stac_catalog(path)` | writes STAC catalog |
+
+Use `add_source(name, source)` to register at runtime.
+
+### `contains_source` gotcha
+The `contains_source` method (~line 509) has a suspected boolean-inversion bug
+in provider/version logic. Verify its behaviour with a test before relying on it.
+
+---
+
+## Testing DataCatalog changes
+
+- Test files live in `tests/data_catalog/`.
+- Shared fixtures (sample rasters, GeoDataFrames, catalog YAML paths) in
+  `tests/conftest.py` — reuse them.
+- Mark tests needing external data: `@pytest.mark.integration`.
+- Guard optional-dep paths: `@pytest.mark.skipif(not HAS_S3FS, reason="s3fs not installed")`.
+- Run: `pixi run test tests/data_catalog/`
+
+---
+
+## Checklist before opening a PR
+
+- [ ] New source/driver/resolver registered in `__init__.py` and `pyproject.toml`.
+- [ ] `DataType` literal consistent with `factory.py` casing.
+- [ ] `NoDataStrategy` accepted and passed to `exec_nodata_strat`.
+- [ ] NumPy docstrings on all public methods.
+- [ ] Tests added under `tests/data_catalog/`.
+- [ ] `docs/changelog.rst` updated.

--- a/.github/prompts/hydromt-model.prompt.md
+++ b/.github/prompts/hydromt-model.prompt.md
@@ -1,0 +1,197 @@
+---
+mode: agent
+description: >
+  Expert guidance for working on HydroMT's Model abstraction and
+  ModelComponent system: adding model steps, implementing new components,
+  or changing Model base-class behaviour. Auto-invoked when editing files
+  under hydromt/model/.
+applyTo: "hydromt/model/**"
+---
+
+# HydroMT Model & Component skill
+
+You are working on the **HydroMT Model** subsystem (`hydromt/model/`). Follow
+the rules below precisely.
+
+---
+
+## Key classes and files
+
+| Class | File | Purpose |
+|---|---|---|
+| `Model` | `model/model.py` | Base class for all HydroMT models |
+| `ModelRoot` | `model/root.py` | Filesystem mode/path management |
+| `ModelComponent` | `model/components/base.py` | ABC for all model artefact components |
+| `HydromtModelSetup` | `_validators/model_config.py` | Pydantic validator for workflow YAML |
+| `@hydromt_step` | `model/steps.py` | Decorator gating YAML-callable methods |
+
+---
+
+## `Model` base class — core methods
+
+```python
+model.build(region, res, write=True)   # orchestrate build workflow
+model.update(…)                         # update existing model
+model.read()                            # read all components from disk
+model.write()                           # write all components to disk
+model.test_equal(other) -> (bool, dict) # compare two model instances
+```
+
+`model.components["name"]` gives access to registered `ModelComponent`
+instances. Components are registered by passing them to the `Model` constructor
+or via plugin entry points.
+
+---
+
+## Adding a new `@hydromt_step` method
+
+A step is a public `Model` method callable from workflow YAML:
+
+```python
+from hydromt.model.steps import hydromt_step
+
+class MyModel(Model):
+
+    @hydromt_step
+    def setup_dem(
+        self,
+        dem_fn: str,          # catalog key or file path
+        res: float = 100.0,
+        crs: int | None = None,
+    ) -> None:
+        """Set up DEM grid.
+
+        Parameters
+        ----------
+        dem_fn : str
+            Catalog key or path to DEM source.
+        res : float, optional
+            Target resolution in metres.
+        crs : int, optional
+            EPSG code. Defaults to model CRS.
+        """
+        ...
+```
+
+### Rules for `@hydromt_step` methods
+1. **All positional arguments must be JSON-safe**: `str`, `int`, `float`,
+   `bool`, `None`, `list`, `dict`. No xarray objects, GeoDataFrames, etc.
+2. Argument names ending in `_fn` are resolved as catalog keys or file paths
+   via the model's `DataCatalog`.
+3. The method is validated against the YAML step schema at workflow-load time
+   (`_validators/model_config.py`). Signature mismatches fail at load, not at
+   runtime.
+4. Do not decorate private helpers or utility methods with `@hydromt_step`.
+
+---
+
+## Implementing a new `ModelComponent`
+
+```python
+from hydromt.model.components.base import ModelComponent
+
+class MyComponent(ModelComponent):
+    # Required — declare component data type
+    _data: MyDataType | None = None
+
+    def read(self, fn: str = "mydata.nc", **kwargs) -> None:
+        """Read component from disk."""
+        ...
+
+    def write(self, fn: str = "mydata.nc", **kwargs) -> None:
+        """Write component to disk.
+
+        IMPORTANT: write() must have NO required positional arguments.
+        It is called as component.write() by Model.write().
+        """
+        ...
+
+    def test_equal(self, other: "MyComponent") -> tuple[bool, dict[str, str]]:
+        """Return (all_equal, {field: error_message}) accumulating all diffs."""
+        errors: dict[str, str] = {}
+        # ... compare fields, add to errors dict
+        return len(errors) == 0, errors
+
+    def close(self) -> None:
+        """Release any open file handles."""
+        ...
+```
+
+### `ModelComponent` contract checklist
+- [ ] `write()` has **no required positional args**.
+- [ ] `test_equal()` returns `tuple[bool, dict[str, str]]` and accumulates
+  all errors rather than raising on the first difference.
+- [ ] `read()` and `write()` use `self._root` (a `ModelRoot`) for FS paths.
+- [ ] Register via entry-point `[project.entry-points."hydromt.components"]`
+  in `pyproject.toml` if intended to be discoverable by downstream plugins.
+
+---
+
+## Workflow YAML structure (for reference)
+
+```yaml
+modeltype: MyModel
+global:
+  data_libs: [artifact_data]
+  region: {geom: path/to/region.geojson}
+build:
+  - setup_dem:
+      dem_fn: merit_hydro
+      res: 100.0
+  - setup_rivers:
+      river_fn: rivers_glob_v1
+```
+
+Each step name must match a `@hydromt_step`-decorated method on the model.
+Step arguments are validated by `HydromtModelSetup` against the method
+signature.
+
+---
+
+## `ModelRoot` — filesystem state
+
+`model._root` is a `ModelRoot` instance managing:
+- `model._root.path` — absolute root directory.
+- `model._root.mode` — `"r"` (read-only), `"w"` (new/overwrite), `"w+"` (append).
+
+Access paths for components via:
+```python
+component_path = self._root.path / "subdir" / filename
+```
+
+Do not hardcode absolute paths; always go through `_root`.
+
+---
+
+## Testing model changes
+
+- Test files: `tests/model/`, `tests/components/`.
+- Fixtures: `tests/conftest.py` (shared model instances, temp dirs).
+- `test_equal` pattern — write tests that call `model.test_equal(other)` and
+  assert `equal is True` with `errors == {}`.
+- Mark tests requiring disk I/O with `tmp_path` fixture (pytest built-in).
+- Run: `pixi run test tests/model/ tests/components/`
+
+---
+
+## Domain vocabulary
+
+| Term | Meaning in model context |
+|---|---|
+| `_fn` arg suffix | Catalog key or file path resolved via `DataCatalog` |
+| `region` | Spatial bounding geometry/mask defining the model domain |
+| `res` | Spatial resolution (usually in metres or degrees) |
+| `flwdir` | Flow direction grid (D8/LDD encoding) |
+| `basid` | Sub-basin identifier integer |
+| PET | Potential evapotranspiration (see `model/processes/meteo.py`) |
+
+---
+
+## Checklist before opening a PR
+
+- [ ] New `@hydromt_step` methods have only JSON-safe arg types.
+- [ ] `ModelComponent.write()` has no required positional args.
+- [ ] `test_equal()` accumulates errors into a dict rather than raising.
+- [ ] NumPy docstrings on all public methods.
+- [ ] Tests added under `tests/model/` or `tests/components/`.
+- [ ] `docs/changelog.rst` updated.

--- a/.github/prompts/hydromt-plugin.prompt.md
+++ b/.github/prompts/hydromt-plugin.prompt.md
@@ -1,0 +1,199 @@
+---
+mode: agent
+description: >
+  Expert guidance for working on the HydroMT plugin system: registering new
+  plugins (models, components, drivers, catalogs, URI resolvers), writing
+  downstream plugin packages, and understanding plugin discovery and
+  validation. Auto-invoked when editing hydromt/plugins.py or
+  pyproject.toml entry-point sections.
+applyTo: "hydromt/plugins.py"
+---
+
+# HydroMT Plugin system skill
+
+You are working on the **HydroMT plugin system** (`hydromt/plugins.py`). This
+system enables downstream packages (`hydromt_sfincs`, `hydromt_wflow`, …) to
+extend HydroMT by registering their own models, components, drivers, and more.
+
+---
+
+## Five plugin entry-point groups
+
+| Group | Base class | Registered by |
+|---|---|---|
+| `hydromt.models` | `hydromt.Model` | Downstream model packages |
+| `hydromt.components` | `hydromt.ModelComponent` | Core + downstream |
+| `hydromt.drivers` | `hydromt.data_catalog.drivers.BaseDriver` | Core + downstream |
+| `hydromt.catalogs` | `hydromt.data_catalog.sources.DataSource` | Core + downstream |
+| `hydromt.uri_resolvers` | `hydromt.data_catalog.uri_resolvers.URIResolver` | Core + downstream |
+
+---
+
+## Registering a plugin in `pyproject.toml`
+
+```toml
+[project.entry-points."hydromt.models"]
+"MyModel" = "my_package.models.my_model:MyModel"
+
+[project.entry-points."hydromt.components"]
+"MyComponent" = "my_package.components.my_component:MyComponent"
+
+[project.entry-points."hydromt.drivers"]
+"MyDriver" = "my_package.drivers.my_driver:MyDriver"
+
+[project.entry-points."hydromt.catalogs"]
+"MyDataSource" = "my_package.sources.my_source:MyDataSource"
+
+[project.entry-points."hydromt.uri_resolvers"]
+"MyResolver" = "my_package.resolvers.my_resolver:MyResolver"
+```
+
+The key string (e.g. `"MyModel"`) is the **plugin name** used at runtime. It
+must be unique across all installed packages for a given group.
+
+---
+
+## Multiple names for one class (`__hydromt_eps__`)
+
+If a class should be discoverable under more than one name (e.g. for backwards
+compatibility), declare:
+
+```python
+class MyDriver(BaseDriver):
+    __hydromt_eps__: ClassVar[list[str]] = ["MyDriver", "my_driver_legacy"]
+```
+
+And register both names in `pyproject.toml`. The plugin registry will validate
+that both names point to the same class.
+
+---
+
+## Plugin discovery at runtime
+
+`hydromt/plugins.py` builds a global `PLUGINS` registry object. It:
+
+1. Calls `importlib.metadata.entry_points(group="hydromt.*")` for each group.
+2. Loads each entry point and checks `issubclass(cls, expected_base)`.
+3. Raises `PluginError` on duplicate names or subclass failures.
+4. Exposes `PLUGINS.models`, `PLUGINS.components`, `PLUGINS.drivers`, etc.
+
+`PLUGINS` is importable from `hydromt` directly:
+```python
+from hydromt import PLUGINS
+my_model_cls = PLUGINS.models["MyModel"]
+```
+
+### Plugin validation rules (enforced at import time)
+- The registered class **must** be a subclass of the expected base.
+- Plugin names **must** be unique within their group.
+- If `__hydromt_eps__` is declared, all listed names must be registered and
+  resolve to the same class.
+
+---
+
+## Writing a downstream plugin package (checklist)
+
+When creating a new downstream HydroMT plugin package:
+
+```
+my_package/
+  __init__.py
+  models/
+    my_model.py          # subclasses hydromt.Model
+  components/            # optional, if adding new component types
+  drivers/               # optional, if adding custom I/O drivers
+  sources/               # optional, if adding new DataSource types
+pyproject.toml           # registers entry points
+```
+
+**`pyproject.toml` minimum for a model plugin:**
+
+```toml
+[project]
+name = "hydromt-mypackage"
+dependencies = ["hydromt>=X.Y"]
+
+[project.entry-points."hydromt.models"]
+"MyModel" = "my_package.models.my_model:MyModel"
+
+[build-system]
+requires = ["flit_core>=3.2"]
+build-backend = "flit_core.buildapi"
+```
+
+---
+
+## `AbstractBaseModel` — polymorphic Pydantic deserialization
+
+For Pydantic models that need to deserialize from a `"name"` discriminator field
+(e.g. driver options, resolver configs), subclass `AbstractBaseModel`:
+
+```python
+from hydromt._abstract_base import AbstractBaseModel
+
+class MyDriverOptions(AbstractBaseModel):
+    name: Literal["MyDriver"] = "MyDriver"
+    compression: str = "lzw"
+```
+
+`AbstractBaseModel` enables `Union[DriverOptionsA, DriverOptionsB]` to
+deserialize correctly by inspecting the `"name"` field.
+
+---
+
+## Testing plugin registration
+
+Tests for plugin discovery live in `tests/` (look for `test_plugins.py` or
+`test_*plugin*`). When adding a new plugin:
+
+1. Verify it is discoverable: `PLUGINS.models["MyModel"]` should not raise.
+2. Verify subclass check: `issubclass(PLUGINS.models["MyModel"], Model)`.
+3. Test duplicate-name rejection if applicable.
+
+Run: `pixi run test tests/` (or target the specific test file).
+
+---
+
+## Optional dependency guards
+
+If a plugin requires an optional dependency, guard the import:
+
+```python
+# hydromt/_compat.py pattern
+try:
+    import s3fs
+    HAS_S3FS = True
+except ImportError:
+    HAS_S3FS = False
+```
+
+Then in the plugin:
+```python
+from hydromt._compat import HAS_S3FS
+
+class S3Driver(BaseDriver):
+    def read(self, uris, **kwargs):
+        if not HAS_S3FS:
+            raise ImportError("s3fs is required for S3Driver. Install with: pip install s3fs")
+        ...
+```
+
+And in tests:
+```python
+import pytest
+from hydromt._compat import HAS_S3FS
+
+@pytest.mark.skipif(not HAS_S3FS, reason="s3fs not installed")
+def test_s3_driver(): ...
+```
+
+---
+
+## Checklist before opening a PR
+
+- [ ] Entry points registered in `pyproject.toml` under correct group.
+- [ ] Class is a subclass of the expected base (verified by `issubclass`).
+- [ ] `__hydromt_eps__` declared if multiple names are needed.
+- [ ] Optional deps guarded via `_compat.py` + `pytest.mark.skipif`.
+- [ ] Plugin discovery tested (assert `PLUGINS.group["Name"]` works).
+- [ ] `docs/changelog.rst` updated.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: code-review
+description: Perform a code review of the current session's changes against HydroMT conventions. Use when the user requests a code review, clicks the Run Code Review button, or asks to review changes.
+---
+
+# Code Review (HydroMT)
+
+You are a coding agent acting as a code reviewer for the **HydroMT** repository.
+Review changed files and surface concrete, actionable issues as inline comments.
+
+---
+
+## Workflow
+
+1. Identify changed files: `git diff --name-only HEAD` and `git status --short`.
+2. For each changed file read the relevant ranges and review them against the codebase.
+3. For every issue found, use the `addComment` tool to attach a comment to the exact file URI and line range.
+4. Do **not** modify files, commit, or push. Output is review comments only.
+5. When all changed files are reviewed, stop.
+
+---
+
+## HydroMT-specific review checklist
+
+Work through these checks for **every changed file** before moving on.
+
+### Architecture invariants
+
+- [ ] **DataCatalog pipeline layers are not collapsed.** `DataSource`, `URIResolver`, `Driver`, and `DataAdapter` must stay separate — flag any method that does raw I/O *and* normalisation, or resolves URIs *and* reads.
+- [ ] **`@hydromt_step` usage.** Any new `Model` method intended to be called from workflow YAML must carry `@hydromt_step`. All its positional args must be JSON-safe primitives (`str`, `int`, `float`, `bool`, `None`, `list`, `dict`) — flag objects, xarray types, GeoDataFrames, etc.
+- [ ] **`NoDataStrategy` honoured.** New data-access paths must accept `handle_nodata: NoDataStrategy` and call `exec_nodata_strat` from `hydromt/error.py`. Flag silent returns of `None` or bare raises.
+- [ ] **`ModelComponent.write()` signature.** `write()` must have no required positional arguments. Flag any required positional params added to `write`.
+- [ ] **Plugin contracts intact.** New pluggable classes must declare the correct entry-point group and pass subclass checks. Flag missing `__hydromt_eps__` when multiple names are needed.
+- [ ] **Pydantic v2 only.** No new plain dataclasses or `TypedDict` for validated config — use `pydantic.BaseModel` or `AbstractBaseModel`.
+
+### Correctness & bugs
+
+- [ ] **Walrus-operator precedence.** Flag any `if x := expr is not None:` — the `is not None` binds tighter than `:=`, assigning a bool. Use `if (x := expr) is not None:` instead.
+- [ ] **`DataType` literal casing.** Any new `data_type` literal must match `factory.py` casing (`"Dataset"`, `"GeoDataset"`), **not** `type_def.py` (`"DataSet"`, `"GeoDataSet"`).
+- [ ] **Import-time side effects in `__init__.py`.** Do not reorder or remove the Rasterio `sys.excepthook` patch or the `netCDF4` import workaround.
+- [ ] **Optional-dep guards.** Code that imports optional packages (`s3fs`, `adlfs`, `pyet`, …) must check the `HAS_*` flag from `hydromt/_compat.py` and raise a helpful `ImportError` if absent.
+
+### Conventions
+
+- [ ] **NumPy docstrings** on all public functions/methods/classes. Flag missing or `Args:`-style docstrings on public API.
+- [ ] **`_fn` suffix** on arguments that accept a catalog key or file path.
+- [ ] **Naming conventions**: model subclasses `<Name>Model`, driver subclasses `<Name>Driver`, component subclasses `<Name>Component`.
+- [ ] **Type hints** on all public function signatures.
+
+### Tests & docs
+
+- [ ] **Tests cover the change.** If behaviour changed, flag missing or insufficient test coverage.
+- [ ] **Test structure mirrors source** (`tests/data_catalog/` for catalog changes, etc.). Flag misplaced tests.
+- [ ] **`test_equal` pattern**: helpers that compare model state must return `tuple[bool, dict[str, str]]` accumulating all diffs — not raise on first failure.
+- [ ] **`docs/changelog.rst` updated.** Flag if the PR modifies user-facing behaviour but `changelog.rst` is not touched.
+- [ ] **No modifications to `data/catalogs/predefined_catalogs.yml`** unless that is the explicit goal.
+
+### General
+
+- [ ] Correctness and edge cases
+- [ ] Security and data-handling issues
+- [ ] Code clarity and consistency with surrounding code
+
+---
+
+## Comment quality
+
+- Prefer **fewer, higher-signal** comments over stylistic nits.
+- Each comment must explain *what* is wrong and *why* it matters.
+- Be specific to the exact line range — do not leave per-file summary comments.
+- Do not comment on things that are already correct.

--- a/.github/skills/pr/SKILL.md
+++ b/.github/skills/pr/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: pr
+description: Create a pull request for the current session following HydroMT conventions. Use when the user wants to open a PR, says "create PR", "open a pull request", or "submit my changes".
+---
+
+# Create Pull Request (HydroMT)
+
+Create a pull request for the current session's changes, following HydroMT's commit
+conventions, PR template, and changelog requirement.
+
+Use the **GitHub MCP server** to create the PR — do NOT use the `gh` CLI.
+
+---
+
+## Workflow
+
+### 1. Run hygiene checks
+
+```bash
+pixi run lint
+```
+
+Fix any lint errors before proceeding. Do **not** skip pre-commit hooks.
+
+### 2. Commit any uncommitted changes
+
+If `git status --short` shows uncommitted changes, use the `/commit` skill.
+
+**HydroMT commit convention** (inferred from `git log --oneline -20`):
+- Mix of Conventional Commits (`fix:`, `feat:`, `chore:`, `docs:`) and free-form.
+- Subject ≤ 72 characters.
+- Reference the related issue number when one exists, e.g. `fix: ... (fixes #1234)`.
+- PR number is appended automatically by GitHub merge — do not add it manually.
+
+Always include the Co-authored-by trailer:
+```
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+### 3. Push the branch
+
+Push to `origin` if not already pushed:
+```bash
+git push -u origin HEAD
+```
+
+### 4. Verify the changelog
+
+Check that `docs/changelog.rst` has been updated. If the change is user-facing
+and the file was not touched, **stop and ask the user** to add a changelog entry
+before proceeding.
+
+### 5. Determine the base branch
+
+- Default base: `main`.
+- If the current branch name starts with `release/`, base onto `main` and note
+  this in the PR description.
+
+### 6. Write the PR title
+
+Follow the repository convention:
+- Conventional prefix when applicable: `fix:`, `feat:`, `docs:`, `chore:`.
+- Or free-form short summary matching existing commit style.
+- ≤ 72 characters, no trailing period.
+
+### 7. Write the PR description
+
+Fill in the HydroMT PR template sections:
+
+```markdown
+## Issue addressed
+
+Fixes #<issue number>   <!-- omit if no issue -->
+
+## Explanation
+
+<What changed, why, and any design decisions made.>
+
+## General Checklist
+
+- [x] Updated tests or added new tests
+- [x] Branch is up to date with `main`
+- [x] Tests & pre-commit hooks pass
+- [x] Updated documentation
+- [x] Updated changelog.rst
+
+## Data/Catalog checklist   <!-- include only if data_catalog/ files changed -->
+
+- [x] `data/catalogs/predefined_catalogs.yml` has not been modified.
+- [x] None of the old `data_catalog.yml` files have been changed
+- [x] `data/changelog.rst` has been updated   <!-- if catalog files changed -->
+```
+
+Omit the **Data/Catalog checklist** section entirely if no files under
+`hydromt/data_catalog/` or `data/` were changed.
+
+Mark checklist items `[ ]` (unchecked) for anything that has **not** been done,
+so the reviewer knows what is still outstanding.
+
+### 8. Create the pull request
+
+Use the GitHub MCP server `create_pull_request` tool with:
+- `owner`: `Deltares`
+- `repo`: `hydromt`
+- `head`: current branch name
+- `base`: target branch (default `main`)
+- `title`: PR title from step 6
+- `body`: PR description from step 7
+- `draft`: `false` unless the user explicitly asks for a draft
+
+After creation, report the PR URL to the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,209 @@
+# HydroMT — Agent Guide
+
+HydroMT is a Python framework for building and analysing hydrology/hydraulics
+models. The core library (this repo) provides the data catalogue, model
+abstraction, GIS utilities, and a plugin system that downstream packages
+(`hydromt_sfincs`, `hydromt_wflow`, …) extend.
+
+---
+
+## Essential commands
+
+```bash
+# Install / sync environment (pixi manages all deps + lockfile)
+pixi install
+
+# Run tests (default env)
+pixi run test
+
+# Run tests with coverage
+pixi run test-cov
+
+# Lint (runs pre-commit on all files)
+pixi run lint
+
+# Type-check
+pixi run mypy
+
+# Build docs locally
+pixi run docs
+```
+
+> **Never use `pip install` directly.** All dependency management goes through
+> `pixi`. The lockfile `pixi.lock` is committed; update it with
+> `pixi update` when adding or bumping deps in `pyproject.toml`.
+
+---
+
+## Repo layout
+
+```
+hydromt/
+  data_catalog/       # DataCatalog + 4-layer pipeline (source/resolver/driver/adapter)
+    sources/          # DataSource subclasses (RasterDataset, GeoDataFrame, …)
+    drivers/          # I/O drivers (rasterio, geodataframe, zarr, …)
+    uri_resolvers/    # URI resolution (ConventionResolver, …)
+    adapters/         # Post-load normalisation (unit convert, rename, slice)
+  model/
+    model.py          # Model base class
+    components/       # ModelComponent ABC + built-in implementations
+    processes/        # Domain helpers (basin_mask, meteo, …)
+  gis/                # Raster/vector GIS utilities
+  stats/              # Statistical helpers
+  _validators/        # Pydantic validators for workflow YAML
+  _utils/             # Internal helpers (not public API)
+  typing/             # Typed aliases and type definitions
+  cli/main.py         # CLI entry points (build, update, check, export)
+  plugins.py          # Plugin discovery via entry points
+  error.py            # NoDataStrategy enum + exec_nodata_strat
+  log.py              # Logging helpers
+
+tests/                # Mirrors hydromt/ layout; shared fixtures in conftest.py
+docs/                 # Sphinx docs; dev guides in docs/dev/
+data/catalogs/        # Predefined data catalogue YAML files
+.github/workflows/    # CI pipelines (tests, lint, docs, release, sonar)
+pyproject.toml        # All project + tooling + pixi config
+```
+
+---
+
+## Architecture invariants — do not violate
+
+### 1. Plugin contracts
+Every pluggable class (`Model`, `ModelComponent`, `BaseDriver`, `URIResolver`,
+`DataSource`) must:
+- Be discoverable via its entry-point group (`hydromt.models`,
+  `hydromt.components`, `hydromt.drivers`, `hydromt.catalogs`,
+  `hydromt.uri_resolvers`).
+- Pass the subclass check performed by `hydromt/plugins.py`.
+- Declare `__hydromt_eps__: ClassVar[list[str]]` when registering multiple names.
+
+### 2. DataCatalog pipeline split
+Keep the four layers separate. Do not collapse Driver + Adapter logic or merge
+Resolver concerns into a Source:
+- **DataSource** — owns metadata, Pydantic config, `read_data()`/`to_file()`.
+- **URIResolver** — translates source config into concrete URIs.
+- **Driver** — raw I/O only (`read(uris)` / `write(path, data)`).
+- **DataAdapter** — post-load normalisation only (rename, unit add/mult, bbox/time/var slice).
+
+### 3. `@hydromt_step` decorator
+Every `Model` method intended to be callable from a workflow YAML **must** be
+decorated with `@hydromt_step`. All positional arguments must be JSON-safe
+primitives (`str`, `int`, `float`, `bool`, `None`, `list`, `dict`). Methods
+decorated this way are validated at workflow-load time.
+
+### 4. `NoDataStrategy`
+All data-access paths must accept and honour the `NoDataStrategy` enum
+(`RAISE`, `WARN`, `IGNORE`). Never silently swallow missing-data errors
+without passing through `exec_nodata_strat`.
+
+### 5. `ModelComponent.write()` signature
+`write()` on any `ModelComponent` subclass must have **no required positional
+arguments** — it is called as `component.write()` by the model's batch writer.
+
+### 6. Pydantic v2 throughout
+All config/validation models use **Pydantic v2**. Do not introduce dataclasses
+or `TypedDict` for validated config; use `pydantic.BaseModel` or
+`AbstractBaseModel` (for polymorphic deserialization by `"name"` field).
+
+---
+
+## Conventions
+
+### Naming
+| Thing | Convention | Example |
+|---|---|---|
+| Model subclass | `<Name>Model` | `SfincsModel` |
+| Driver subclass | `<Format>Driver` | `RasterioDriver` |
+| Component subclass | `<Name>Component` | `GridComponent` |
+| Arg meaning "catalog key or file path" | `_fn` suffix | `dem_fn` |
+| Internal/private module | `_` prefix | `_utils/`, `_validators/` |
+| Data type literal strings | PascalCase | `"RasterDataset"`, `"GeoDataFrame"` |
+
+### Typing
+- Add type hints to all public functions/methods.
+- Use typed aliases from `hydromt/typing/type_def.py` for catalog-specific types.
+- Optional deps are guarded via `hydromt/_compat.py` flags (`HAS_S3FS`, etc.).
+
+### Docstrings
+NumPy docstring format is required for all public API. Example:
+
+```python
+def my_func(x: int, y: str) -> bool:
+    """Short one-line summary.
+
+    Longer description if needed.
+
+    Parameters
+    ----------
+    x : int
+        Description of x.
+    y : str
+        Description of y.
+
+    Returns
+    -------
+    bool
+        Description of return value.
+    """
+```
+
+### Tests
+- Mirror the source layout: `tests/data_catalog/`, `tests/model/`, etc.
+- Fixtures go in `tests/conftest.py` (shared) or local `conftest.py`.
+- Use `pytest.mark.integration` for tests requiring external resources.
+- Use `pytest.mark.skipif(not HAS_X, reason="...")` for optional-dep tests.
+- `test_equal` helpers return `tuple[bool, dict[str, str]]` accumulating all
+  errors rather than raising on the first failure.
+
+---
+
+## PR checklist (enforced by PR template)
+
+Every PR must:
+1. Update `docs/changelog.rst` with a note under the correct version header.
+2. Include or update tests for changed behaviour.
+3. Pass `pixi run lint` (ruff + ruff-format) and the test suite.
+4. Not modify `data/catalogs/predefined_catalogs.yml` unless that is the
+   explicit goal of the PR.
+
+---
+
+## Gotchas
+
+| # | File | Issue |
+|---|---|---|
+| 1 | `hydromt/data_catalog/adapters/rasterdataset.py` | Walrus-precedence bug: `if nodata := metadata.nodata is not None:` assigns a `bool`, not the nodata value. Check before touching this method. |
+| 2 | `hydromt/typing/type_def.py` vs `sources/factory.py` | `DataType` literal uses `"DataSet"`/`"GeoDataSet"` but factory/source files use `"Dataset"`/`"GeoDataset"` — case mismatch. |
+| 3 | `hydromt/data_catalog/data_catalog.py` ~line 509 | `contains_source` provider/version lookup logic appears to invert a boolean — verify carefully before refactoring. |
+| 4 | `hydromt/_compat.py` | Python <3.10 entry-point fallback is dead code; project requires >=3.11. Do not add more compat branches. |
+| 5 | `hydromt/__init__.py` | Contains intentional import-time side effects: patches a Rasterio `sys.excepthook` bug and forces `netCDF4` import ordering. Do not reorder or remove these. |
+| 6 | `docs/dev/core_dev/code_conventions.rst` | Docs still reference "black" and pip-first examples; actual tooling is `ruff-format` + pixi. Ignore the docs, follow the tooling. |
+| 7 | `pyproject.toml` pixi tasks | `pypi-git-resore` (missing `t`) — typo in task name; do not rely on that task until fixed. |
+
+---
+
+## Domain vocabulary
+
+| Term | Meaning |
+|---|---|
+| `flwdir` | Flow direction grid (D8, LDD, or nextxy encoding) |
+| `basid` | Basin/sub-basin identifier integer |
+| PET | Potential evapotranspiration |
+| LDD | Local drain direction (PCRaster encoding) |
+| `_fn` arg suffix | "catalog key or file path" — resolves via `DataCatalog.get_*` |
+| `NoDataStrategy` | RAISE / WARN / IGNORE policy for missing data |
+| `hydromt_step` | Decorator that gates a method for YAML workflow invocation |
+| STAC | SpatioTemporal Asset Catalog — supported export/import format for DataCatalog |
+
+---
+
+## Release process (brief)
+
+1. Releases live on `release/vX.Y` branches.
+2. Use `.github/workflows/create-release-branch.yml` to cut a release branch.
+3. Use `.github/workflows/create-release.yml` to tag and publish.
+4. PyPI publish is gated by `.github/workflows/publish-pypi.yml`.
+5. A `record-release` PR automatically merges the release back to `main`.
+
+Do not manually edit `hydromt/__init__.py` version; the release scripts manage it.

--- a/ARCHITECTURE_REPORT.md
+++ b/ARCHITECTURE_REPORT.md
@@ -1,0 +1,260 @@
+# HydroMT Repository Architecture & Conventions Report (AI-agent oriented)
+
+> Scope: direct inspection of source, tests, docs, and CI config in this repo (not README-only).
+> Confidence markers: **High** (direct code/config), **Medium** (inference from behavior/docs), **Low** (explicitly uncertain).
+
+---
+
+## 1) Structure & entry points
+
+## High-level module/package map
+
+- `hydromt/` is the core library.
+  - Core packages by size: `data_catalog` (largest), `model`, `gis`, `stats`, plus internal helper layers `_utils`, `_validators`, `typing`.
+    - Evidence: `hydromt/` tree and per-folder file counts from direct listing (`hydromt/data_catalog`, `hydromt/model`, etc.; `pyproject.toml`).
+- `tests/` mirrors package domains (`data_catalog`, `model`, `gis`, `components`, etc.), with heavy shared fixture setup in `tests/conftest.py`.
+  - Evidence: `tests/` tree, `tests/conftest.py`.
+- `docs/` includes end-user + dev docs, architecture docs, release process docs, and Sphinx build config.
+  - Evidence: `docs/dev/**`, `docs/conf.py`.
+- `data/catalogs/` stores predefined catalog YAMLs used by `DataCatalog`.
+  - Evidence: `data/`, `hydromt/data_catalog/predefined_catalog.py`.
+- `.github/workflows/` has CI/testing, docs, release, PyPI publish, downstream compatibility, and maintenance automations.
+  - Evidence: `.github/workflows/tests.yml`, `docs.yml`, `create-release.yml`, `publish-pypi.yml`, etc.
+
+## Main entry points (CLI/public API)
+
+- CLI entrypoint:
+  - Script: `hydromt` -> `hydromt.cli.main:main`.
+  - Commands: `build`, `update`, `check`, `export`.
+  - Evidence: `pyproject.toml` `[project.scripts]`; `hydromt/cli/main.py`.
+- Public Python API exported from package root:
+  - `DataCatalog`, `Model`, `hydromt_step`, `PLUGINS`, subpackages.
+  - Evidence: `hydromt/__init__.py`.
+- Plugin/public extension entrypoint groups:
+  - `hydromt.models`, `hydromt.components`, `hydromt.drivers`, `hydromt.catalogs`, `hydromt.uri_resolvers`.
+  - Evidence: `pyproject.toml` `[project.entry-points."..."]`, `hydromt/plugins.py`.
+
+## Conceptual dependency/import graph
+
+Core flow is layered:
+
+1. **CLI** (`hydromt/cli/main.py`) -> loads model plugin + workflow YAML -> calls `Model.build/update` or `DataCatalog.export_data`.
+2. **Model** (`hydromt/model/model.py`) owns:
+   - `ModelRoot` for FS mode/state,
+   - `DataCatalog` for data access,
+   - `ModelComponent`s for model artifacts.
+3. **DataCatalog** (`hydromt/data_catalog/data_catalog.py`) resolves source definitions -> delegates to:
+   - `DataSource` (`sources/data_source.py`)
+   - `URIResolver` (`uri_resolvers/uri_resolver.py`)
+   - `Driver` (`drivers/base_driver.py`)
+   - `DataAdapter` (`adapters/data_adapter_base.py`)
+4. **Plugin registry** (`hydromt/plugins.py`) discovers extensible classes via Python entry points + `__hydromt_eps__`.
+
+This is the central architecture to preserve when changing behavior.
+
+---
+
+## 2) Architecture & design decisions
+
+## Core abstractions/patterns
+
+- **Plugin architecture via entry points** with runtime validation against expected base classes and duplicate-name detection.
+  - Evidence: `hydromt/plugins.py`.
+- **Pydantic-based typed config models** in extension layers:
+  - `AbstractBaseModel` supports polymorphic deserialization by `"name"` field.
+  - `BaseDriver` and related options use typed Pydantic models.
+  - Workflow validator (`HydromtModelSetup`) binds functions/signatures.
+  - Evidence: `hydromt/_abstract_base.py`, `hydromt/data_catalog/drivers/base_driver.py`, `hydromt/_validators/model_config.py`.
+- **Workflow-step gating**:
+  - Only methods decorated with `@hydromt_step` are callable from workflow YAML.
+  - Enforced at runtime (`_validate_steps`) and validator level.
+  - Evidence: `hydromt/model/steps.py`, `hydromt/_utils/steps_validator.py`, `hydromt/_validators/model_config.py`.
+- **Data access pipeline split** (resolver/driver/adapter):
+  - Resolver finds URIs, driver loads raw data, adapter normalizes/slices/units.
+  - Evidence: `hydromt/data_catalog/sources/rasterdataset.py`, `.../uri_resolvers/convention_resolver.py`, `.../drivers/raster/rasterio_driver.py`, `.../adapters/rasterdataset.py`.
+
+## Notable design decisions + tradeoffs
+
+- **Strong extensibility over simplicity**:
+  - Many base types + plugin discovery means flexibility but more indirection.
+  - Evidence: `hydromt/plugins.py`, `docs/dev/architecture/architecture.rst`.
+- **Runtime strategy-based no-data handling** (`RAISE/WARN/IGNORE`) instead of a single exception policy.
+  - Good for batch export/use-cases; increases branching complexity.
+  - Evidence: `hydromt/error.py`, `data_catalog` methods using `handle_nodata`.
+- **Cross-platform and cloud-first IO** through `fsspec` + protocol-aware providers.
+  - Evidence: drivers/sources; `hydromt/data_catalog/drivers/base_driver.py`.
+- **Release process intentionally branch-family based** (`release/vX.Y`) with automated record-back PR flow.
+  - Evidence: `.github/workflows/create-release*.yml`, `docs/dev/core_dev/release.rst`.
+
+## Deviations from “obvious” approach
+
+- `hydromt/__init__.py` patches a Rasterio `sys.excepthook` bug and forces `netCDF4` import ordering to avoid xarray issue.
+  - Non-obvious import-time side effects, intentionally defensive.
+  - Evidence: `hydromt/__init__.py`.
+- `exec_nodata_strat` introspects caller module/logger dynamically.
+  - Non-obvious logging behavior based on call stack.
+  - Evidence: `hydromt/error.py`, tests `tests/_typing/test_error_*.py`.
+
+---
+
+## 3) Conventions
+
+## Naming conventions
+
+- Stated conventions: PEP8-ish, CamelCase classes, snake_case methods, NumPy docstrings.
+  - Evidence: `docs/dev/core_dev/code_conventions.rst`, `docs/dev/architecture/conventions.rst`.
+- In practice:
+  - Internal modules often prefixed with `_` for helper/private semantics (`_utils`, `_validators`, `_compat`).
+  - Data catalog type names use PascalCase strings (`RasterDataset`, `GeoDataFrame`, etc.).
+  - Evidence: package structure + class names in `data_catalog/sources/*.py`.
+
+## Typing conventions
+
+- Strong type hints throughout core interfaces (`Model`, `DataCatalog`, drivers/adapters/sources).
+- Pydantic v2 is heavily used for config/runtime model validation.
+- Typed aliases and typed models in `hydromt/typing`.
+  - Evidence: `pyproject.toml` (`pydantic>=2.11`), `hydromt/typing/type_def.py`, `hydromt/_validators/model_config.py`, `drivers/base_driver.py`.
+
+## Testing conventions
+
+- Test structure mostly mirrors source package layout.
+- Pytest fixtures are extensive and centralized in `tests/conftest.py`.
+- Mostly function-style tests; selective class-based grouping (e.g., driver option tests).
+- Markers used: `integration`, `manual`, plus many `skipif` for optional deps.
+  - Evidence: `pyproject.toml` `[tool.pytest.ini_options]`, `tests/conftest.py`, `tests/data_catalog/test_data_catalog.py`, `tests/data_catalog/drivers/test_base_driver.py`.
+
+## Error handling / logging patterns
+
+- Explicit `NoDataStrategy` enum used per call path.
+- Logging is centralized under `hydromt` root logger with helper context manager `log.to_file(...)`.
+- Build/update workflows write `hydromt.log`.
+  - Evidence: `hydromt/error.py`, `hydromt/log.py`, `hydromt/model/model.py`, `hydromt/cli/main.py`.
+
+## Docstring/comment style
+
+- Declared style: NumPy docstring format.
+- Mostly followed; but some files/functions have sparse or inconsistent docs (“Args:” placeholders, typos).
+  - Evidence: `docs/dev/core_dev/code_conventions.rst`; compare with `hydromt/data_catalog/sources/rasterdataset.py` (`Args:` placeholders), misc typos in comments/docs.
+
+---
+
+## 4) Tooling & workflows
+
+## Build/dependency management
+
+- Build backend: **flit** (`flit_core`).
+- Dependency definition: `pyproject.toml`.
+- Locking/runtime envs/tasks: **pixi** (`pixi.lock` committed).
+- Pre-commit hooks: ruff + ruff-format + hygiene hooks + nbstripout.
+  - Evidence: `pyproject.toml`, `pixi.lock`, `.pre-commit-config.yaml`.
+
+## Local run workflows (from config)
+
+- CLI: `hydromt ...`
+- Tests: `pixi run test`, `pixi run test-cov`
+- Lint: `pixi run lint` (pre-commit all files)
+- Type-check: `pixi run mypy`
+- Docs: `pixi run docs` / `pixi run doc`
+  - Evidence: `pyproject.toml` `[tool.pixi.feature.*.tasks]`.
+
+## CI/CD pipeline structure
+
+- PR/push pipelines:
+  - Linting: `.github/workflows/linting.yml`
+  - Test matrix (OS x Python x dependency mode): `.github/workflows/tests.yml`
+  - Sonar + coverage: `.github/workflows/sonar.yml`
+  - Docs build/publish: `.github/workflows/docs.yml`
+  - Data catalog validation: `.github/workflows/check-data-catalogs.yml`
+  - Binder/docker smoke: `.github/workflows/test-docker.yml`
+- Maintenance automation:
+  - monthly pixi lock + SBOM update PR,
+  - monthly pre-commit autoupdate PR.
+  - Evidence: `pixi_auto_update.yml`, `pre-commit_auto_update.yml`.
+- Release/deploy:
+  - release branch creation, tag/release creation, docs publish, PyPI publish.
+  - Evidence: `create-release-branch.yml`, `create-release.yml`, `publish-pypi.yml`.
+
+**Merge gating note (uncertain):** workflows indicate expected quality gates, but actual required-status enforcement is repository settings (not visible here).
+
+## Versioning/release process
+
+- SemVer + changelog-based release notes.
+- Version source of truth in `hydromt/__init__.py` (`__version__`).
+- Release families on `release/vX.Y` branches; `record-release` PR merges back to `main`.
+  - Evidence: `hydromt/__init__.py`, `docs/changelog.rst`, `docs/dev/core_dev/release.rst`, release workflows.
+
+---
+
+## 5) Domain-specific context
+
+Key hydrology/geospatial terms used in code:
+
+- **Basin / subbasin / interbasin**, **basid**: watershed delineation semantics.
+  - Evidence: `hydromt/model/processes/basin_mask.py`.
+- **Flow direction** (`flwdir`, D8/LDD/nextxy), stream maps, outlets.
+  - Evidence: `hydromt/model/processes/basin_mask.py`, `hydromt/gis/flw.py`.
+- **PET** (potential evapotranspiration) methods:
+  - `debruin`, `makkink`, `penman-monteith_*`.
+  - Evidence: `hydromt/model/processes/meteo.py`.
+- **Raster/vector/geodataset** distinction as first-class data types in catalog APIs.
+  - Evidence: `hydromt/data_catalog/data_catalog.py`, `sources/*.py`.
+- **STAC** conversion support for catalog/sources.
+  - Evidence: `data_catalog.py` (`to_stac_catalog/from_stac_catalog`), source `to_stac_catalog`.
+
+Non-obvious external coupling:
+
+- Heavy dependence on geospatial stack (`rasterio`, `geopandas`, `xarray`, `pyproj`, `pyflwdir`, `fsspec`).
+- Predefined catalog fallback to GitHub raw URLs when local catalogs absent.
+  - Evidence: `hydromt/data_catalog/predefined_catalog.py`.
+- Optional capability flags (`HAS_S3FS`, `HAS_ADLFS`, `HAS_PYET`, etc.) alter behavior/tests.
+  - Evidence: `hydromt/_compat.py`, many `pytest.mark.skipif`.
+
+---
+
+## 6) Gotchas & inconsistencies (important for AI agents)
+
+1. **Potential typo/bug in pixi task wiring**
+   - `pypi` task depends on `pypi-git-restore`, but task appears defined as `pypi-git-resore` (missing `t`).
+   - Evidence: `pyproject.toml` around `[tool.pixi.feature.dev.tasks]`.
+   - Confidence: **High** (direct string mismatch).
+
+2. **Type alias inconsistency**
+   - `DataType` literal in `hydromt/typing/type_def.py` uses `"DataSet"` / `"GeoDataSet"`, while factory and sources use `"Dataset"` / `"GeoDataset"`.
+   - Evidence: `hydromt/typing/type_def.py`, `hydromt/data_catalog/sources/factory.py`.
+   - Confidence: **High** (direct mismatch).
+
+3. **Possible logic bug in `contains_source`**
+   - Provider/version lookup logic appears inconsistent with internal `_sources` structure and may invert a boolean.
+   - Evidence: `hydromt/data_catalog/data_catalog.py` (`contains_source` block around lines ~509–521) versus `add_source` shape.
+   - Confidence: **Medium** (strongly suspicious; not fully validated by execution).
+
+4. **Possible walrus-precedence bug in nodata handling**
+   - In `RasterDatasetAdapter._set_nodata`, expression `if nodata := metadata.nodata is not None:` assigns boolean, not nodata object.
+   - Evidence: `hydromt/data_catalog/adapters/rasterdataset.py`.
+   - Confidence: **High** (syntax semantics), runtime impact depends on metadata usage.
+
+5. **Docs/conventions drift vs current tooling**
+   - Docs still describe “black style” and pip-first examples, while repo runs `ruff-format` and pixi-centric workflows.
+   - Evidence: `docs/dev/core_dev/code_conventions.rst`, `.pre-commit-config.yaml`, `pyproject.toml`.
+   - Confidence: **High**.
+
+6. **Dead compatibility branches likely obsolete**
+   - `_compat.py` has logic for Python <3.10 entry-point fallback, but project requires >=3.11.
+   - Evidence: `_compat.py`, `pyproject.toml` (`requires-python`).
+   - Confidence: **High**.
+
+7. **Known flaky/external tests are explicitly excluded**
+   - `manual` and skipped flaky HTTP tests exist; default pytest excludes manual.
+   - Evidence: `pyproject.toml` markers/addopts, `tests/data_catalog/test_data_catalog.py`.
+   - Confidence: **High**.
+
+---
+
+## Practical “agent mental model” before editing
+
+- Treat **plugin contracts** (`name`, entry points, `__hydromt_eps__`, subclass checks) as critical compatibility surface.
+- For workflow features, ensure methods are `@hydromt_step` and signature-bindable from YAML-safe args.
+- Preserve the **DataCatalog pipeline split** (resolver/driver/adapter); don’t collapse responsibilities.
+- Respect `NoDataStrategy` behavior in new data paths.
+- Expect optional-dependency guarded behavior in both code and tests.
+- Update `docs/changelog.rst` and tests when changing behavior (repo conventions and PR template explicitly ask this).


### PR DESCRIPTION
## Issue addressed

No linked issue — this is a developer-tooling addition.

## Explanation

Adds AI-agent guidance files derived from a direct analysis of the HydroMT codebase (source, tests, CI, docs). These files help AI coding agents (GitHub Copilot CLI, Codex, VS Code Copilot) understand the repo before making changes, reducing incorrect edits and missed conventions.

**Files added:**

| File | Purpose |
|---|---|
| `AGENTS.md` | Comprehensive agent guide: build commands, repo layout, architecture invariants, conventions, gotchas, domain vocabulary |
| `.github/copilot-instructions.md` | Concise always-loaded context for GitHub Copilot in VS Code and on the web |
| `.github/prompts/hydromt-data-catalog.prompt.md` | Focused skill for DataSource / Driver / URIResolver / DataAdapter work |
| `.github/prompts/hydromt-model.prompt.md` | Focused skill for Model / ModelComponent / `@hydromt_step` work |
| `.github/prompts/hydromt-plugin.prompt.md` | Focused skill for plugin registration and downstream package authoring |
| `.github/skills/code-review/SKILL.md` | Overrides built-in code-review skill with HydroMT-specific checklist |
| `.github/skills/pr/SKILL.md` | PR creation skill following HydroMT commit conventions and PR template |
| `ARCHITECTURE_REPORT.md` | Full source architecture report (basis for the above) |

The guidance covers: pixi-based commands, DataCatalog pipeline invariants, `@hydromt_step` rules, `NoDataStrategy` requirements, plugin contracts, Pydantic v2 conventions, NumPy docstring style, known bugs/gotchas, and the release process.

## General Checklist

- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation
- [ ] Updated changelog.rst

> No tests needed (documentation/tooling only). No changelog entry needed (not a user-facing behaviour change).
