### PR TITLE
Fix typos in docstrings, comments and messages

### DIFF
--- a/hydromt/cli/main.py
+++ b/hydromt/cli/main.py
@@ -493,7 +493,7 @@ def check(
 @click.option(
     "-b",
     "--bbox",
-    help="a bbox in EPSG:4236 designating the region of which to export the data",
+    help="a bbox in EPSG:4326 designating the region of which to export the data",
 )
 @region_opt
 @export_dest_path

--- a/hydromt/error.py
+++ b/hydromt/error.py
@@ -1,4 +1,4 @@
-"""All of the types for handeling errors within HydroMT."""
+"""All of the types for handling errors within HydroMT."""
 
 import inspect
 import logging

--- a/hydromt/gis/flw.py
+++ b/hydromt/gis/flw.py
@@ -39,7 +39,7 @@ def flwdir_from_da(
     """Parse dataarray to flow direction raster object.
 
     If a mask coordinate is present this will be passed
-    on the the pyflwdir.from_array method.
+    on the pyflwdir.from_array method.
 
     Parameters
     ----------
@@ -535,7 +535,7 @@ def stream_map(ds, *, stream=None, **stream_kwargs):
     ds : xarray.Dataset
         dataset containing all maps for stream criteria
     stream: 2D array of bool, optional
-        Initial mask of stream cells. If a stream if provided, it is combined with the
+        Initial mask of stream cells. If a stream is provided, it is combined with the
         threshold based map using a logical AND operation.
     stream_kwargs : dict, optional
         Parameter: minimum threshold pairs to define streams.
@@ -592,9 +592,9 @@ def basin_map(
     stream: 2D array of bool, optional
         Mask of stream cells used to snap outlets to, by default None
     stream_kwargs : dict, optional
-        Parameter-treshold pairs to define streams. Multiple threshold will be combined
-        using a logical_and operation. If a stream if provided, it is combined with the
-        threshhold based map as well.
+        Parameter-threshold pairs to define streams. Multiple threshold will be combined
+        using a logical_and operation. If a stream is provided, it is combined with the
+        threshold based map as well.
 
     Returns
     -------

--- a/hydromt/gis/gis_utils.py
+++ b/hydromt/gis/gis_utils.py
@@ -132,7 +132,7 @@ def _parse_geom_bbox_buffer(
         Buffer around the `bbox` or `geom` area of interest in meters. By default 0.
     crs: pyproj.CRS, optional
         projection of the bbox or geometry. If the geometry already has a crs, this
-        argument is ignored. Defaults to EPSG:4236.
+        argument is ignored. Defaults to EPSG:4326.
 
     Returns
     -------
@@ -142,7 +142,7 @@ def _parse_geom_bbox_buffer(
     if crs is None:
         crs = CRS("EPSG:4326")
     if geom is None and bbox is not None:
-        # convert bbox to geom with crs EPGS:4326 to apply buffer later
+        # convert bbox to geom with crs EPSG:4326 to apply buffer later
         geom = gpd.GeoDataFrame(geometry=[box(*bbox)], crs=crs)
     elif geom is None:
         raise ValueError("No geom or bbox provided.")

--- a/hydromt/gis/raster.py
+++ b/hydromt/gis/raster.py
@@ -1666,7 +1666,7 @@ class RasterDataArray(XRasterBase):
     """GIS extension for xarray.DataArray."""
 
     def __init__(self, xarray_obj):
-        """Initiallize the object based on the provided xarray object."""
+        """Initialize the object based on the provided xarray object."""
         super(RasterDataArray, self).__init__(xarray_obj)
 
     @staticmethod
@@ -1759,7 +1759,7 @@ class RasterDataArray(XRasterBase):
                 raise ValueError(
                     f"Nodata value {nodata} of type {type(nodata).__name__} is "
                     f"incompatible with raster dtype {self._obj.dtype}. Please provide"
-                    " a compatible nodata value for example by specifiying it in the"
+                    " a compatible nodata value for example by specifying it in the"
                     " data catalog."
                 )
         else:
@@ -2348,7 +2348,7 @@ class RasterDataset(XRasterBase):
 
     @property
     def vars(self):
-        """list: Returns non-coordinate varibles."""
+        """list: Returns non-coordinate variables."""
         return list(self._obj.data_vars.keys())
 
     def mask_nodata(self):

--- a/hydromt/gis/vector.py
+++ b/hydromt/gis/vector.py
@@ -885,7 +885,7 @@ class GeoDataset(GeoBase):
     # Will probably be deleted in the future but now needed for compatibility
     @property
     def vars(self) -> list[str]:
-        """list: Returns non-coordinate varibles."""
+        """list: Returns non-coordinate variables."""
         return list(self._obj.data_vars.keys())
 
     # Internal conversion and selection methods

--- a/hydromt/log.py
+++ b/hydromt/log.py
@@ -179,7 +179,7 @@ def to_file(
         yield
     except Exception:
         # This also logs the stack trace + exception
-        logger.exception("Unhandled exception occured.")
+        logger.exception("Unhandled exception occurred.")
         raise
     finally:
         handler.flush()

--- a/hydromt/model/mode.py
+++ b/hydromt/model/mode.py
@@ -1,4 +1,4 @@
-"""Handeling for the mode a HydroMT Model can be in."""
+"""Handling for the mode a HydroMT Model can be in."""
 
 from enum import Enum
 from typing import Union

--- a/hydromt/model/model.py
+++ b/hydromt/model/model.py
@@ -453,7 +453,7 @@ class Model(object, metaclass=ABCMeta):
         Parameters
         ----------
             components: Optional[List[str]]
-                the components that should be writen to disk. If None is provided
+                the components that should be written to disk. If None is provided
                 all components will be written.
         """
         components = components or list(self.components.keys())

--- a/hydromt/model/processes/basin_mask.py
+++ b/hydromt/model/processes/basin_mask.py
@@ -49,13 +49,13 @@ def get_basin_geometry(
     ds : xr.Dataset
         Dataset containing basin and flow direction variables
     basin_index: gpd.GeoDataFrame
-        Dataframe with basin geomtries or bounding boxes with "basid" column
+        Dataframe with basin geometries or bounding boxes with "basid" column
         corresponding to the ``ds[<basins_name>]`` map.
     kind : str
         Kind of basin description, choose from "basin", "subbasin" or "interbasin"
     bounds : list[float] | tuple[float], optional
         [xmin, ymin, xmax, ymax] coordinates of total bounding box, i.e. the data is
-        clipped to this domain before futher processing. By default None
+        clipped to this domain before further processing. By default None
     bbox : list[float] | tuple[float], optional
         [xmin, ymin, xmax, ymax] coordinates to infer (sub)(inter)basin(s),
         by default None
@@ -251,7 +251,7 @@ def get_basin_geometry(
                 outmap = outmap.where(stream_kwargs, False)
             idxs_out = np.nonzero(outmap.values.ravel())[0]
             if not np.any(outmap):
-                raise ValueError("No outlets found with with given criteria.")
+                raise ValueError("No outlets found with the given criteria.")
             xy = outmap.raster.idx_to_xy(idxs_out)
         # get subbasin map
         bas_mask, xy_out = basin_map(ds, flwdir, xy=xy, **kwargs)

--- a/hydromt/model/processes/grid.py
+++ b/hydromt/model/processes/grid.py
@@ -318,7 +318,7 @@ def grid_from_constant(
     dtype: type, optional
         Data type of grid. By default np.float32.
     nodata: int, float, optional
-        Nodata value. By default infered from dtype.
+        Nodata value. By default inferred from dtype.
     mask_name: str, optional
         Name of mask in self.grid to use for masking raster_data. By default 'mask'.
         Use None to disable masking.

--- a/hydromt/readers.py
+++ b/hydromt/readers.py
@@ -249,7 +249,7 @@ def open_mfraster(
     dataset is a merge of the rasters.
     If ``concat`` the DataArrays are concatenated along ``concat_dim`` returning a
     Dataset with a single 3D DataArray.
-    If ``mosaic`` the DataArrays are concatenated along the the spatial dimensions
+    If ``mosaic`` the DataArrays are concatenated along the spatial dimensions
     using :py:meth:`~hydromt.raster.merge`.
 
     Arguments
@@ -398,7 +398,7 @@ def open_raster_from_tindex(
     tindex_path: path, str
         Path to tile index file.
     bbox : tuple of floats, optional
-        (xmin, ymin, xmax, ymax) bounding box in EPGS:4326, by default None.
+        (xmin, ymin, xmax, ymax) bounding box in EPSG:4326, by default None.
     geom : geopandas.GeoDataFrame/Series, optional
         A geometry defining the area of interest, by default None. The geom.crs
         defaults to EPSG:4326 if not set.
@@ -476,7 +476,7 @@ def open_geodataset(
         Note that this MUST be relative to the directory where `loc_path` points to
     var_name: str, optional
         Name of the variable in case of a csv, or parquet data_path file. By default,
-        None and infered from basename.
+        None and inferred from basename.
     crs: str, `pyproj.CRS`, or dict
         Source coordinate reference system, ignored for files with a native crs.
     bbox : array of float, default None


### PR DESCRIPTION
## Issue addressed

No issue - a small typo pass, which the contributing guide exempts from
needing one. Happy to open an issue first if you prefer.

## Explanation

Spelling and doubled words in docstrings, comments and a few messages:
"handeling", "Initiallize", "varibles", "occured", "specifiying",
"geomtries", "futher", "writen", "treshold"/"threshhold", "infered", and
"if a stream if provided" -> "is provided".

Two runtime strings are reworded the same way - the `ValueError` in
`gis/raster.py` and "No outlets found with with given criteria" in
`model/processes/basin_mask.py`. Neither is asserted on in the test suite.

Separately, EPSG:4326 was misspelled in four places: as "EPSG:4236" in
the `export` CLI help text and a `gis_utils` docstring, and as
"EPGS:4326" in a comment and in a `readers.py` docstring.

## General Checklist

- [ ] Updated tests or added new tests - text-only change, nothing new to test
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass - I could not run the full suite locally; leaving this to CI
- [ ] Updated documentation - the docstrings *are* the documentation change
- [ ] Updated changelog.rst - left out on purpose; happy to add a line if you want typo passes recorded

## Data/Catalog checklist

- [x] `data/catalogs/predefined_catalogs.yml` has not been modified.
- [x] None of the old `data_catalog.yml` files have been changed
