### PR TITLE
Improve licence metadata (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.4.0,<5"]
+requires = ["flit_core >=3.11,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -50,12 +50,13 @@ dependencies = [
 
 requires-python = ">=3.11,<3.15"
 readme = "README.rst"
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
 	"Intended Audience :: Developers",
 	"Intended Audience :: Science/Research",
 	"Topic :: Scientific/Engineering :: Hydrology",
-	"License :: OSI Approved :: MIT License",
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: 3.13",


### PR DESCRIPTION
This PR improves the licence metadata, aligned with [PEP 639](https://peps.python.org/pep-0639/#add-license-file-field) with the following changes to `pyproject.toml`:

- Add `license` and `license-files` attributes to describe the MIT licence
- Remove the licence classifier, which is deprecated
- Increase the minimum version of `flit_core` to [v3.11](https://flit.pypa.io/en/stable/history.html#version-3-11) to support this metadata
